### PR TITLE
CborMapper and JsonMapper threadsafety

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AttestationObjectConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AttestationObjectConverter.java
@@ -29,14 +29,12 @@ public class AttestationObjectConverter {
 
     // ~ Instance fields
     // ================================================================================================
-    private CborConverter cborConverter;
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     // ~ Constructors
     // ================================================================================================
 
-    public AttestationObjectConverter(CborConverter cborConverter) {
-        AssertUtil.notNull(cborConverter, "cborConverter must not be null");
-        this.cborConverter = cborConverter;
+    public AttestationObjectConverter() {
     }
 
     // ~ Methods

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
@@ -37,21 +37,21 @@ import java.security.cert.X509Certificate;
  */
 public class WebAuthnCBORModule extends SimpleModule {
 
-    public WebAuthnCBORModule(JsonConverter jsonConverter, CborConverter cborConverter) {
+    public WebAuthnCBORModule() {
         super("WebAuthnCBORModule");
 
         this.addDeserializer(AuthenticationExtensionsAuthenticatorOutputsEnvelope.class, new AuthenticationExtensionsAuthenticatorOutputsEnvelopeDeserializer());
         this.addDeserializer(CertPath.class, new CertPathDeserializer());
         this.addDeserializer(Challenge.class, new ChallengeDeserializer());
         this.addDeserializer(CredentialPublicKeyEnvelope.class, new CredentialPublicKeyEnvelopeDeserializer());
-        this.addDeserializer(AuthenticatorData.class, new AuthenticatorDataDeserializer(cborConverter));
+        this.addDeserializer(AuthenticatorData.class, new AuthenticatorDataDeserializer());
         this.addDeserializer(ExtensionAuthenticatorOutput.class, new ExtensionAuthenticatorOutputDeserializer());
         this.addDeserializer(TPMSAttest.class, new TPMSAttestDeserializer());
         this.addDeserializer(TPMTPublic.class, new TPMTPublicDeserializer());
         this.addDeserializer(X509Certificate.class, new X509CertificateDeserializer());
-        this.addDeserializer(JWS.class, new JWSDeserializer(jsonConverter));
+        this.addDeserializer(JWS.class, new JWSDeserializer());
 
-        this.addSerializer(AuthenticatorData.class, new AuthenticatorDataSerializer(cborConverter));
+        this.addSerializer(AuthenticatorData.class, new AuthenticatorDataSerializer());
         this.addSerializer(CertPath.class, new CertPathSerializer());
         this.addSerializer(Challenge.class, new ChallengeSerializer());
         this.addSerializer(JWS.class, new JWSSerializer());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
@@ -36,13 +36,13 @@ import java.security.cert.X509Certificate;
 public class WebAuthnJSONModule extends SimpleModule {
 
     @SuppressWarnings("unused")
-    public WebAuthnJSONModule(JsonConverter jsonConverter, CborConverter cborConverter) {
+    public WebAuthnJSONModule() {
         super("WebAuthnJSONModule");
 
         this.addDeserializer(Challenge.class, new ChallengeDeserializer());
         this.addDeserializer(ExtensionClientInput.class, new ExtensionClientInputDeserializer());
         this.addDeserializer(ExtensionClientOutput.class, new ExtensionClientOutputDeserializer());
-        this.addDeserializer(JWS.class, new JWSDeserializer(jsonConverter));
+        this.addDeserializer(JWS.class, new JWSDeserializer());
         this.addDeserializer(X509Certificate.class, new X509CertificateDeserializer());
 
         this.addSerializer(Challenge.class, new ChallengeSerializer());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/AuthenticatorDataDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/AuthenticatorDataDeserializer.java
@@ -30,15 +30,8 @@ import java.io.IOException;
  * Jackson Deserializer for {@link AuthenticatorData}
  */
 public class AuthenticatorDataDeserializer extends StdDeserializer<AuthenticatorData> {
-
-    private CborConverter cborConverter;
-
-    public AuthenticatorDataDeserializer(CborConverter cborConverter) {
+    public AuthenticatorDataDeserializer() {
         super(AuthenticatorData.class);
-
-        AssertUtil.notNull(cborConverter, "cborConverter must not be null");
-
-        this.cborConverter = cborConverter;
     }
 
     /**
@@ -47,7 +40,7 @@ public class AuthenticatorDataDeserializer extends StdDeserializer<Authenticator
     @Override
     public AuthenticatorData deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         byte[] value = p.getBinaryValue();
-        return new AuthenticatorDataConverter(cborConverter).convert(value);
+        return new AuthenticatorDataConverter(CborConverter.INSTANCE).convert(value);
     }
 
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/JWSDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/JWSDeserializer.java
@@ -36,12 +36,10 @@ public class JWSDeserializer extends StdDeserializer<JWS> {
 
     private transient JWSFactory jwsFactory;
 
-    public JWSDeserializer(JsonConverter jsonConverter) {
+    public JWSDeserializer() {
         super(JWS.class);
 
-        AssertUtil.notNull(jsonConverter, "jsonConverter must not be null");
-
-        this.jwsFactory = new JWSFactory(jsonConverter);
+        this.jwsFactory = new JWSFactory(JsonConverter.INSTANCE);
     }
 
     @Override

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/AuthenticatorDataSerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/AuthenticatorDataSerializer.java
@@ -30,15 +30,8 @@ import java.io.IOException;
  * Jackson Serializer for {@link AuthenticatorData}
  */
 public class AuthenticatorDataSerializer extends StdSerializer<AuthenticatorData> {
-
-    private CborConverter cborConverter;
-
-    public AuthenticatorDataSerializer(CborConverter cborConverter) {
+    public AuthenticatorDataSerializer() {
         super(AuthenticatorData.class);
-
-        AssertUtil.notNull(cborConverter, "cborConverter must not be null");
-
-        this.cborConverter = cborConverter;
     }
 
     /**
@@ -46,7 +39,7 @@ public class AuthenticatorDataSerializer extends StdSerializer<AuthenticatorData
      */
     @Override
     public void serialize(AuthenticatorData value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        gen.writeBinary(new AuthenticatorDataConverter(cborConverter).convert(value));
+        gen.writeBinary(new AuthenticatorDataConverter(CborConverter.INSTANCE).convert(value));
     }
 
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/CborConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/CborConverter.java
@@ -44,14 +44,11 @@ public class CborConverter implements Serializable {
     public final static CborConverter INSTANCE = new CborConverter();
     private static final String INPUT_MISMATCH_ERROR_MESSAGE = "Input data does not match expected form";
     private final ObjectMapper cborMapper;
-    private final JsonConverter jsonConverter;
 
     private CborConverter() {
-        ObjectMapper jsonMapper = new ObjectMapper();
         this.cborMapper = new ObjectMapper(new CBORFactory());
-        this.jsonConverter = new JsonConverter(jsonMapper, cborMapper);
 
-        cborMapper.registerModule(new WebAuthnCBORModule(getJsonConverter(), this));
+        cborMapper.registerModule(new WebAuthnCBORModule());
         cborMapper.configure(DeserializationFeature.WRAP_EXCEPTIONS, false);
         cborMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         cborMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
@@ -125,14 +122,5 @@ public class CborConverter implements Serializable {
      */
     private ObjectMapper getCborMapper() {
         return cborMapper;
-    }
-
-    /**
-     * Returns the twined {@link JsonConverter}
-     *
-     * @return the twined {@link JsonConverter}
-     */
-    public JsonConverter getJsonConverter() {
-        return jsonConverter;
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSFactory.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSFactory.java
@@ -29,14 +29,14 @@ import java.security.SignatureException;
 
 public class JWSFactory {
 
-    private JsonConverter jsonConverter;
+    private final JsonConverter jsonConverter;
 
     public JWSFactory(JsonConverter jsonConverter) {
         this.jsonConverter = jsonConverter;
     }
 
     public JWSFactory() {
-        this(new JsonConverter());
+        this(JsonConverter.INSTANCE);
     }
 
     public <T extends Serializable> JWS<T> create(JWSHeader header, T payload, PrivateKey privateKey) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
@@ -66,7 +66,7 @@ public class WebAuthnAuthenticationContextValidator {
     // ========================================================================================================
 
     public WebAuthnAuthenticationContextValidator() {
-        this(new JsonConverter(), CborConverter.INSTANCE);
+        this(JsonConverter.INSTANCE, CborConverter.INSTANCE);
     }
 
     public WebAuthnAuthenticationContextValidator(JsonConverter jsonConverter, CborConverter cborConverter) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
@@ -66,7 +66,7 @@ public class WebAuthnAuthenticationContextValidator {
     // ========================================================================================================
 
     public WebAuthnAuthenticationContextValidator() {
-        this(new JsonConverter(), new CborConverter());
+        this(new JsonConverter(), CborConverter.INSTANCE);
     }
 
     public WebAuthnAuthenticationContextValidator(JsonConverter jsonConverter, CborConverter cborConverter) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
@@ -89,7 +89,7 @@ public class WebAuthnRegistrationContextValidator {
                 certPathTrustworthinessValidator,
                 ecdaaTrustworthinessValidator,
                 new DefaultSelfAttestationTrustworthinessValidator(),
-                new JsonConverter(),
+                JsonConverter.INSTANCE,
                 CborConverter.INSTANCE);
     }
 
@@ -103,7 +103,7 @@ public class WebAuthnRegistrationContextValidator {
                 certPathTrustworthinessValidator,
                 ecdaaTrustworthinessValidator,
                 selfAttestationTrustworthinessValidator,
-                new JsonConverter(),
+                JsonConverter.INSTANCE,
                 CborConverter.INSTANCE);
     }
 
@@ -141,7 +141,7 @@ public class WebAuthnRegistrationContextValidator {
 
 
         collectedClientDataConverter = new CollectedClientDataConverter(jsonConverter);
-        attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+        attestationObjectConverter = new AttestationObjectConverter();
         authenticatorTransportConverter = new AuthenticatorTransportConverter();
         authenticationExtensionsClientOutputsConverter = new AuthenticationExtensionsClientOutputsConverter(jsonConverter);
 
@@ -162,7 +162,7 @@ public class WebAuthnRegistrationContextValidator {
      * @return configured {@link WebAuthnRegistrationContextValidator}
      */
     public static WebAuthnRegistrationContextValidator createNonStrictRegistrationContextValidator() {
-        return createNonStrictRegistrationContextValidator(new JsonConverter(), CborConverter.INSTANCE);
+        return createNonStrictRegistrationContextValidator(JsonConverter.INSTANCE, CborConverter.INSTANCE);
     }
 
     /**

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
@@ -90,7 +90,7 @@ public class WebAuthnRegistrationContextValidator {
                 ecdaaTrustworthinessValidator,
                 new DefaultSelfAttestationTrustworthinessValidator(),
                 new JsonConverter(),
-                new CborConverter());
+                CborConverter.INSTANCE);
     }
 
     public WebAuthnRegistrationContextValidator(
@@ -104,7 +104,7 @@ public class WebAuthnRegistrationContextValidator {
                 ecdaaTrustworthinessValidator,
                 selfAttestationTrustworthinessValidator,
                 new JsonConverter(),
-                new CborConverter());
+                CborConverter.INSTANCE);
     }
 
     public WebAuthnRegistrationContextValidator(
@@ -162,7 +162,7 @@ public class WebAuthnRegistrationContextValidator {
      * @return configured {@link WebAuthnRegistrationContextValidator}
      */
     public static WebAuthnRegistrationContextValidator createNonStrictRegistrationContextValidator() {
-        return createNonStrictRegistrationContextValidator(new JsonConverter(), new CborConverter());
+        return createNonStrictRegistrationContextValidator(new JsonConverter(), CborConverter.INSTANCE);
     }
 
     /**

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationContextTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationContextTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.mock;
 
 class WebAuthnAuthenticationContextTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
     private CborConverter cborConverter = CborConverter.INSTANCE;
 
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationContextTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationContextTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.mock;
 class WebAuthnAuthenticationContextTest {
 
     private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnRegistrationContextTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnRegistrationContextTest.java
@@ -35,14 +35,14 @@ import static org.mockito.Mockito.mock;
 
 class WebAuthnRegistrationContextTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
     private CborConverter cborConverter = CborConverter.INSTANCE;
 
 
     @Test
     void test() {
         byte[] collectedClientData = new CollectedClientDataConverter(jsonConverter).convertToBytes(createClientData(ClientDataType.GET));
-        byte[] authenticatorData = new AttestationObjectConverter(cborConverter).convertToBytes(createAttestationObjectWithFIDOU2FAttestationStatement());
+        byte[] authenticatorData = new AttestationObjectConverter().convertToBytes(createAttestationObjectWithFIDOU2FAttestationStatement());
         Set<String> transports = Collections.emptySet();
 
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnRegistrationContextTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnRegistrationContextTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 class WebAuthnRegistrationContextTest {
 
     private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationCertificatePathConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationCertificatePathConverterTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AttestationCertificatePathConverterTest {
 
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
     void test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationObjectConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationObjectConverterTest.java
@@ -32,7 +32,7 @@ class AttestationObjectConverterTest {
 
     private CborConverter cborConverter = CborConverter.INSTANCE;
 
-    private AttestationObjectConverter target = new AttestationObjectConverter(cborConverter);
+    private AttestationObjectConverter target = new AttestationObjectConverter();
 
     @Test
     void convert_deserialization_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationObjectConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationObjectConverterTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AttestationObjectConverterTest {
 
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     private AttestationObjectConverter target = new AttestationObjectConverter(cborConverter);
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverterTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AuthenticationExtensionsClientInputsConverterTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     private AuthenticationExtensionsClientInputsConverter authenticationExtensionsClientInputsConverter = new AuthenticationExtensionsClientInputsConverter(jsonConverter);
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverterTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthenticationExtensionsClientOutputsConverterTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     private AuthenticationExtensionsClientOutputsConverter target = new AuthenticationExtensionsClientOutputsConverter(jsonConverter);
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorDataConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorDataConverterTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class AuthenticatorDataConverterTest {
 
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
     void convert_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/CollectedClientDataConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/CollectedClientDataConverterTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class CollectedClientDataConverterTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     private CollectedClientDataConverter target = new CollectedClientDataConverter(jsonConverter);
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/AttestationObjectDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/AttestationObjectDeserializerTest.java
@@ -32,7 +32,7 @@ class AttestationObjectDeserializerTest {
 
     @Test
     void test() {
-        CborConverter cborConverter = new CborConverter();
+        CborConverter cborConverter = CborConverter.INSTANCE;
 
         //Given
         //noinspection SpellCheckingInspection

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/AttestationStatementDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/AttestationStatementDeserializerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class AttestationStatementDeserializerTest {
 
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
     void test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/ChallengeDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/ChallengeDeserializerTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class ChallengeDeserializerTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/ExtensionClientOutputDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/ExtensionClientOutputDeserializerTest.java
@@ -32,7 +32,7 @@ class ExtensionClientOutputDeserializerTest {
 
     @Test
     void deserialize_test_with_JSON_data() {
-        JsonConverter jsonConverter = new JsonConverter();
+        JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
         Map<String, ExtensionClientOutput> extensionOutputs =
                 jsonConverter.readValue(

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/X509CertificateDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/X509CertificateDeserializerTest.java
@@ -31,7 +31,7 @@ class X509CertificateDeserializerTest {
 
     @Test
     void deserialize_test() throws CertificateEncodingException {
-        CborConverter cborConverter = new CborConverter();
+        CborConverter cborConverter = CborConverter.INSTANCE;
 
         Map<String, byte[]> source = new HashMap<>();
         source.put("certificate", TestAttestationUtil.load2tierTestAuthenticatorAttestationCertificate().getEncoded());
@@ -43,7 +43,7 @@ class X509CertificateDeserializerTest {
 
     @Test
     void deserialize_empty_byte_array_test() {
-        CborConverter cborConverter = new CborConverter();
+        CborConverter cborConverter = CborConverter.INSTANCE;
 
         Map<String, byte[]> source = new HashMap<>();
         source.put("certificate", new byte[0]);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/AuthenticatorDataSerializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/AuthenticatorDataSerializerTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
  */
 class AuthenticatorDataSerializerTest {
 
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
     void test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/CertPathSerializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/CertPathSerializerTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class CertPathSerializerTest {
 
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
     void test() throws CertificateException {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/util/JsonConverterIntegrationTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/util/JsonConverterIntegrationTest.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -34,11 +33,10 @@ class JsonConverterIntegrationTest {
     @Test
     void constructor_with_customized_objectMapper_inherits_customization() {
         ObjectMapper jsonMapper = new ObjectMapper(new JsonFactory());
-        ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
         SimpleModule module = new SimpleModule();
         module.addSerializer(TestData.class, new TestDataSerializer());
         jsonMapper.registerModule(module);
-        JsonConverter jsonConverter = new JsonConverter(jsonMapper, cborMapper);
+        JsonConverter jsonConverter = new JsonConverter(jsonMapper);
         assertThat(jsonConverter.writeValueAsString(new TestData())).isEqualTo("\"serialized by TestDataSerializer\"");
     }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/util/JsonConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/util/JsonConverterTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JsonConverterTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void readValue_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AttestationConveyancePreferenceTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AttestationConveyancePreferenceTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("ResultOfMethodCallIgnored")
 class AttestationConveyancePreferenceTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationContextTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationContextTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class WebAuthnRegistrationContextTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
 
     private Origin origin = new Origin("http://localhost");

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2CredentialPublicKeyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2CredentialPublicKeyTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class EC2CredentialPublicKeyTest {
 
     private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
     void createFromUncompressedECCKey_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2CredentialPublicKeyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2CredentialPublicKeyTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class EC2CredentialPublicKeyTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
     private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/RSACredentialPublicKeyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/RSACredentialPublicKeyTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class RSACredentialPublicKeyTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
     private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/RSACredentialPublicKeyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/RSACredentialPublicKeyTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class RSACredentialPublicKeyTest {
 
     private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
     void equals_hashCode_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class COSEAlgorithmIdentifierTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyOperationTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyOperationTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class COSEKeyOperationTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyTypeTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class COSEKeyTypeTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMEccCurveTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMEccCurveTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TPMEccCurveTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TPMGeneratedTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgHashTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgHashTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TPMIAlgHashTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgPublicTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgPublicTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TPMIAlgPublicTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TPMISTAttestTest {
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ClientDataTypeTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class OriginTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void equals_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/TokenBindingStatusTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/TokenBindingStatusTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TokenBindingStatusTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWAIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWAIdentifierTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JWAIdentifierTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationObjectTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationObjectTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class AuthenticationObjectTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
     private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationObjectTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationObjectTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class AuthenticationObjectTest {
 
     private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
     void getter_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationObjectTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationObjectTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class RegistrationObjectTest {
 
     private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
     void getter_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationObjectTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationObjectTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class RegistrationObjectTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
     private CborConverter cborConverter = CborConverter.INSTANCE;
 
     @Test
@@ -50,7 +50,7 @@ class RegistrationObjectTest {
         CollectedClientData clientData = TestDataUtil.createClientData(ClientDataType.CREATE);
         byte[] clientDataBytes = new CollectedClientDataConverter(jsonConverter).convertToBytes(clientData);
         AttestationObject attestationObject = TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement();
-        byte[] attestationObjectBytes = new AttestationObjectConverter(cborConverter).convertToBytes(attestationObject);
+        byte[] attestationObjectBytes = new AttestationObjectConverter().convertToBytes(attestationObject);
         AuthenticatorData authenticatorData = TestDataUtil.createAuthenticatorData();
         byte[] authenticatorDataBytes = new AuthenticatorDataConverter(cborConverter).convert(authenticatorData);
         Set<AuthenticatorTransport> transports = Collections.emptySet();
@@ -87,7 +87,7 @@ class RegistrationObjectTest {
         CollectedClientData clientData = TestDataUtil.createClientData(ClientDataType.CREATE);
         byte[] clientDataBytes = new CollectedClientDataConverter(jsonConverter).convertToBytes(clientData);
         AttestationObject attestationObject = TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement();
-        byte[] attestationObjectBytes = new AttestationObjectConverter(cborConverter).convertToBytes(attestationObject);
+        byte[] attestationObjectBytes = new AttestationObjectConverter().convertToBytes(attestationObject);
         AuthenticatorData authenticatorData = TestDataUtil.createAuthenticatorData();
         byte[] authenticatorDataBytes = new AuthenticatorDataConverter(cborConverter).convert(authenticatorData);
         Set<AuthenticatorTransport> transports = Collections.emptySet();

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/packed/PackedAttestationStatementValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/packed/PackedAttestationStatementValidatorTest.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PackedAttestationStatementValidatorTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
     private CborConverter cborConverter = CborConverter.INSTANCE;
 
     private PackedAttestationStatementValidator validator = new PackedAttestationStatementValidator();
@@ -178,12 +178,12 @@ class PackedAttestationStatementValidatorTest {
 
     private void validate(byte[] clientDataBytes, AttestationObject attestationObject) {
 
-        byte[] attestationObjectBytes = new AttestationObjectConverter(cborConverter).convertToBytes(attestationObject);
+        byte[] attestationObjectBytes = new AttestationObjectConverter().convertToBytes(attestationObject);
 
         Origin origin = new Origin(originUrl);
         Challenge challenge = (Challenge) () -> Base64UrlUtil.decode(challengeString);
 
-        AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+        AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter();
         CollectedClientData collectedClientData = new CollectedClientDataConverter(jsonConverter).convert(clientDataBytes);
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/packed/PackedAttestationStatementValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/packed/PackedAttestationStatementValidatorTest.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class PackedAttestationStatementValidatorTest {
 
     private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = new CborConverter();
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     private PackedAttestationStatementValidator validator = new PackedAttestationStatementValidator();
 

--- a/webauthn4j-core/src/test/java/integration/scenario/AndroidKeyAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/AndroidKeyAuthenticatorRegistrationValidationTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class AndroidKeyAuthenticatorRegistrationValidationTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
 
     private Origin origin = new Origin("http://localhost");

--- a/webauthn4j-core/src/test/java/integration/scenario/AndroidSafetyNetAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/AndroidSafetyNetAuthenticatorRegistrationValidationTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class AndroidSafetyNetAuthenticatorRegistrationValidationTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
 
     private Origin origin = new Origin("http://localhost");

--- a/webauthn4j-core/src/test/java/integration/scenario/CustomAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/CustomAuthenticationValidationTest.java
@@ -43,8 +43,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CustomAuthenticationValidationTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = jsonConverter.getCborConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
 
     private Origin origin = new Origin("http://example.com");
@@ -116,7 +116,7 @@ public class CustomAuthenticationValidationTest {
                 Collections.singletonList(publicKeyCredentialParameters)
         );
         AuthenticatorAttestationResponse registrationRequest = clientPlatform.create(credentialCreationOptions).getAuthenticatorResponse();
-        AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+        AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter();
         return attestationObjectConverter.convert(registrationRequest.getAttestationObject());
     }
 }

--- a/webauthn4j-core/src/test/java/integration/scenario/CustomRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/CustomRegistrationValidationTest.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CustomRegistrationValidationTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
 
     private Origin origin = new Origin("http://localhost");

--- a/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorAuthenticationValidationTest.java
@@ -50,8 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = jsonConverter.getCborConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
 
     private Origin origin = new Origin("http://example.com");
@@ -486,7 +486,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 Collections.singletonList(publicKeyCredentialParameters)
         );
         AuthenticatorAttestationResponse registrationRequest = clientPlatform.create(credentialCreationOptions).getAuthenticatorResponse();
-        AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+        AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter();
         return attestationObjectConverter.convert(registrationRequest.getAttestationObject());
     }
 }

--- a/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorRegistrationValidationTest.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.mock;
 
 class FIDOU2FAuthenticatorRegistrationValidationTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
 
     private Origin origin = new Origin("http://localhost");

--- a/webauthn4j-core/src/test/java/integration/scenario/TPMAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/TPMAuthenticatorRegistrationValidationTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class TPMAuthenticatorRegistrationValidationTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
 
     private Origin origin = new Origin("http://localhost");

--- a/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorAuthenticationValidationTest.java
@@ -50,8 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserVerifyingAuthenticatorAuthenticationValidationTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = jsonConverter.getCborConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
+    private CborConverter cborConverter = CborConverter.INSTANCE;
 
     private Origin origin = new Origin("http://example.com");
     private ClientPlatform clientPlatform = EmulatorUtil.createClientPlatform(EmulatorUtil.PACKED_AUTHENTICATOR);
@@ -424,7 +424,7 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
         );
 
         AuthenticatorAttestationResponse registrationRequest = clientPlatform.create(credentialCreationOptions).getAuthenticatorResponse();
-        AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+        AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter();
         return attestationObjectConverter.convert(registrationRequest.getAttestationObject());
     }
 }

--- a/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorRegistrationValidationTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserVerifyingAuthenticatorRegistrationValidationTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
 
     private Origin origin = new Origin("http://localhost");

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/FidoMdsMetadataItemsProvider.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/FidoMdsMetadataItemsProvider.java
@@ -63,7 +63,7 @@ public class FidoMdsMetadataItemsProvider implements MetadataItemsProvider {
 
     public FidoMdsMetadataItemsProvider(JsonConverter jsonConverter, HttpClient httpClient, X509Certificate rootCertificate) {
         this.jsonConverter = jsonConverter;
-        this.jwsFactory = new JWSFactory(jsonConverter);
+        this.jwsFactory = new JWSFactory(JsonConverter.INSTANCE);
         this.httpClient = httpClient;
         this.trustAnchor = new TrustAnchor(rootCertificate, null);
     }

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/JsonFileMetadataStatementsProviderTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/JsonFileMetadataStatementsProviderTest.java
@@ -41,8 +41,7 @@ class JsonFileMetadataStatementsProviderTest {
     public JsonFileMetadataStatementsProviderTest() {
         ObjectMapper jsonMapper = new ObjectMapper();
         jsonMapper.registerModule(new WebAuthnMetadataJSONModule());
-        ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
-        jsonConverter = new JsonConverter(jsonMapper, cborMapper);
+        jsonConverter = new JsonConverter(jsonMapper);
     }
 
     @Test

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/MetadataItemsProviderTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/MetadataItemsProviderTest.java
@@ -48,8 +48,7 @@ class MetadataItemsProviderTest {
     public MetadataItemsProviderTest() {
         ObjectMapper jsonMapper = new ObjectMapper();
         jsonMapper.registerModule(new WebAuthnMetadataJSONModule());
-        ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
-        jsonConverter = new JsonConverter(jsonMapper, cborMapper);
+        jsonConverter = new JsonConverter(jsonMapper);
     }
 
     @Test

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AttachmentHintTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AttachmentHintTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AttachmentHintTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AttestationTypeTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AttestationTypeTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("ResultOfMethodCallIgnored")
 class AttestationTypeTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticationAlgorithmTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticationAlgorithmTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("ResultOfMethodCallIgnored")
 class AuthenticationAlgorithmTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/KeyProtectionTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/KeyProtectionTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class KeyProtectionTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MatcherProtectionTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MatcherProtectionTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class MatcherProtectionTest {
 
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MetadataStatementTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MetadataStatementTest.java
@@ -115,8 +115,7 @@ class MetadataStatementTest {
     public MetadataStatementTest() {
         ObjectMapper jsonMapper = new ObjectMapper();
         jsonMapper.registerModule(new WebAuthnMetadataJSONModule());
-        ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
-        jsonConverter = new JsonConverter(jsonMapper, cborMapper);
+        jsonConverter = new JsonConverter(jsonMapper);
     }
 
     @Test

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/PublicKeyRepresentationFormatTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/PublicKeyRepresentationFormatTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PublicKeyRepresentationFormatTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/TransactionConfirmationDisplayTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/TransactionConfirmationDisplayTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TransactionConfirmationDisplayTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/UserVerificationMethodTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/UserVerificationMethodTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("ResultOfMethodCallIgnored")
 class UserVerificationMethodTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/toc/AuthenticatorStatusTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/toc/AuthenticatorStatusTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AuthenticatorStatusTest {
 
-    JsonConverter jsonConverter = new JsonConverter();
+    JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void create_test() {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/uaf/AAIDTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/uaf/AAIDTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class AAIDTest {
 
-    private JsonConverter jsonConverter = new JsonConverter();
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
 
     @Test
     void constructor_test() {

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
@@ -70,10 +70,10 @@ import static com.webauthn4j.data.attestation.authenticator.AuthenticatorData.BI
  */
 public class TestDataUtil {
 
-    private static JsonConverter jsonConverter = new JsonConverter();
-    private static CborConverter cborConverter = jsonConverter.getCborConverter();
+    private static JsonConverter jsonConverter = JsonConverter.INSTANCE;
+    private static CborConverter cborConverter = CborConverter.INSTANCE;
     private static CollectedClientDataConverter collectedClientDataConverter = new CollectedClientDataConverter(jsonConverter);
-    private static AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+    private static AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter();
     private static AuthenticatorDataConverter authenticatorDataConverter = new AuthenticatorDataConverter(cborConverter);
     private static AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
             = new AuthenticationExtensionsClientOutputsConverter(jsonConverter);

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/u2f/FIDOU2FAuthenticatorAdaptor.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/u2f/FIDOU2FAuthenticatorAdaptor.java
@@ -60,13 +60,13 @@ public class FIDOU2FAuthenticatorAdaptor implements AuthenticatorAdaptor {
     public FIDOU2FAuthenticatorAdaptor(FIDOU2FAuthenticator fidoU2FAuthenticator, JsonConverter jsonConverter) {
         this.fidoU2FAuthenticator = fidoU2FAuthenticator;
 
-        CborConverter cborConverter = jsonConverter.getCborConverter();
+        CborConverter cborConverter = CborConverter.INSTANCE;
         this.collectedClientDataConverter = new CollectedClientDataConverter(jsonConverter);
         this.authenticatorDataConverter = new AuthenticatorDataConverter(cborConverter);
     }
 
     public FIDOU2FAuthenticatorAdaptor(FIDOU2FAuthenticator fidoU2FAuthenticator) {
-        this(fidoU2FAuthenticator, new JsonConverter());
+        this(fidoU2FAuthenticator, JsonConverter.INSTANCE);
     }
 
     public FIDOU2FAuthenticatorAdaptor() {

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/AndroidSafetyNetAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/AndroidSafetyNetAuthenticator.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.test.authenticator.webauthn;
 
+import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.data.attestation.statement.AndroidSafetyNetAttestationStatement;
 import com.webauthn4j.data.attestation.statement.AttestationCertificatePath;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
@@ -77,7 +78,7 @@ public class AndroidSafetyNetAuthenticator extends WebAuthnModelAuthenticator {
 
     private JWSFactory getJwsFactory() {
         if (jwsFactory == null) {
-            jwsFactory = new JWSFactory(cborConverter.getJsonConverter());
+            jwsFactory = new JWSFactory(JsonConverter.INSTANCE);
         }
         return jwsFactory;
     }

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnAuthenticatorAdaptor.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnAuthenticatorAdaptor.java
@@ -41,7 +41,7 @@ public class WebAuthnAuthenticatorAdaptor implements AuthenticatorAdaptor {
     }
 
     public WebAuthnAuthenticatorAdaptor(WebAuthnAuthenticator webAuthnAuthenticator) {
-        this(webAuthnAuthenticator, new JsonConverter());
+        this(webAuthnAuthenticator, JsonConverter.INSTANCE);
     }
 
     @Override

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
@@ -104,7 +104,7 @@ public abstract class WebAuthnModelAuthenticator implements WebAuthnAuthenticato
                 TestAttestationUtil.load3tierTestIntermediateCAPrivateKey(),
                 0,
                 true,
-                new CborConverter()
+                CborConverter.INSTANCE
         );
     }
 

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/client/ClientPlatform.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/client/ClientPlatform.java
@@ -42,9 +42,9 @@ import java.util.Map;
 @WIP
 public class ClientPlatform {
 
-    private JsonConverter jsonConverter = new JsonConverter();
-    private CborConverter cborConverter = jsonConverter.getCborConverter();
-    private AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+    private JsonConverter jsonConverter = JsonConverter.INSTANCE;
+    private CborConverter cborConverter = CborConverter.INSTANCE;
+    private AttestationObjectConverter attestationObjectConverter = new AttestationObjectConverter();
     private CollectedClientDataConverter collectedClientDataConverter = new CollectedClientDataConverter(jsonConverter);
 
     private Origin origin;


### PR DESCRIPTION
Both the `CborMapper` and `JsonMapper` are not thread safe on initialization of the `WebAuthnCborModule` and `WebAuthnJSONModule`. 

```
   /**
     * Returns the {@link ObjectMapper} configured for CBOR processing
     *
     * @return the {@link ObjectMapper} configured for CBOR processing
     */
    private ObjectMapper getCborMapper() {
        // not thread safe...
        if (!cborMapperInitialized) {
            cborMapper.registerModule(new WebAuthnCBORModule(getJsonConverter(), this));
            cborMapper.configure(DeserializationFeature.WRAP_EXCEPTIONS, false);
            cborMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
            cborMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
            cborMapperInitialized = true;
        }
        return cborMapper;
    }

    /**
     * Returns the twined {@link JsonConverter}
     *
     * @return the twined {@link JsonConverter}
     */
    public JsonConverter getJsonConverter() {
        if (jsonConverter == null) {
            jsonConverter = new JsonConverter(jsonMapper, cborMapper);
        }
        return jsonConverter;
    }
```
Jackson's ObjectMappers are by design thread safe:

```
com.fasterxml.jackson.databind.ObjectMapper


*<p> 
* Mapper instances are fully thread-safe provided that ALL configuration of the
* instance occurs before ANY read or write calls. If configuration of a mapper instance
* is modified after first usage, changes may or may not take effect, and configuration
* calls themselves may fail.
* If you need to use different configuration, you have two main possibilities:
*<ul>
* <li>Construct and use {@link ObjectReader} for reading, {@link ObjectWriter} for writing.
* Both types are fully immutable and you can freely create new instances with different
* configuration using either factory methods of {@link ObjectMapper}, or readers/writers
* themselves. Construction of new {@link ObjectReader}s and {@link ObjectWriter}s is
* a very light-weight operation so it is usually appropriate to create these on per-call
* basis, as needed, for configuring things like optional indentation of JSON.
* </li>
* <li>If the specific kind of configurability is not available via {@link ObjectReader} and
* {@link ObjectWriter}, you may need to use multiple {@link ObjectMapper} instead (for example:
* you cannot change mix-in annotations on-the-fly; or, set of custom (de)serializers).
* To help with this usage, you may want to use method {@link #copy()} which creates a clone
* of the mapper with specific configuration, and allows configuration of the copied instance
* before it gets used. Note that {@link #copy} operation is as expensive as constructing
* a new {@link ObjectMapper} instance: if possible, you should still pool and reuse mappers
* if you intend to use them for multiple operations.
* </li>
* </ul>
*<p>
```

As indicated by the comment, the ObjectMappers are recreated with every validation or registration. Thus they could benefit from being implemented as a single instance. Applying this also removes the need for the cyclic dependency of passing either the CborMapper or the JsonMapper to their corresponding module.
