### PR TITLE
FIX json mapping

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/CredentialPublicKey.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/CredentialPublicKey.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = "1")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = EC2CredentialPublicKey.class, name = "2"),

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/AttestationStatement.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/AttestationStatement.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.attestation.statement;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.io.Serializable;
@@ -24,7 +25,16 @@ import java.io.Serializable;
  * Attestation metadata.certs container
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "format")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = AndroidKeyAttestationStatement.class, name = AndroidKeyAttestationStatement.FORMAT),
+        @JsonSubTypes.Type(value = AndroidSafetyNetAttestationStatement.class, name = AndroidSafetyNetAttestationStatement.FORMAT),
+        @JsonSubTypes.Type(value = FIDOU2FAttestationStatement.class, name = FIDOU2FAttestationStatement.FORMAT),
+        @JsonSubTypes.Type(value = NoneAttestationStatement.class, name = NoneAttestationStatement.FORMAT),
+        @JsonSubTypes.Type(value = PackedAttestationStatement.class, name = PackedAttestationStatement.FORMAT),
+        @JsonSubTypes.Type(value = TPMAttestationStatement.class, name = TPMAttestationStatement.FORMAT),
+})
 public interface AttestationStatement extends Serializable {
+
     String getFormat();
 
     /**


### PR DESCRIPTION
JsonTypeInfo duplicates existing propery "1" of subclasses resulting in
invalid json and failure on deserializion

before serialization result looked like {"1":"2","2":null,"3":-7," ..... ,"1":2} with duplicate keys
after fix like {"2":null,"3":-7," ..... ,"1":2} and deserializion works