### PR TITLE
Redesign COSEAlgorithmIdentifier class

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/AttestationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/AttestationObject.java
@@ -54,7 +54,7 @@ public class AttestationObject implements Serializable {
         this.attestationStatement = attestationStatement;
     }
 
-    public com.webauthn4j.data.attestation.authenticator.AuthenticatorData<RegistrationExtensionAuthenticatorOutput> getAuthenticatorData() {
+    public AuthenticatorData<RegistrationExtensionAuthenticatorOutput> getAuthenticatorData() {
         return authenticatorData;
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AbstractCOSEKey.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AbstractCOSEKey.java
@@ -17,7 +17,6 @@
 package com.webauthn4j.data.attestation.authenticator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.data.attestation.statement.COSEKeyOperation;
@@ -74,27 +73,19 @@ public abstract class AbstractCOSEKey implements COSEKey {
         return ArrayUtil.clone(baseIV);
     }
 
-    @JsonIgnore
-    private String getAlgorithmName() {
-        return algorithm.getJcaName();
-    }
-
-
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AbstractCOSEKey that = (AbstractCOSEKey) o;
         return Arrays.equals(keyId, that.keyId) &&
-                algorithm == that.algorithm &&
+                Objects.equals(algorithm, that.algorithm) &&
                 Objects.equals(keyOps, that.keyOps) &&
                 Arrays.equals(baseIV, that.baseIV);
     }
 
     @Override
     public int hashCode() {
-
         int result = Objects.hash(algorithm, keyOps);
         result = 31 * result + Arrays.hashCode(keyId);
         result = 31 * result + Arrays.hashCode(baseIV);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AttestedCredentialData.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AttestedCredentialData.java
@@ -73,7 +73,6 @@ public class AttestedCredentialData implements Serializable {
 
     @Override
     public int hashCode() {
-
         int result = Objects.hash(aaguid, coseKey);
         result = 31 * result + Arrays.hashCode(credentialId);
         return result;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AuthenticatorData.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AuthenticatorData.java
@@ -137,14 +137,11 @@ public class AuthenticatorData<T extends ExtensionAuthenticatorOutput> implement
         return extensions;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        AuthenticatorData that = (AuthenticatorData) o;
+        AuthenticatorData<?> that = (AuthenticatorData<?>) o;
         return flags == that.flags &&
                 signCount == that.signCount &&
                 Arrays.equals(rpIdHash, that.rpIdHash) &&
@@ -152,9 +149,6 @@ public class AuthenticatorData<T extends ExtensionAuthenticatorOutput> implement
                 Objects.equals(extensions, that.extensions);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         int result = Objects.hash(flags, signCount, attestedCredentialData, extensions);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/AndroidKeyAttestationStatement.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/AndroidKeyAttestationStatement.java
@@ -87,14 +87,13 @@ public class AndroidKeyAttestationStatement implements CertificateBaseAttestatio
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AndroidKeyAttestationStatement that = (AndroidKeyAttestationStatement) o;
-        return alg == that.alg &&
+        return Objects.equals(alg, that.alg) &&
                 Arrays.equals(sig, that.sig) &&
                 Objects.equals(x5c, that.x5c);
     }
 
     @Override
     public int hashCode() {
-
         int result = Objects.hash(alg, x5c);
         result = 31 * result + Arrays.hashCode(sig);
         return result;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifier.java
@@ -21,56 +21,27 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 public class COSEAlgorithmIdentifier implements Serializable {
 
-    public static final COSEAlgorithmIdentifier RS1 = new COSEAlgorithmIdentifier(-65535, "SHA1withRSA", "SHA-1");
-    public static final COSEAlgorithmIdentifier RS256 = new COSEAlgorithmIdentifier(-257, "SHA256withRSA", "SHA-256");
-    public static final COSEAlgorithmIdentifier RS384 = new COSEAlgorithmIdentifier(-258, "SHA384withRSA", "SHA-384");
-    public static final COSEAlgorithmIdentifier RS512 = new COSEAlgorithmIdentifier(-259, "SHA512withRSA", "SHA-512");
-    public static final COSEAlgorithmIdentifier ES256 = new COSEAlgorithmIdentifier(-7, "SHA256withECDSA", "SHA-256");
-    public static final COSEAlgorithmIdentifier ES384 = new COSEAlgorithmIdentifier(-35, "SHA384withECDSA", "SHA-384");
-    public static final COSEAlgorithmIdentifier ES512 = new COSEAlgorithmIdentifier(-36, "SHA512withECDSA", "SHA-512");
-    public static final COSEAlgorithmIdentifier PS256 = new COSEAlgorithmIdentifier(-37, "SHA256withRSA/PSS", "SHA-256");
-    public static final COSEAlgorithmIdentifier PS384 = new COSEAlgorithmIdentifier(-38, "SHA384withRSA/PSS", "SHA-384");
-    public static final COSEAlgorithmIdentifier PS512 = new COSEAlgorithmIdentifier(-39, "SHA512withRSA/PSS", "SHA-512");
-
-    private static final Map<Long, COSEAlgorithmIdentifier> predefinedAlgorithmMap = new HashMap<>();
-
-    static {
-        predefinedAlgorithmMap.put(RS1.value, RS1);
-        predefinedAlgorithmMap.put(RS256.value, RS256);
-        predefinedAlgorithmMap.put(RS384.value, RS384);
-        predefinedAlgorithmMap.put(RS512.value, RS512);
-        predefinedAlgorithmMap.put(ES256.value, ES256);
-        predefinedAlgorithmMap.put(ES384.value, ES384);
-        predefinedAlgorithmMap.put(ES512.value, ES512);
-        predefinedAlgorithmMap.put(PS256.value, PS256);
-        predefinedAlgorithmMap.put(PS384.value, PS384);
-        predefinedAlgorithmMap.put(PS512.value, PS512);
-    }
+    public static final COSEAlgorithmIdentifier RS1   = new COSEAlgorithmIdentifier(-65535);
+    public static final COSEAlgorithmIdentifier RS256 = new COSEAlgorithmIdentifier(-257);
+    public static final COSEAlgorithmIdentifier RS384 = new COSEAlgorithmIdentifier(-258);
+    public static final COSEAlgorithmIdentifier RS512 = new COSEAlgorithmIdentifier(-259);
+    public static final COSEAlgorithmIdentifier ES256 = new COSEAlgorithmIdentifier(-7);
+    public static final COSEAlgorithmIdentifier ES384 = new COSEAlgorithmIdentifier(-35);
+    public static final COSEAlgorithmIdentifier ES512 = new COSEAlgorithmIdentifier(-36);
 
     private final long value;
-    private final String jcaName;
-    private final String messageDigestJcaName;
 
-    private COSEAlgorithmIdentifier(long value, String jcaName, String messageDigestJcaName) {
+    COSEAlgorithmIdentifier(long value) {
         this.value = value;
-        this.jcaName = jcaName;
-        this.messageDigestJcaName = messageDigestJcaName;
     }
 
     // COSEAlgorithmIdentifier doesn't accept jcaName and messageDigestJcaName from caller for the time being
     public static COSEAlgorithmIdentifier create(long value) {
-
-        COSEAlgorithmIdentifier identifier = predefinedAlgorithmMap.get(value);
-        if(identifier == null){
-            identifier = new COSEAlgorithmIdentifier(value, null, null);
-        }
-        return identifier;
+        return new COSEAlgorithmIdentifier(value);
     }
 
     @JsonCreator
@@ -83,26 +54,16 @@ public class COSEAlgorithmIdentifier implements Serializable {
         return value;
     }
 
-    public String getJcaName() {
-        return jcaName;
-    }
-
-    public String getMessageDigestJcaName() {
-        return messageDigestJcaName;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         COSEAlgorithmIdentifier that = (COSEAlgorithmIdentifier) o;
-        return value == that.value &&
-                Objects.equals(jcaName, that.jcaName) &&
-                Objects.equals(messageDigestJcaName, that.messageDigestJcaName);
+        return value == that.value;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(value, jcaName, messageDigestJcaName);
+        return Objects.hash(value);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/SignatureAlgorithm.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/SignatureAlgorithm.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.attestation.statement;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class SignatureAlgorithm {
+
+    public static final SignatureAlgorithm ES256 = new SignatureAlgorithm("SHA256withECDSA", "SHA-256");
+    public static final SignatureAlgorithm ES384 = new SignatureAlgorithm("SHA384withECDSA", "SHA-384");
+    public static final SignatureAlgorithm ES512 = new SignatureAlgorithm("SHA512withECDSA", "SHA-512");
+    public static final SignatureAlgorithm RS1   = new SignatureAlgorithm("SHA1withRSA", "SHA-1");
+    public static final SignatureAlgorithm RS256 = new SignatureAlgorithm("SHA256withRSA", "SHA-256");
+    public static final SignatureAlgorithm RS384 = new SignatureAlgorithm("SHA384withRSA", "SHA-384");
+    public static final SignatureAlgorithm RS512 = new SignatureAlgorithm("SHA512withRSA", "SHA-512");
+
+    private static final Map<COSEAlgorithmIdentifier, SignatureAlgorithm> predefinedAlgorithmMap = new HashMap<>();
+
+    static {
+        predefinedAlgorithmMap.put(COSEAlgorithmIdentifier.ES256, ES256);
+        predefinedAlgorithmMap.put(COSEAlgorithmIdentifier.ES384, ES384);
+        predefinedAlgorithmMap.put(COSEAlgorithmIdentifier.ES512, ES512);
+        predefinedAlgorithmMap.put(COSEAlgorithmIdentifier.RS1,   RS1);
+        predefinedAlgorithmMap.put(COSEAlgorithmIdentifier.RS256, RS256);
+        predefinedAlgorithmMap.put(COSEAlgorithmIdentifier.RS384, RS384);
+        predefinedAlgorithmMap.put(COSEAlgorithmIdentifier.RS512, RS512);
+    }
+
+    private final String jcaName;
+    private final String messageDigestJcaName;
+
+    private SignatureAlgorithm(String jcaName, String messageDigestJcaName){
+        this.jcaName = jcaName;
+        this.messageDigestJcaName = messageDigestJcaName;
+    }
+
+    public static SignatureAlgorithm create(COSEAlgorithmIdentifier coseAlgorithmIdentifier){
+        SignatureAlgorithm signatureAlgorithm = predefinedAlgorithmMap.get(coseAlgorithmIdentifier);
+        if(signatureAlgorithm == null){
+            throw new IllegalArgumentException("provided algorithm is not supported.");
+        }
+        return signatureAlgorithm;
+    }
+
+    public String getJcaName() {
+        return jcaName;
+    }
+
+    public String getMessageDigestJcaName() {
+        return messageDigestJcaName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SignatureAlgorithm that = (SignatureAlgorithm) o;
+        return Objects.equals(jcaName, that.jcaName) &&
+                Objects.equals(messageDigestJcaName, that.messageDigestJcaName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jcaName, messageDigestJcaName);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/TPMAttestationStatement.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/TPMAttestationStatement.java
@@ -122,7 +122,7 @@ public class TPMAttestationStatement implements CertificateBaseAttestationStatem
         if (o == null || getClass() != o.getClass()) return false;
         TPMAttestationStatement that = (TPMAttestationStatement) o;
         return Objects.equals(ver, that.ver) &&
-                alg == that.alg &&
+                Objects.equals(alg, that.alg) &&
                 Objects.equals(x5c, that.x5c) &&
                 Arrays.equals(ecdaaKeyId, that.ecdaaKeyId) &&
                 Arrays.equals(sig, that.sig) &&
@@ -132,7 +132,6 @@ public class TPMAttestationStatement implements CertificateBaseAttestationStatem
 
     @Override
     public int hashCode() {
-
         int result = Objects.hash(ver, alg, x5c, certInfo, pubArea);
         result = 31 * result + Arrays.hashCode(ecdaaKeyId);
         result = 31 * result + Arrays.hashCode(sig);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/AbstractStatementValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/AbstractStatementValidator.java
@@ -17,7 +17,10 @@
 package com.webauthn4j.validator.attestation.statement;
 
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
+import com.webauthn4j.data.attestation.statement.SignatureAlgorithm;
 import com.webauthn4j.validator.RegistrationObject;
+import com.webauthn4j.validator.exception.BadAttestationStatementException;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -48,4 +51,17 @@ public abstract class AbstractStatementValidator<T extends AttestationStatement>
 
         return this.parameterizedTypeClass.isAssignableFrom(attestationStatement.getClass());
     }
+
+    protected String getJcaName(COSEAlgorithmIdentifier alg) {
+        String jcaName;
+        try{
+            SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.create(alg);
+            jcaName = signatureAlgorithm.getJcaName();
+        }
+        catch (IllegalArgumentException e){
+            throw new BadAttestationStatementException("alg is not signature algorithm", e);
+        }
+        return jcaName;
+    }
+
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/androidkey/AndroidKeyAttestationStatementValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/androidkey/AndroidKeyAttestationStatementValidator.java
@@ -77,7 +77,9 @@ public class AndroidKeyAttestationStatementValidator extends AbstractStatementVa
         PublicKey publicKey = getPublicKey(attestationStatement);
 
         try {
-            Signature verifier = SignatureUtil.createSignature(attestationStatement.getAlg().getJcaName());
+            String jcaName;
+            jcaName = getJcaName(attestationStatement.getAlg());
+            Signature verifier = SignatureUtil.createSignature(jcaName);
             verifier.initVerify(publicKey);
             verifier.update(signedData);
             if (verifier.verify(signature)) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/packed/PackedAttestationStatementValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/packed/PackedAttestationStatementValidator.java
@@ -18,10 +18,7 @@ package com.webauthn4j.validator.attestation.statement.packed;
 
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.authenticator.COSEKey;
-import com.webauthn4j.data.attestation.statement.AttestationStatement;
-import com.webauthn4j.data.attestation.statement.AttestationType;
-import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
-import com.webauthn4j.data.attestation.statement.PackedAttestationStatement;
+import com.webauthn4j.data.attestation.statement.*;
 import com.webauthn4j.util.MessageDigestUtil;
 import com.webauthn4j.util.SignatureUtil;
 import com.webauthn4j.util.UUIDUtil;
@@ -119,7 +116,8 @@ public class PackedAttestationStatementValidator extends AbstractStatementValida
 
     private boolean verifySignature(PublicKey publicKey, COSEAlgorithmIdentifier algorithmIdentifier, byte[] signature, byte[] data) {
         try {
-            Signature verifier = SignatureUtil.createSignature(algorithmIdentifier.getJcaName());
+            String jcaName = getJcaName(algorithmIdentifier);
+            Signature verifier = SignatureUtil.createSignature(jcaName);
             verifier.initVerify(publicKey);
             verifier.update(data);
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2COSEKeyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2COSEKeyTest.java
@@ -206,6 +206,13 @@ class EC2COSEKeyTest {
         assertThat(target.getPublicKey()).isNull();
     }
 
+    @Test
+    void equals_hashCode_test(){
+        EC2COSEKey instanceA = TestDataUtil.createEC2COSEPublicKey();
+        EC2COSEKey instanceB = TestDataUtil.createEC2COSEPublicKey();
+        assertThat(instanceA).isEqualTo(instanceB);
+    }
+
     private EC2COSEKey createNullXKey() {
         EC2COSEKey original = TestDataUtil.createEC2COSEPublicKey();
         return new EC2COSEKey(

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/ESSignatureAlgorithmTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/ESSignatureAlgorithmTest.java
@@ -20,7 +20,8 @@ import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class ESSignatureAlgorithmTest {
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
@@ -48,16 +48,6 @@ class COSEAlgorithmIdentifierTest {
     }
 
     @Test
-    void getJcaName_test() {
-        assertThat(COSEAlgorithmIdentifier.RS256.getJcaName()).isEqualTo("SHA256withRSA");
-    }
-
-    @Test
-    void getMessageDigestJcaName_test() {
-        assertThat(COSEAlgorithmIdentifier.RS256.getMessageDigestJcaName()).isEqualTo("SHA-256");
-    }
-
-    @Test
     void deserialize_test() {
         TestDTO dto = jsonConverter.readValue("{\"cose_alg_id\":-257}", TestDTO.class);
         assertThat(dto.cose_alg_id).isEqualTo(COSEAlgorithmIdentifier.RS256);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/SignatureAlgorithmTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/SignatureAlgorithmTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.attestation.statement;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+class SignatureAlgorithmTest {
+
+    @Test
+    void create_with_invalid_alg_test(){
+        assertThatThrownBy(()-> SignatureAlgorithm.create(new COSEAlgorithmIdentifier(-16))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void getJcaName_test() {
+        assertThat(SignatureAlgorithm.RS256.getJcaName()).isEqualTo("SHA256withRSA");
+    }
+
+    @Test
+    void getMessageDigestJcaName_test() {
+        assertThat(SignatureAlgorithm.RS256.getMessageDigestJcaName()).isEqualTo("SHA-256");
+    }
+
+    @Test
+    void equals_hashCode_test(){
+        assertThat(SignatureAlgorithm.ES256).isEqualTo(SignatureAlgorithm.ES256);
+        assertThat(SignatureAlgorithm.ES256).hasSameHashCodeAs(SignatureAlgorithm.ES256);
+        assertThat(SignatureAlgorithm.ES256).isNotEqualTo(SignatureAlgorithm.RS512);
+        assertThat(SignatureAlgorithm.ES256).isNotEqualTo(SignatureAlgorithm.ES512);
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/AbstractStatementValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/AbstractStatementValidatorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.validator.attestation.statement;
+
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
+import com.webauthn4j.validator.attestation.statement.packed.PackedAttestationStatementValidator;
+import com.webauthn4j.validator.exception.BadAttestationStatementException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AbstractStatementValidatorTest {
+
+    private PackedAttestationStatementValidator packedAttestationStatementValidator = new PackedAttestationStatementValidator();
+
+    @Test
+    void getJcaName() {
+        assertThatThrownBy(()->packedAttestationStatementValidator.getJcaName(COSEAlgorithmIdentifier.create(-16))).isInstanceOf(BadAttestationStatementException.class);
+    }
+}

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/AndroidKeyAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/AndroidKeyAuthenticator.java
@@ -16,10 +16,7 @@
 
 package com.webauthn4j.test.authenticator.webauthn;
 
-import com.webauthn4j.data.attestation.statement.AndroidKeyAttestationStatement;
-import com.webauthn4j.data.attestation.statement.AttestationCertificatePath;
-import com.webauthn4j.data.attestation.statement.AttestationStatement;
-import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
+import com.webauthn4j.data.attestation.statement.*;
 import com.webauthn4j.test.AttestationCertificateBuilder;
 import com.webauthn4j.test.TestDataUtil;
 import com.webauthn4j.test.client.RegistrationEmulationOption;

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticator.java
@@ -16,10 +16,7 @@
 
 package com.webauthn4j.test.authenticator.webauthn;
 
-import com.webauthn4j.data.attestation.statement.AttestationCertificatePath;
-import com.webauthn4j.data.attestation.statement.AttestationStatement;
-import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
-import com.webauthn4j.data.attestation.statement.PackedAttestationStatement;
+import com.webauthn4j.data.attestation.statement.*;
 import com.webauthn4j.test.AttestationCertificateBuilder;
 import com.webauthn4j.test.TestDataUtil;
 import com.webauthn4j.test.client.RegistrationEmulationOption;

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/TPMAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/TPMAuthenticator.java
@@ -19,6 +19,7 @@ package com.webauthn4j.test.authenticator.webauthn;
 import com.webauthn4j.data.attestation.statement.*;
 import com.webauthn4j.test.AttestationCertificateBuilder;
 import com.webauthn4j.test.TestDataUtil;
+import com.webauthn4j.test.authenticator.webauthn.exception.WebAuthnModelException;
 import com.webauthn4j.test.client.RegistrationEmulationOption;
 import com.webauthn4j.util.Base64UrlUtil;
 import com.webauthn4j.util.MessageDigestUtil;
@@ -88,7 +89,15 @@ public class TPMAuthenticator extends WebAuthnModelAuthenticator {
         TPMGenerated magic = TPMGenerated.TPM_GENERATED_VALUE;
         TPMISTAttest type = TPMISTAttest.TPM_ST_ATTEST_CERTIFY;
         byte[] qualifiedSigner = Base64UrlUtil.decode("AAu8WfTf2aakLcO4Zq_y3w0Zgmu_AUtnqwrW67F2MGuABw");
-        byte[] extraData = MessageDigestUtil.createMessageDigest(alg.getMessageDigestJcaName()).digest(attestationStatementRequest.getSignedData());
+        String messageDigestJcaName;
+        try{
+            SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.create(alg);
+            messageDigestJcaName = signatureAlgorithm.getMessageDigestJcaName();
+        }
+        catch (IllegalArgumentException e){
+            throw new WebAuthnModelException("alg is not signature algorithm", e);
+        }
+        byte[] extraData = MessageDigestUtil.createMessageDigest(messageDigestJcaName).digest(attestationStatementRequest.getSignedData());
         BigInteger clock = BigInteger.valueOf(7270451399L);
         long resetCount = 1749088739L;
         long restartCount = 3639844613L;


### PR DESCRIPTION
as COSE algorithms are not limited to signature algorithms, `jcaName` and `messageDigestJcaName` are moved to `SignatureAlgorithm` class.