### PR TITLE
TPMAttestationValidator validateSubjectAlternativeName bug

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/tpm/TPMAttestationStatementValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/tpm/TPMAttestationStatementValidator.java
@@ -255,7 +255,6 @@ public class TPMAttestationStatementValidator extends AbstractStatementValidator
     }
 
     private void validateSubjectAlternativeName(X509Certificate certificate) throws CertificateParsingException {
-
         try {
             for (List entry : certificate.getSubjectAlternativeNames()) {
                 if (entry.get(0).equals(4)) {


### PR DESCRIPTION
The TPMAttestationValidator.validateSubjectAlternativeName triggered a NullPointerException on line 263:

```
                    byte[] manufacturerAttr = (byte[]) directoryName.getRdns().get(0).toAttributes().get("2.23.133.2.1").get();
                    byte[] partNumberAttr = (byte[]) directoryName.getRdns().get(0).toAttributes().get("2.23.133.2.2").get();
                    byte[] firmwareVersionAttr = (byte[]) directoryName.getRdns().get(0).toAttributes().get("2.23.133.2.3").get();
````

The .getRdns() returns List<Rdns>, so moving it to index 0 always returns the same. The get("...") on the attributes failed on 2.23.133.2.2 because it did not exist.

Refactored it to
```
Map<String, Object> map = directoryName.getRdns().stream()
                            .map(Rdn::toAttributes) //Stream<Attributes>
                            .map(this::toKeyValue) //Steam<KeyValue>
                            .flatMap(Collection::stream)
                            .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
```

So that you can use a Map to get the elements.  We'll do some more tests on the TPM soon, so I might suggest some other changes/improvements if that's ok.