### PR TITLE
Improve SecureRandom handling

### DIFF
--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/u2f/FIDOU2FAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/u2f/FIDOU2FAuthenticator.java
@@ -34,6 +34,7 @@ public class FIDOU2FAuthenticator {
 
     public static final byte FLAG_OFF = (byte) 0b00000000;
     public static final byte FLAG_UP = (byte) 0b00000001;
+    private SecureRandom secureRandom = new SecureRandom();
 
     private PrivateKey attestationPrivateKey;
     private X509Certificate attestationPublicKeyCertificate;
@@ -60,7 +61,6 @@ public class FIDOU2FAuthenticator {
         byte[] challengeParameter = registrationRequest.getChallengeParameter();
         byte[] applicationParameter = registrationRequest.getApplicationParameter();
 
-        SecureRandom secureRandom = new SecureRandom();
         byte[] nonce = new byte[32];
         secureRandom.nextBytes(nonce);
         KeyPair keyPair = getKeyPair(applicationParameter, nonce);

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
@@ -56,6 +56,7 @@ import static com.webauthn4j.data.attestation.authenticator.AuthenticatorData.*;
 public abstract class WebAuthnModelAuthenticator implements WebAuthnAuthenticator{
 
     private CborConverter cborConverter = new CborConverter();
+    private SecureRandom secureRandom = new SecureRandom();
 
     AAGUID aaguid;
     private boolean capableOfUserVerification;
@@ -197,7 +198,7 @@ public abstract class WebAuthnModelAuthenticator implements WebAuthnAuthenticato
             if (makeCredentialRequest.isRequireResidentKey()) {
                 // Let credentialId be a new credential id.
                 credentialId = new byte[32];
-                new SecureRandom().nextBytes(credentialId);
+                secureRandom.nextBytes(credentialId);
                 // Set credentialSource.id to credentialId.
                 credentialSource.setId(credentialId);
                 // Let credentials be this authenticator’s credentials map.

--- a/webauthn4j-util/src/main/java/com/webauthn4j/util/KeyUtil.java
+++ b/webauthn4j-util/src/main/java/com/webauthn4j/util/KeyUtil.java
@@ -29,6 +29,8 @@ import java.security.spec.RSAKeyGenParameterSpec;
  */
 public class KeyUtil {
 
+    private static SecureRandom secureRandom = new SecureRandom();
+
     private KeyUtil() {
     }
 
@@ -53,13 +55,13 @@ public class KeyUtil {
 
     public static KeyPair createECKeyPair(byte[] seed, ECParameterSpec ecParameterSpec) {
         KeyPairGenerator keyPairGenerator = createECKeyPairGenerator();
-        SecureRandom random = null;
+        SecureRandom random;
         try {
             if (seed != null) {
                 random = SecureRandom.getInstance("SHA1PRNG"); // to make it deterministic
                 random.setSeed(seed);
             } else {
-                random = SecureRandom.getInstanceStrong();
+                random = secureRandom;
             }
             keyPairGenerator.initialize(ecParameterSpec, random);
             return keyPairGenerator.generateKeyPair();


### PR DESCRIPTION
* Stop using `SecureRandom.getInstanceStrong()` as it makes large overhead, and I don't see value on using it
* Have `SecureRandom` per classes to reduce instance creation overhead.