### PR TITLE
Static secure random

### DIFF
--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/u2f/FIDOU2FAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/u2f/FIDOU2FAuthenticator.java
@@ -60,9 +60,7 @@ public class FIDOU2FAuthenticator {
         byte[] challengeParameter = registrationRequest.getChallengeParameter();
         byte[] applicationParameter = registrationRequest.getApplicationParameter();
 
-        SecureRandom secureRandom = new SecureRandom();
-        byte[] nonce = new byte[32];
-        secureRandom.nextBytes(nonce);
+        byte[] nonce = SecureRandomFactory.getSecureRandom().randomBytes(32);
         KeyPair keyPair = getKeyPair(applicationParameter, nonce);
 
         byte[] rpPrivateKey = keyPair.getPrivate().getEncoded();

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
@@ -39,13 +39,13 @@ import com.webauthn4j.test.client.AuthenticationEmulationOption;
 import com.webauthn4j.test.client.RegistrationEmulationOption;
 import com.webauthn4j.util.KeyUtil;
 import com.webauthn4j.util.MessageDigestUtil;
+import com.webauthn4j.util.SecureRandomFactory;
 import com.webauthn4j.util.WIP;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.PrivateKey;
-import java.security.SecureRandom;
 import java.security.interfaces.ECPublicKey;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -196,8 +196,7 @@ public abstract class WebAuthnModelAuthenticator implements WebAuthnAuthenticato
             // Credential Private Key:
             if (makeCredentialRequest.isRequireResidentKey()) {
                 // Let credentialId be a new credential id.
-                credentialId = new byte[32];
-                new SecureRandom().nextBytes(credentialId);
+                credentialId = SecureRandomFactory.getSecureRandom().randomBytes(32);
                 // Set credentialSource.id to credentialId.
                 credentialSource.setId(credentialId);
                 // Let credentials be this authenticator’s credentials map.

--- a/webauthn4j-util/src/main/java/com/webauthn4j/util/KeyUtil.java
+++ b/webauthn4j-util/src/main/java/com/webauthn4j/util/KeyUtil.java
@@ -53,13 +53,12 @@ public class KeyUtil {
 
     public static KeyPair createECKeyPair(byte[] seed, ECParameterSpec ecParameterSpec) {
         KeyPairGenerator keyPairGenerator = createECKeyPairGenerator();
-        SecureRandom random = null;
+        SecureRandom random;
         try {
             if (seed != null) {
-                random = SecureRandom.getInstance("SHA1PRNG"); // to make it deterministic
-                random.setSeed(seed);
+                random = SecureRandomFactory.createSeededSecureRandom(SecureRandomFactory.SHA1PRNG, seed); // to make it deterministic
             } else {
-                random = SecureRandom.getInstanceStrong();
+                random = SecureRandomFactory.getStrongSecureRandom().get();
             }
             keyPairGenerator.initialize(ecParameterSpec, random);
             return keyPairGenerator.generateKeyPair();
@@ -84,7 +83,7 @@ public class KeyUtil {
         KeyPairGenerator keyPairGenerator = null;
         try {
             keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-            keyPairGenerator.initialize(new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4), new SecureRandom());
+            keyPairGenerator.initialize(new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4), SecureRandomFactory.getSecureRandom().get());
         } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
             throw new UnexpectedCheckedException(e);
         }

--- a/webauthn4j-util/src/main/java/com/webauthn4j/util/KeyUtil.java
+++ b/webauthn4j-util/src/main/java/com/webauthn4j/util/KeyUtil.java
@@ -80,7 +80,7 @@ public class KeyUtil {
     }
 
     public static KeyPair createRSAKeyPair() {
-        KeyPairGenerator keyPairGenerator = null;
+        KeyPairGenerator keyPairGenerator;
         try {
             keyPairGenerator = KeyPairGenerator.getInstance("RSA");
             keyPairGenerator.initialize(new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4), SecureRandomFactory.getSecureRandom().get());

--- a/webauthn4j-util/src/main/java/com/webauthn4j/util/SecureRandomFactory.java
+++ b/webauthn4j-util/src/main/java/com/webauthn4j/util/SecureRandomFactory.java
@@ -1,0 +1,61 @@
+package com.webauthn4j.util;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+public final class SecureRandomFactory {
+    public final static String SHA1PRNG = "SHA1PRNG";
+
+    private final static SRI SECURE_RANDOM = new SRI(new SecureRandom());
+    private static SRI STRONG_SECURE_RANDOM = null;
+
+
+    public static SecureRandom createSeededSecureRandom(String algorithm, byte[] seed) throws NoSuchAlgorithmException {
+        SecureRandom random = SecureRandom.getInstance(algorithm);
+        random.setSeed(seed);
+
+        return random;
+    }
+
+    public static SRI getSecureRandom() {
+        return SECURE_RANDOM;
+    }
+
+    public static synchronized SRI getStrongSecureRandom() {
+        synchronized (SecureRandomFactory.class) {
+            if (STRONG_SECURE_RANDOM == null) {
+                try {
+                    STRONG_SECURE_RANDOM = new SRI(SecureRandom.getInstanceStrong());
+                } catch (NoSuchAlgorithmException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            return STRONG_SECURE_RANDOM;
+        }
+    }
+
+    public static class SRI {
+        private SecureRandom secureRandom;
+
+        SRI(final SecureRandom secureRandom) {
+            this.secureRandom = secureRandom;
+        }
+
+        SecureRandom get() {
+            return secureRandom;
+        }
+
+        synchronized void nextBytes(byte[] bytes) {
+            this.secureRandom.nextBytes(bytes);
+        }
+
+        public byte[] randomBytes(int size) {
+            byte[] nonce = new byte[size];
+
+            nextBytes(nonce);
+
+            return nonce.clone();
+        }
+    }
+}


### PR DESCRIPTION
We've run into a problem that the seeding on creating new SecureRandoms takes too much time (taking up more than 20 - 25s/req). We foresee a large load, so my suggestion would be to make this static/factory based. What do you think?