### PR TITLE
PublicKeyCredentialRequestOptions.timeout is an optional value 

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/request/PublicKeyCredentialRequestOptions.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/request/PublicKeyCredentialRequestOptions.java
@@ -38,14 +38,14 @@ public class PublicKeyCredentialRequestOptions implements Serializable {
     // ================================================================================================
 
     private Challenge challenge;
-    private long timeout;
+    private Long timeout;
     private String rpId;
     private List<PublicKeyCredentialDescriptor> allowCredentials;
     private UserVerificationRequirement userVerification;
     private AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> extensions;
 
     public PublicKeyCredentialRequestOptions(Challenge challenge,
-                                             long timeout,
+                                             Long timeout,
                                              String rpId,
                                              List<PublicKeyCredentialDescriptor> allowCredentials,
                                              UserVerificationRequirement userVerification,
@@ -62,7 +62,7 @@ public class PublicKeyCredentialRequestOptions implements Serializable {
         return challenge;
     }
 
-    public long getTimeout() {
+    public Long getTimeout() {
         return timeout;
     }
 
@@ -87,7 +87,7 @@ public class PublicKeyCredentialRequestOptions implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PublicKeyCredentialRequestOptions that = (PublicKeyCredentialRequestOptions) o;
-        return timeout == that.timeout &&
+        return Objects.equals(timeout, that.timeout) &&
                 Objects.equals(challenge, that.challenge) &&
                 Objects.equals(rpId, that.rpId) &&
                 Objects.equals(allowCredentials, that.allowCredentials) &&
@@ -97,7 +97,6 @@ public class PublicKeyCredentialRequestOptions implements Serializable {
 
     @Override
     public int hashCode() {
-
         return Objects.hash(challenge, timeout, rpId, allowCredentials, userVerification, extensions);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnContextValidatorFactory.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnContextValidatorFactory.java
@@ -1,0 +1,69 @@
+package com.webauthn4j.validator;
+
+import com.webauthn4j.converter.util.CborConverter;
+import com.webauthn4j.converter.util.JsonConverter;
+import com.webauthn4j.validator.attestation.statement.androidkey.AndroidKeyAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.androidkey.NullAndroidKeyAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.androidsafetynet.AndroidSafetyNetAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.androidsafetynet.NullAndroidSafetyNetAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.none.NoneAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.packed.NullPackedAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.packed.PackedAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.tpm.TPMAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.u2f.FIDOU2FAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.u2f.NullFIDOU2FAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.certpath.NullCertPathTrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.NullECDAATrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.self.NullSelfAttestationTrustworthinessValidator;
+
+import java.util.Arrays;
+
+public final class WebAuthnContextValidatorFactory {
+    private WebAuthnContextValidatorFactory() {
+
+    }
+
+    public static WebAuthnRegistrationContextValidator createNonStrictRegistrationContextValidator() {
+        return createNonStrictRegistrationContextValidator(new JsonConverter(), new CborConverter());
+    }
+
+    public static WebAuthnRegistrationContextValidator createNonStrictRegistrationContextValidator(JsonConverter jsonConverter, CborConverter cborConverter) {
+        return new WebAuthnRegistrationContextValidator(
+                Arrays.asList(
+                        new NoneAttestationStatementValidator(),
+                        new NullFIDOU2FAttestationStatementValidator(),
+                        new NullPackedAttestationStatementValidator(),
+                        new NullAndroidKeyAttestationStatementValidator(),
+                        new NullAndroidSafetyNetAttestationStatementValidator()
+                ),
+                new NullCertPathTrustworthinessValidator(),
+                new NullECDAATrustworthinessValidator(),
+                new NullSelfAttestationTrustworthinessValidator(),
+                jsonConverter,
+                cborConverter
+        );
+    }
+
+    public static WebAuthnRegistrationContextValidator createDefaultRegistrationContextValidator(JsonConverter jsonConverter, CborConverter cborConverter) {
+        return new WebAuthnRegistrationContextValidator(
+                Arrays.asList(
+                        new NoneAttestationStatementValidator(),
+                        new FIDOU2FAttestationStatementValidator(),
+                        new PackedAttestationStatementValidator(),
+                        new AndroidKeyAttestationStatementValidator(),
+                        new AndroidSafetyNetAttestationStatementValidator(),
+                        new TPMAttestationStatementValidator()
+                ),
+                new NullCertPathTrustworthinessValidator(),
+                new NullECDAATrustworthinessValidator(),
+                new NullSelfAttestationTrustworthinessValidator(),
+                jsonConverter,
+                cborConverter
+        );
+    }
+
+    public static WebAuthnAuthenticationContextValidator createDefaultAuthenticationContextValidator() {
+        return new WebAuthnAuthenticationContextValidator(new JsonConverter(), new CborConverter());
+    }
+
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
@@ -149,41 +149,17 @@ public class WebAuthnRegistrationContextValidator {
                 selfAttestationTrustworthinessValidator);
     }
 
-
-    // ~ Factory methods
-    // ========================================================================================================
-
-    public static WebAuthnRegistrationContextValidator createNonStrictRegistrationContextValidator() {
-        return createNonStrictRegistrationContextValidator(new JsonConverter(), new CborConverter());
-    }
-
-    public static WebAuthnRegistrationContextValidator createNonStrictRegistrationContextValidator(JsonConverter jsonConverter, CborConverter cborConverter) {
-        return new WebAuthnRegistrationContextValidator(
-                Arrays.asList(
-                        new NoneAttestationStatementValidator(),
-                        new NullFIDOU2FAttestationStatementValidator(),
-                        new NullPackedAttestationStatementValidator(),
-                        new NullAndroidKeyAttestationStatementValidator(),
-                        new NullAndroidSafetyNetAttestationStatementValidator()
-                ),
-                new NullCertPathTrustworthinessValidator(),
-                new NullECDAATrustworthinessValidator(),
-                new NullSelfAttestationTrustworthinessValidator(),
-                jsonConverter,
-                cborConverter
-        );
-    }
-
     // ~ Methods
     // ========================================================================================================
 
     /**
      * validates WebAuthn registration request
+     *
      * @param registrationContext registration context
      * @return validation result
      * @throws DataConversionException if the input cannot be parsed
-     * @throws ValidationException if the input is not valid from the point of WebAuthn validation steps
-     * @throws WebAuthnException if WebAuthn error occurred
+     * @throws ValidationException     if the input is not valid from the point of WebAuthn validation steps
+     * @throws WebAuthnException       if WebAuthn error occurred
      */
     @SuppressWarnings("squid:RedundantThrowsDeclarationCheck")
     public WebAuthnRegistrationContextValidationResponse validate(WebAuthnRegistrationContext registrationContext) throws WebAuthnException {
@@ -274,14 +250,14 @@ public class WebAuthnRegistrationContextValidator {
         // ******* This step is up to library user *******
 
         // validate with custom logic
-        for (CustomRegistrationValidator customRegistrationValidator : customRegistrationValidators){
+        for (CustomRegistrationValidator customRegistrationValidator : customRegistrationValidators) {
             customRegistrationValidator.validate(registrationObject);
         }
 
         return new WebAuthnRegistrationContextValidationResponse(collectedClientData, attestationObject, clientExtensions);
     }
 
-    void validateAuthenticatorDataField(AuthenticatorData authenticatorData){
+    void validateAuthenticatorDataField(AuthenticatorData authenticatorData) {
         // attestedCredentialData must be present on registration
         if (authenticatorData.getAttestedCredentialData() == null) {
             throw new MaliciousDataException("attestedCredentialData must not be null on registration");

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidatorTest.java
@@ -70,27 +70,27 @@ class WebAuthnRegistrationContextValidatorTest {
     void validateAuthenticatorDataField_test() {
         AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
         assertThrows(MaliciousDataException.class,
-                () -> WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateAuthenticatorDataField(authenticatorData)
+                () -> WebAuthnContextValidatorFactory.createNonStrictRegistrationContextValidator().validateAuthenticatorDataField(authenticatorData)
         );
     }
 
     @Test
     void validateUVUPFlags_not_required_test() {
         AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
-        WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, false, false);
+        WebAuthnContextValidatorFactory.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, false, false);
     }
 
     @Test
     void validateUVUPFlags_required_test() {
         AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) (AuthenticatorData.BIT_UP | AuthenticatorData.BIT_UV), 0);
-        WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, true, true);
+        WebAuthnContextValidatorFactory.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, true, true);
     }
 
     @Test
     void validateUVUPFlags_UserNotVerifiedException_test() {
         AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
         assertThrows(UserNotVerifiedException.class,
-                () -> WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, true, false)
+                () -> WebAuthnContextValidatorFactory.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, true, false)
         );
     }
 
@@ -98,7 +98,7 @@ class WebAuthnRegistrationContextValidatorTest {
     void validateUVUPFlags_UserNotPresentException_test() {
         AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
         assertThrows(UserNotPresentException.class,
-                () -> WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, false, true)
+                () -> WebAuthnContextValidatorFactory.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, false, true)
         );
     }
 }

--- a/webauthn4j-core/src/test/java/integration/component/NullAttestationStatementValidatorTest.java
+++ b/webauthn4j-core/src/test/java/integration/component/NullAttestationStatementValidatorTest.java
@@ -29,6 +29,7 @@ import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.test.authenticator.webauthn.WebAuthnAuthenticatorAdaptor;
 import com.webauthn4j.test.authenticator.u2f.FIDOU2FAuthenticatorAdaptor;
 import com.webauthn4j.test.client.ClientPlatform;
+import com.webauthn4j.validator.WebAuthnContextValidatorFactory;
 import com.webauthn4j.validator.WebAuthnRegistrationContextValidator;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +38,7 @@ import java.util.Collections;
 class NullAttestationStatementValidatorTest {
 
     private Origin origin = new Origin("http://localhost");
-    private WebAuthnRegistrationContextValidator target = WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator();
+    private WebAuthnRegistrationContextValidator target = WebAuthnContextValidatorFactory.createNonStrictRegistrationContextValidator();
 
     @Test
     void validate_WebAuthnRegistrationContext_with_fido_u2f_attestation_statement_test() {

--- a/webauthn4j-core/src/test/java/sample/Sample.java
+++ b/webauthn4j-core/src/test/java/sample/Sample.java
@@ -24,10 +24,7 @@ import com.webauthn4j.response.WebAuthnRegistrationContext;
 import com.webauthn4j.response.client.Origin;
 import com.webauthn4j.response.client.challenge.Challenge;
 import com.webauthn4j.server.ServerProperty;
-import com.webauthn4j.validator.WebAuthnAuthenticationContextValidationResponse;
-import com.webauthn4j.validator.WebAuthnAuthenticationContextValidator;
-import com.webauthn4j.validator.WebAuthnRegistrationContextValidationResponse;
-import com.webauthn4j.validator.WebAuthnRegistrationContextValidator;
+import com.webauthn4j.validator.*;
 
 import java.util.Set;
 
@@ -54,7 +51,7 @@ class Sample {
         // If you are building enterprise web application and need to validate the attestation statement, use the constructor of
         // WebAuthnRegistrationContextValidator and provide validators you like
         WebAuthnRegistrationContextValidator webAuthnRegistrationContextValidator =
-                WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator();
+                WebAuthnContextValidatorFactory.createNonStrictRegistrationContextValidator();
 
 
         WebAuthnRegistrationContextValidationResponse response = webAuthnRegistrationContextValidator.validate(registrationContext);
@@ -97,7 +94,7 @@ class Sample {
         Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
 
         WebAuthnAuthenticationContextValidator webAuthnAuthenticationContextValidator =
-                new WebAuthnAuthenticationContextValidator();
+                WebAuthnContextValidatorFactory.createDefaultAuthenticationContextValidator();
 
         WebAuthnAuthenticationContextValidationResponse response = webAuthnAuthenticationContextValidator.validate(authenticationContext, authenticator);
 


### PR DESCRIPTION
PublicKeyCredentialRequestOptions.timeout is an optional value and can be overridden by the client. 

The object has been updated to better match the IDL and provide the ability to use it as a JSON object when preparing for the authentication flow.