### PR TITLE
Bump Jackson version to 2.9.9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,6 @@ buildscript {
 
 }
 
-ext['jackson.version'] = jacksonVersion // temporary fix for CVE-2019-12814
-
 apply plugin: 'java'
 apply plugin: 'org.sonarqube'
 apply plugin: 'com.jfrog.artifactory'
@@ -64,6 +62,15 @@ subprojects {
 
     repositories {
         mavenCentral()
+    }
+
+    dependencyManagement {
+        imports {
+            mavenBom "org.springframework.boot:spring-boot-dependencies:${springBootVersion}"
+
+            // Import Jackson Bom independently as Spring Boot 2.1.7 does not provide way to specify Jackson Bom version
+            mavenBom "com.fasterxml.jackson:jackson-bom:${jacksonBomVersion}"
+        }
     }
 
     javadoc {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ latestReleasedWebAuthn4JVersion=0.9.10.RELEASE
 # Spring Boot BOM is used for dependency management
 springBootVersion=2.1.7.RELEASE
 
-jacksonVersion=2.9.9
+jacksonBomVersion=2.9.9.20190807
 sonarqubeVersion=2.7
 asciidoctorJVersion=1.6.2
 asciidoctorGradleVersion=1.5.11

--- a/owasp/suppression.xml
+++ b/owasp/suppression.xml
@@ -42,13 +42,4 @@
    ]]></notes>
         <cve>CVE-2019-11358</cve>
     </suppress>
-    <suppress>
-        <cve>CVE-2019-12814</cve>
-    </suppress>
-    <suppress>
-        <cve>CVE-2019-14379</cve>
-    </suppress>
-    <suppress>
-        <cve>CVE-2019-14439</cve>
-    </suppress>
 </suppressions>

--- a/webauthn4j-core/build.gradle
+++ b/webauthn4j-core/build.gradle
@@ -38,9 +38,3 @@ dependencies {
     testCompile('org.junit.jupiter:junit-jupiter-api')
     testRuntime('org.junit.jupiter:junit-jupiter-engine')
 }
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.boot:spring-boot-dependencies:${springBootVersion}"
-    }
-}

--- a/webauthn4j-metadata/build.gradle
+++ b/webauthn4j-metadata/build.gradle
@@ -40,11 +40,7 @@ dependencies {
 
 }
 
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.boot:spring-boot-dependencies:${springBootVersion}"
-    }
-}
+
 
 sonarqube {
     skipProject = true

--- a/webauthn4j-test/build.gradle
+++ b/webauthn4j-test/build.gradle
@@ -40,12 +40,6 @@ dependencies {
     testRuntime('org.junit.jupiter:junit-jupiter-engine')
 }
 
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.boot:spring-boot-dependencies:${springBootVersion}"
-    }
-}
-
 sonarqube {
     skipProject = true
 }

--- a/webauthn4j-util/build.gradle
+++ b/webauthn4j-util/build.gradle
@@ -39,12 +39,6 @@ dependencies {
 
 }
 
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.boot:spring-boot-dependencies:${springBootVersion}"
-    }
-}
-
 sonarqube {
     skipProject = true
 }


### PR DESCRIPTION
As the vulnerbility does not affect WebAuthn4J directly,
this issue is not marked as bug.