### PR TITLE
Make WebAuthnRegistrationContext transports String set

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticatorTransportConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticatorTransportConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter;
+
+import com.webauthn4j.converter.exception.DataConversionException;
+import com.webauthn4j.data.AuthenticatorTransport;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class AuthenticatorTransportConverter {
+
+    public AuthenticatorTransport convert(String value){
+        try{
+            return AuthenticatorTransport.create(value);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
+    }
+
+    @SuppressWarnings("squid:S1168")
+    public Set<AuthenticatorTransport> convertSet(Set<String> values){
+        if(values == null){
+            return null;
+        }
+        return values.stream().map(this::convert).collect(Collectors.toSet());
+    }
+
+    public String convertToString(AuthenticatorTransport value){
+        return value.getValue();
+    }
+
+    @SuppressWarnings("squid:S1168")
+    public Set<String> convertSetToStringSet(Set<AuthenticatorTransport> values){
+        if(values == null){
+            return null;
+        }
+        return values.stream().map(this::convertToString).collect(Collectors.toSet());
+    }
+
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationContext.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationContext.java
@@ -34,14 +34,14 @@ public class WebAuthnRegistrationContext extends AbstractWebAuthnContext {
     // ================================================================================================
 
     private final byte[] attestationObject;
-    private final Set<AuthenticatorTransport> transports;
+    private final Set<String> transports;
 
     // ~ Constructor
     // ========================================================================================================
     @SuppressWarnings("squid:S00107")
     public WebAuthnRegistrationContext(byte[] clientDataJSON,
                                        byte[] attestationObject,
-                                       Set<AuthenticatorTransport> transports,
+                                       Set<String> transports,
                                        String clientExtensionsJSON,
                                        ServerProperty serverProperty,
                                        boolean userVerificationRequired,
@@ -62,7 +62,7 @@ public class WebAuthnRegistrationContext extends AbstractWebAuthnContext {
 
     public WebAuthnRegistrationContext(byte[] clientDataJSON,
                                        byte[] attestationObject,
-                                       Set<AuthenticatorTransport> authenticatorTransports,
+                                       Set<String> authenticatorTransports,
                                        String clientExtensionsJSON,
                                        ServerProperty serverProperty,
                                        boolean userVerificationRequired,
@@ -82,7 +82,7 @@ public class WebAuthnRegistrationContext extends AbstractWebAuthnContext {
 
     public WebAuthnRegistrationContext(byte[] clientDataJSON,
                                        byte[] attestationObject,
-                                       Set<AuthenticatorTransport> transports,
+                                       Set<String> transports,
                                        ServerProperty serverProperty,
                                        boolean userVerificationRequired) {
 
@@ -157,7 +157,7 @@ public class WebAuthnRegistrationContext extends AbstractWebAuthnContext {
         return ArrayUtil.clone(attestationObject);
     }
 
-    public Set<AuthenticatorTransport> getTransports() {
+    public Set<String> getTransports() {
         return transports;
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
@@ -19,6 +19,7 @@ package com.webauthn4j.validator;
 
 import com.webauthn4j.converter.AttestationObjectConverter;
 import com.webauthn4j.converter.AuthenticationExtensionsClientOutputsConverter;
+import com.webauthn4j.converter.AuthenticatorTransportConverter;
 import com.webauthn4j.converter.CollectedClientDataConverter;
 import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.CborConverter;
@@ -63,6 +64,7 @@ public class WebAuthnRegistrationContextValidator {
 
     private final CollectedClientDataConverter collectedClientDataConverter;
     private final AttestationObjectConverter attestationObjectConverter;
+    private final AuthenticatorTransportConverter authenticatorTransportConverter;
     private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter;
 
     private final ChallengeValidator challengeValidator = new ChallengeValidator();
@@ -140,6 +142,7 @@ public class WebAuthnRegistrationContextValidator {
 
         collectedClientDataConverter = new CollectedClientDataConverter(jsonConverter);
         attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+        authenticatorTransportConverter = new AuthenticatorTransportConverter();
         authenticationExtensionsClientOutputsConverter = new AuthenticationExtensionsClientOutputsConverter(jsonConverter);
 
         this.attestationValidator = new AttestationValidator(
@@ -205,7 +208,7 @@ public class WebAuthnRegistrationContextValidator {
 
         CollectedClientData collectedClientData = collectedClientDataConverter.convert(clientDataBytes);
         AttestationObject attestationObject = attestationObjectConverter.convert(attestationObjectBytes);
-        Set<AuthenticatorTransport> transports = registrationContext.getTransports();
+        Set<AuthenticatorTransport> transports = authenticatorTransportConverter.convertSet(registrationContext.getTransports());
         AuthenticationExtensionsClientOutputs<ExtensionClientOutput> clientExtensions =
                 authenticationExtensionsClientOutputsConverter.convert(registrationContext.getClientExtensionsJSON());
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnRegistrationContextTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnRegistrationContextTest.java
@@ -20,7 +20,6 @@ import com.webauthn4j.converter.AttestationObjectConverter;
 import com.webauthn4j.converter.CollectedClientDataConverter;
 import com.webauthn4j.converter.util.CborConverter;
 import com.webauthn4j.converter.util.JsonConverter;
-import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.WebAuthnRegistrationContext;
 import com.webauthn4j.data.client.ClientDataType;
 import com.webauthn4j.server.ServerProperty;
@@ -44,7 +43,7 @@ class WebAuthnRegistrationContextTest {
     void test() {
         byte[] collectedClientData = new CollectedClientDataConverter(jsonConverter).convertToBytes(createClientData(ClientDataType.GET));
         byte[] authenticatorData = new AttestationObjectConverter(cborConverter).convertToBytes(createAttestationObjectWithFIDOU2FAttestationStatement());
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
+        Set<String> transports = Collections.emptySet();
 
 
         ServerProperty serverProperty = mock(ServerProperty.class);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorTransportConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorTransportConverterTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter;
+
+
+import com.webauthn4j.converter.exception.DataConversionException;
+import com.webauthn4j.data.AuthenticatorTransport;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AuthenticatorTransportConverterTest {
+
+    private AuthenticatorTransportConverter converter = new AuthenticatorTransportConverter();
+
+
+    @Test
+    void convert_test(){
+        assertThat(converter.convert("usb")).isEqualTo(AuthenticatorTransport.USB);
+    }
+
+    @Test
+    void convert_invalid_value_test(){
+        assertThatThrownBy(()->converter.convert("invalid")).isInstanceOf(DataConversionException.class);
+    }
+
+    @Test
+    void convertSet_test(){
+        assertThat(converter.convertSet(Collections.singleton("usb"))).containsExactly(AuthenticatorTransport.USB);
+    }
+
+    @Test
+    void convertSet_null_test(){
+        assertThat(converter.convertSet(null)).isEqualTo(null);
+    }
+
+    @Test
+    void convertToString_test(){
+        assertThat(converter.convertToString(AuthenticatorTransport.USB)).isEqualTo("usb");
+    }
+
+    @Test
+    void convertSetToStringSet_test(){
+        assertThat(converter.convertSetToStringSet(Collections.singleton(AuthenticatorTransport.USB))).containsExactly("usb");
+    }
+
+    @Test
+    void convertSetToStringSet_null_test(){
+        assertThat(converter.convertSetToStringSet(null)).isEqualTo(null);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticatorAttestationResponseTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticatorAttestationResponseTest.java
@@ -16,8 +16,6 @@
 
 package com.webauthn4j.data;
 
-import com.webauthn4j.data.AuthenticatorAttestationResponse;
-import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.util.CollectionUtil;
 import org.junit.jupiter.api.Test;
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationContextTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationContextTest.java
@@ -79,7 +79,7 @@ class WebAuthnRegistrationContextTest {
         PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput> credential = clientPlatform.create(credentialCreationOptions);
         AuthenticatorAttestationResponse registrationRequest = credential.getAuthenticatorResponse();
         AuthenticationExtensionsClientOutputs clientExtensionResults = credential.getClientExtensionResults();
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
+        Set<String> transports = Collections.emptySet();
         String clientExtensionJSON = authenticationExtensionsClientOutputsConverter.convertToString(clientExtensionResults);
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
         WebAuthnRegistrationContext instanceA = new WebAuthnRegistrationContext(

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.validator;
 
-import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.WebAuthnAuthenticationContext;
 import com.webauthn4j.data.WebAuthnRegistrationContext;
 import com.webauthn4j.data.attestation.AttestationObject;
@@ -131,7 +130,7 @@ class BeanAssertUtilTest {
 
     @Test
     void validate_WebAuthnRegistrationContext_test() {
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
+        Set<String> transports = Collections.emptySet();
         WebAuthnRegistrationContext registrationContext = new WebAuthnRegistrationContext(
                 new byte[512],
                 new byte[512],
@@ -151,7 +150,7 @@ class BeanAssertUtilTest {
 
     @Test
     void validate_WebAuthnRegistrationContext_with_clientDataJSON_null_test() {
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
+        Set<String> transports = Collections.emptySet();
         WebAuthnRegistrationContext registrationContext = new WebAuthnRegistrationContext(
                 null,
                 new byte[512],
@@ -166,7 +165,7 @@ class BeanAssertUtilTest {
 
     @Test
     void validate_WebAuthnRegistrationContext_with_attestationObject_null_test() {
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
+        Set<String> transports = Collections.emptySet();
 
         WebAuthnRegistrationContext registrationContext = new WebAuthnRegistrationContext(
                 new byte[512],
@@ -182,7 +181,7 @@ class BeanAssertUtilTest {
 
     @Test
     void validate_WebAuthnRegistrationContext_with_serverProperty_null_test() {
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
+        Set<String> transports = Collections.emptySet();
         WebAuthnRegistrationContext registrationContext = new WebAuthnRegistrationContext(
                 new byte[512],
                 new byte[512],

--- a/webauthn4j-core/src/test/java/integration/component/NullAttestationStatementValidatorTest.java
+++ b/webauthn4j-core/src/test/java/integration/component/NullAttestationStatementValidatorTest.java
@@ -16,6 +16,7 @@
 
 package integration.component;
 
+import com.webauthn4j.converter.AuthenticatorTransportConverter;
 import com.webauthn4j.data.*;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientInputs;
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientInput;
@@ -33,11 +34,13 @@ import com.webauthn4j.validator.WebAuthnRegistrationContextValidator;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.Set;
 
 class NullAttestationStatementValidatorTest {
 
     private Origin origin = new Origin("http://localhost");
     private WebAuthnRegistrationContextValidator target = WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator();
+    private AuthenticatorTransportConverter authenticatorTransportConverter = new AuthenticatorTransportConverter();
 
     @Test
     void validate_WebAuthnRegistrationContext_with_fido_u2f_attestation_statement_test() {
@@ -67,12 +70,13 @@ class NullAttestationStatementValidatorTest {
                 extensions
         );
         AuthenticatorAttestationResponse registrationRequest = clientPlatform.create(credentialCreationOptions).getAuthenticatorResponse();
+        Set<String> transports = authenticatorTransportConverter.convertSetToStringSet(registrationRequest.getTransports());
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
         WebAuthnRegistrationContext registrationContext =
                 new WebAuthnRegistrationContext(
                         registrationRequest.getClientDataJSON(),
                         registrationRequest.getAttestationObject(),
-                        registrationRequest.getTransports(),
+                        transports,
                         serverProperty, false);
         target.validate(registrationContext);
     }
@@ -107,8 +111,9 @@ class NullAttestationStatementValidatorTest {
         );
 
         AuthenticatorAttestationResponse registrationRequest = clientPlatform.create(credentialCreationOptions).getAuthenticatorResponse();
+        Set<String> transports = authenticatorTransportConverter.convertSetToStringSet(registrationRequest.getTransports());
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
-        WebAuthnRegistrationContext registrationContext = new WebAuthnRegistrationContext(registrationRequest.getClientDataJSON(), registrationRequest.getAttestationObject(), registrationRequest.getTransports(), serverProperty, true);
+        WebAuthnRegistrationContext registrationContext = new WebAuthnRegistrationContext(registrationRequest.getClientDataJSON(), registrationRequest.getAttestationObject(), transports, serverProperty, true);
         target.validate(registrationContext);
     }
 }

--- a/webauthn4j-core/src/test/java/integration/scenario/CustomRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/CustomRegistrationValidationTest.java
@@ -18,6 +18,7 @@ package integration.scenario;
 
 import com.webauthn4j.anchor.TrustAnchorsResolver;
 import com.webauthn4j.converter.AuthenticationExtensionsClientOutputsConverter;
+import com.webauthn4j.converter.AuthenticatorTransportConverter;
 import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.data.*;
 import com.webauthn4j.data.AuthenticatorAttestationResponse;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,6 +65,7 @@ public class CustomRegistrationValidationTest {
             new DefaultSelfAttestationTrustworthinessValidator()
     );
 
+    private AuthenticatorTransportConverter authenticatorTransportConverter = new AuthenticatorTransportConverter();
     private AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
             = new AuthenticationExtensionsClientOutputsConverter(jsonConverter);
 
@@ -85,12 +88,13 @@ public class CustomRegistrationValidationTest {
         AuthenticatorAttestationResponse registrationRequest = credential.getAuthenticatorResponse();
         AuthenticationExtensionsClientOutputs clientExtensionResults = credential.getClientExtensionResults();
         String clientExtensionJSON = authenticationExtensionsClientOutputsConverter.convertToString(clientExtensionResults);
+        Set<String> transports = authenticatorTransportConverter.convertSetToStringSet(registrationRequest.getTransports());
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
         WebAuthnRegistrationContext registrationContext
                 = new WebAuthnRegistrationContext(
                 registrationRequest.getClientDataJSON(),
                 registrationRequest.getAttestationObject(),
-                registrationRequest.getTransports(),
+                transports,
                 clientExtensionJSON,
                 serverProperty,
                 false,

--- a/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorRegistrationValidationTest.java
@@ -111,7 +111,7 @@ class UserVerifyingAuthenticatorRegistrationValidationTest {
         PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput> credential = clientPlatform.create(credentialCreationOptions);
         AuthenticatorAttestationResponse registrationRequest = credential.getAuthenticatorResponse();
         AuthenticationExtensionsClientOutputs clientExtensionResults = credential.getClientExtensionResults();
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
+        Set<String> transports = Collections.emptySet();
         String clientExtensionJSON = authenticationExtensionsClientOutputsConverter.convertToString(clientExtensionResults);
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
         WebAuthnRegistrationContext registrationContext
@@ -165,7 +165,7 @@ class UserVerifyingAuthenticatorRegistrationValidationTest {
         PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput> credential = clientPlatform.create(credentialCreationOptions);
         AuthenticatorAttestationResponse registrationRequest = credential.getAuthenticatorResponse();
         AuthenticationExtensionsClientOutputs clientExtensionResults = credential.getClientExtensionResults();
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
+        Set<String> transports = Collections.emptySet();
         String clientExtensionJSON = authenticationExtensionsClientOutputsConverter.convertToString(clientExtensionResults);
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
         WebAuthnRegistrationContext registrationContext
@@ -221,7 +221,7 @@ class UserVerifyingAuthenticatorRegistrationValidationTest {
         PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput> credential = clientPlatform.create(credentialCreationOptions);
         AuthenticatorAttestationResponse registrationRequest = credential.getAuthenticatorResponse();
         AuthenticationExtensionsClientOutputs clientExtensionResults = credential.getClientExtensionResults();
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
+        Set<String> transports = Collections.emptySet();
         String clientExtensionJSON = authenticationExtensionsClientOutputsConverter.convertToString(clientExtensionResults);
 
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);

--- a/webauthn4j-core/src/test/java/sample/Sample.java
+++ b/webauthn4j-core/src/test/java/sample/Sample.java
@@ -18,7 +18,6 @@ package sample;
 
 import com.webauthn4j.authenticator.Authenticator;
 import com.webauthn4j.authenticator.AuthenticatorImpl;
-import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.WebAuthnAuthenticationContext;
 import com.webauthn4j.data.WebAuthnRegistrationContext;
 import com.webauthn4j.data.client.Origin;
@@ -37,7 +36,7 @@ class Sample {
         // Client properties
         byte[] clientDataJSON = null /* set clientDataJSON */;
         byte[] attestationObject = null /* set attestationObject */;
-        Set<AuthenticatorTransport> transports = null /* set transports */;
+        Set<String> transports = null /* set transports */;
 
         // Server properties
         Origin origin = null /* set origin */;


### PR DESCRIPTION
Since `WebAuthnRegistrationContext` is an input envelope class for validator, it's field should not be specialized type to leave the validator input check task