### PR TITLE
remove WebAuthnAuthenticationContext#credentialId

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/response/WebAuthnAuthenticationContext.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/response/WebAuthnAuthenticationContext.java
@@ -31,13 +31,11 @@ public class WebAuthnAuthenticationContext extends AbstractWebAuthnContext {
     //~ Instance fields ================================================================================================
 
     // user inputs
-    private final byte[] credentialId;
     private final byte[] authenticatorData;
     private final byte[] signature;
 
     @SuppressWarnings("squid:S00107")
-    public WebAuthnAuthenticationContext(byte[] credentialId,
-                                         byte[] clientDataJSON,
+    public WebAuthnAuthenticationContext(byte[] clientDataJSON,
                                          byte[] authenticatorData,
                                          byte[] signature,
                                          String clientExtensionsJSON,
@@ -53,20 +51,17 @@ public class WebAuthnAuthenticationContext extends AbstractWebAuthnContext {
                 expectedExtensionIds
         );
 
-        this.credentialId = credentialId;
         this.signature = signature;
         this.authenticatorData = authenticatorData;
     }
 
-    public WebAuthnAuthenticationContext(byte[] credentialId,
-                                         byte[] clientDataJSON,
+    public WebAuthnAuthenticationContext(byte[] clientDataJSON,
                                          byte[] authenticatorData,
                                          byte[] signature,
                                          ServerProperty serverProperty,
                                          boolean userVerificationRequired
     ) {
         this(
-                credentialId,
                 clientDataJSON,
                 authenticatorData,
                 signature,
@@ -75,10 +70,6 @@ public class WebAuthnAuthenticationContext extends AbstractWebAuthnContext {
                 userVerificationRequired,
                 Collections.emptyList()
         );
-    }
-
-    public byte[] getCredentialId() {
-        return credentialId;
     }
 
     public byte[] getAuthenticatorData() {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
@@ -49,9 +49,6 @@ class BeanAssertUtil {
         if(webAuthnAuthenticationContext == null){
             throw new ConstraintViolationException("webAuthnAuthenticationContext must not be null");
         }
-        if (webAuthnAuthenticationContext.getCredentialId() == null) {
-            throw new ConstraintViolationException("credentialId must not be null");
-        }
         if (webAuthnAuthenticationContext.getClientDataJSON() == null) {
             throw new ConstraintViolationException("clientDataJSON must not be null");
         }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationContextTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationContextTest.java
@@ -36,14 +36,12 @@ public class WebAuthnAuthenticationContextTest {
     @Test
     public void getter_test() {
 
-        byte[] credentialId = new byte[32];
         byte[] collectedClientData = new CollectedClientDataConverter(registry).convertToBytes(createClientData(ClientDataType.GET));
         byte[] authenticatorData = new AuthenticatorDataConverter(registry).convert(createAuthenticatorData());
         byte[] signature = new byte[]{0x01, 0x23};
         ServerProperty serverProperty = mock(ServerProperty.class);
         WebAuthnAuthenticationContext target = new WebAuthnAuthenticationContext(
-                credentialId, collectedClientData, authenticatorData, signature, serverProperty, false);
-        assertThat(target.getCredentialId()).isEqualTo(credentialId);
+                collectedClientData, authenticatorData, signature, serverProperty, false);
         assertThat(target.getClientDataJSON()).isEqualTo(collectedClientData);
         assertThat(target.getAuthenticatorData()).isEqualTo(authenticatorData);
         assertThat(target.getSignature()).isEqualTo(signature);
@@ -53,15 +51,14 @@ public class WebAuthnAuthenticationContextTest {
 
     @Test
     public void equals_hashCode_test() {
-        byte[] credentialId = new byte[32];
         byte[] collectedClientData = new CollectedClientDataConverter(registry).convertToBytes(createClientData(ClientDataType.GET));
         byte[] authenticatorData = new AuthenticatorDataConverter(registry).convert(createAuthenticatorData());
         byte[] signature = new byte[]{0x01, 0x23};
         ServerProperty serverProperty = mock(ServerProperty.class);
         WebAuthnAuthenticationContext webAuthnAuthenticationContextA = new WebAuthnAuthenticationContext(
-                credentialId, collectedClientData, authenticatorData, signature, serverProperty, true);
+                collectedClientData, authenticatorData, signature, serverProperty, true);
         WebAuthnAuthenticationContext webAuthnAuthenticationContextB = new WebAuthnAuthenticationContext(
-                credentialId, collectedClientData, authenticatorData, signature, serverProperty, true);
+                collectedClientData, authenticatorData, signature, serverProperty, true);
 
         assertThat(webAuthnAuthenticationContextA).isEqualTo(webAuthnAuthenticationContextB);
         assertThat(webAuthnAuthenticationContextA).hasSameHashCodeAs(webAuthnAuthenticationContextB);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
@@ -33,7 +33,6 @@ public class BeanAssertUtilTest {
     @Test
     public void validate_WebAuthnAuthenticationContext_test(){
         WebAuthnAuthenticationContext authenticationContext = new WebAuthnAuthenticationContext(
-                new byte[32],
                 new byte[512],
                 new byte[512],
                 new byte[32],
@@ -51,24 +50,8 @@ public class BeanAssertUtilTest {
     }
 
     @Test(expected = ConstraintViolationException.class)
-    public void validate_WebAuthnAuthenticationContext_with_credentialId_null_test(){
-        WebAuthnAuthenticationContext authenticationContext = new WebAuthnAuthenticationContext(
-                null,
-                new byte[512],
-                new byte[512],
-                new byte[32],
-                null,
-                mock(ServerProperty.class),
-                true,
-                null
-        );
-        BeanAssertUtil.validate(authenticationContext);
-    }
-
-    @Test(expected = ConstraintViolationException.class)
     public void validate_WebAuthnAuthenticationContext_with_clientDataJSON_null_test(){
         WebAuthnAuthenticationContext authenticationContext = new WebAuthnAuthenticationContext(
-                new byte[32],
                 null,
                 new byte[512],
                 new byte[32],
@@ -83,7 +66,6 @@ public class BeanAssertUtilTest {
     @Test(expected = ConstraintViolationException.class)
     public void validate_WebAuthnAuthenticationContext_with_authenticatorData_null_test(){
         WebAuthnAuthenticationContext authenticationContext = new WebAuthnAuthenticationContext(
-                new byte[32],
                 new byte[512],
                 null,
                 new byte[32],
@@ -98,7 +80,6 @@ public class BeanAssertUtilTest {
     @Test(expected = ConstraintViolationException.class)
     public void validate_WebAuthnAuthenticationContext_with_signature_null_test(){
         WebAuthnAuthenticationContext authenticationContext = new WebAuthnAuthenticationContext(
-                new byte[32],
                 new byte[512],
                 new byte[512],
                 null,
@@ -113,7 +94,6 @@ public class BeanAssertUtilTest {
     @Test(expected = ConstraintViolationException.class)
     public void validate_WebAuthnAuthenticationContext_with_serverProperty_null_test(){
         WebAuthnAuthenticationContext authenticationContext = new WebAuthnAuthenticationContext(
-                new byte[32],
                 new byte[512],
                 new byte[512],
                 new byte[32],

--- a/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorAuthenticationValidationTest.java
@@ -92,7 +92,6 @@ public class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -142,7 +141,6 @@ public class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        publicKeyCredential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -190,7 +188,6 @@ public class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -233,7 +230,6 @@ public class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -276,7 +272,6 @@ public class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -318,7 +313,6 @@ public class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -363,7 +357,6 @@ public class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -405,7 +398,6 @@ public class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         new byte[32], //bad signature
@@ -447,7 +439,6 @@ public class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),

--- a/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorAuthenticationValidationTest.java
@@ -87,7 +87,6 @@ public class UserVerifyingAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -138,7 +137,6 @@ public class UserVerifyingAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -184,7 +182,6 @@ public class UserVerifyingAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -222,7 +219,6 @@ public class UserVerifyingAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -260,7 +256,6 @@ public class UserVerifyingAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -300,7 +295,6 @@ public class UserVerifyingAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -339,7 +333,6 @@ public class UserVerifyingAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),
@@ -376,7 +369,6 @@ public class UserVerifyingAuthenticatorAuthenticationValidationTest {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credential.getRawId(),
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getAuthenticatorData(),
                         authenticationRequest.getSignature(),

--- a/webauthn4j-core/src/test/java/sample/Sample.java
+++ b/webauthn4j-core/src/test/java/sample/Sample.java
@@ -49,7 +49,6 @@ public class Sample {
 
     public void authenticationValidationSample() {
         // Client properties
-        byte[] credentialId = null /* set credentialId */;
         byte[] clientDataJSON = null /* set clientDataJSON */;
         byte[] authenticatorData = null /* set authenticatorData */;
         byte[] signature = null /* set signature */;
@@ -63,7 +62,6 @@ public class Sample {
 
         WebAuthnAuthenticationContext authenticationContext =
                 new WebAuthnAuthenticationContext(
-                        credentialId,
                         clientDataJSON,
                         authenticatorData,
                         signature,


### PR DESCRIPTION
WebAuthnAuthenticationContext has a credentialId field that was used up until commit 7a16cdc to find the associated authenticator data. Since commit 6943306 the field is unused, but still required and assigned in the constructor. This is confusing and may cause caller code to be more complicated.