### PR TITLE
Introduce WebAuthnManager and deprecate existing ContextValidator(s)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ subprojects {
     }
 
     tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation" << "-Werror"
+        options.compilerArgs << "-Xlint:unchecked"  << "-Werror"
     }
 
     check.dependsOn dependencyCheckAnalyze

--- a/docs/src/reference/asciidoc/en/quick-start.adoc
+++ b/docs/src/reference/asciidoc/en/quick-start.adoc
@@ -7,10 +7,10 @@ the data which contains signature and is sent at authentication is called "asser
 
 === Attestation verification
 
-To verify an attestation on authenticator registration, call `WebAuthnRegistrationContextValidator#validate`.
-When invoking, you need to specify an instance of `WebAuthnRegistrationContext` as an argument.
+To validate an attestation on authenticator registration, call `WebAuthnManager#parseRegistrationRequest` to parse a registration request,
+and invoke `validate` method of the returned `WebAuthnRegistrationData` instance.
 
-`ClientDataJSON` and `attestationObject`, specified as the argument of the constructor of `WebAuthnRegistrationContext`
+`ClientDataJSON` and `attestationObject`, specified as the argument of the constructor of `WebAuthnRegistrationRequest`
 are the value obtained by the WebAuthn JS API in the front end side.
 `serverProperty` is a parameter that houses values obtained from the server side. Please specify the following values​
 when calling the constructor.
@@ -33,14 +33,15 @@ It is the application's responsibility for retaining the issued Challenge.
 `userVerificationRequired` is a parameter that indicates whether the user verification on the authenticator is required.
 
 If validation fails, an exception inheriting `ValidationException` is thrown.
-If validation succeeds, `WebAuthnRegistrationContextValidationResponse` is returned.
-Please create an `Authenticator` instance from the returned value and persist it to the database or something in your
-application manner. The instance is required at the time of authentication.
+If validation succeeds, please create an `Authenticator` instance from the returned value and persist it to the database
+or something in your application manner. The instance is required at the time of authentication.
 
 ```java
 // Client properties
-byte[] clientDataJSON = null /* set clientDataJSON */;
 byte[] attestationObject = null /* set attestationObject */;
+byte[] clientDataJSON = null /* set clientDataJSON */;
+String clientExtensionJSON = null;  /* set clientExtensionJSON */;
+Set<String> transports = null /* set transports */;
 
 // Server properties
 Origin origin = null /* set origin */;
@@ -48,38 +49,57 @@ String rpId = null /* set rpId */;
 Challenge challenge = null /* set challenge */;
 byte[] tokenBindingId = null /* set tokenBindingId */;
 ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+// expectations
 boolean userVerificationRequired = false;
+boolean userPresenceRequired = true;
+List<String> expectedExtensionIds = Collections.emptyList();
 
-WebAuthnRegistrationContext registrationContext = new WebAuthnRegistrationContext(clientDataJSON, attestationObject, serverProperty, userVerificationRequired);
-
-// WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator() returns a WebAuthnRegistrationContextValidator instance
-// which doesn't validate an attestation statement. It is recommended configuration for most web application.
-// If you are building enterprise web application and need to validate the attestation statement, use the constructor of
-// WebAuthnRegistrationContextValidator and provide validators you like
-WebAuthnRegistrationContextValidator webAuthnRegistrationContextValidator =
-        WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator();
-
-
-WebAuthnRegistrationContextValidationResponse response = webAuthnRegistrationContextValidator.validate(registrationContext);
+WebAuthnRegistrationRequest webAuthnRegistrationRequest = new WebAuthnRegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
+WebAuthnRegistrationParameters webAuthnRegistrationParameters = new WebAuthnRegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
+WebAuthnRegistrationData webAuthnRegistrationData;
+try{
+    webAuthnRegistrationData = webAuthnManager.parseRegistrationRequest(webAuthnRegistrationRequest);
+}
+catch (DataConversionException e){
+    // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
+    throw e;
+}
+try{
+    webAuthnRegistrationData.validate(webAuthnRegistrationParameters);
+}
+catch (ValidationException e){
+    // If you would like to handle WebAuthn data validation error, please catch ValidationException
+    throw e;
+}
 
 // please persist Authenticator object, which will be used in the authentication process.
 Authenticator authenticator =
         new AuthenticatorImpl( // You may create your own Authenticator implementation to save friendly authenticator name
-                response.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),
-                response.getAttestationObject().getAttestationStatement(),
-                response.getAttestationObject().getAuthenticatorData().getSignCount()
+                webAuthnRegistrationData.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),
+                webAuthnRegistrationData.getAttestationObject().getAttestationStatement(),
+                webAuthnRegistrationData.getAttestationObject().getAuthenticatorData().getSignCount()
         );
 save(authenticator); // please persist authenticator in your manner
 ```
 
 === Assertion verification
 
-To verify an assertion on authentication, call `WebAuthnAuthenticationContextValidator#validate`.
+To validate an assertion on authentication, call `WebAuthnManager#parseAuthenticationRequest` to parse a authentication request,
+and invoke `validate` method of the returned `WebAuthnAuthenticationData` instance.
+
+`credentialId`, `userHandle`, `authenticatorData`, `clientDataJSON`, and `clientExtensionJSON`, specified as the argument of
+the constructor of `WebAuthnAuthenticationRequest` are the value obtained by the WebAuthn JS API in the front end side.
+`serverProperty` is a parameter that houses values obtained from the server side. Please specify the following values​
+when calling the constructor.
+
 ```java
 // Client properties
 byte[] credentialId = null /* set credentialId */;
-byte[] clientDataJSON = null /* set clientDataJSON */;
+byte[] userHandle = null /* set userHandle */;
 byte[] authenticatorData = null /* set authenticatorData */;
+byte[] clientDataJSON = null /* set clientDataJSON */;
+String clientExtensionJSON = null /* set clientExtensionJSON */;
 byte[] signature = null /* set signature */;
 
 // Server properties
@@ -88,28 +108,51 @@ String rpId = null /* set rpId */;
 Challenge challenge = null /* set challenge */;
 byte[] tokenBindingId = null /* set tokenBindingId */;
 ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
-boolean userVerificationRequired = true;
 
-WebAuthnAuthenticationContext authenticationContext =
-        new WebAuthnAuthenticationContext(
-                credentialId,
-                clientDataJSON,
-                authenticatorData,
-                signature,
-                serverProperty,
-                userVerificationRequired
-        );
+// expectations
+boolean userVerificationRequired = true;
+boolean userPresenceRequired = true;
+List<String> expectedExtensionIds = Collections.emptyList();
+
 Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
 
-WebAuthnAuthenticationContextValidator webAuthnAuthenticationContextValidator =
-        new WebAuthnAuthenticationContextValidator();
+WebAuthnAuthenticationRequest webAuthnAuthenticationRequest =
+        new WebAuthnAuthenticationRequest(
+                credentialId,
+                userHandle,
+                authenticatorData,
+                clientDataJSON,
+                clientExtensionJSON,
+                signature
+        );
+WebAuthnAuthenticationParameters webAuthnAuthenticationParameters =
+        new WebAuthnAuthenticationParameters(
+                serverProperty,
+                authenticator,
+                userVerificationRequired,
+                userPresenceRequired,
+                expectedExtensionIds
+        );
 
-WebAuthnAuthenticationContextValidationResponse response = webAuthnAuthenticationContextValidator.validate(authenticationContext, authenticator);
-
+WebAuthnAuthenticationData webAuthnAuthenticationData;
+try{
+    webAuthnAuthenticationData = webAuthnManager.parseAuthenticationRequest(webAuthnAuthenticationRequest);
+}
+catch (DataConversionException e){
+    // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
+    throw e;
+}
+try{
+    webAuthnAuthenticationData.validate(webAuthnAuthenticationParameters);
+}
+catch (ValidationException e){
+    // If you would like to handle WebAuthn data validation error, please catch ValidationException
+    throw e;
+}
 // please update the counter of the authenticator record
 updateCounter(
-        response.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
-        response.getAuthenticatorData().getSignCount()
+        webAuthnAuthenticationData.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
+        webAuthnAuthenticationData.getAuthenticatorData().getSignCount()
 );
 ```
 

--- a/docs/src/reference/asciidoc/index-docinfo.xml
+++ b/docs/src/reference/asciidoc/index-docinfo.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2002-2018 the original author or authors.
+  ~ Copyright 2018 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/docs/src/reference/asciidoc/ja/quick-start.adoc
+++ b/docs/src/reference/asciidoc/ja/quick-start.adoc
@@ -1,18 +1,19 @@
 == クイックスタート
 
-WebAuthn認証では、前もって認証デバイスで生成した公開鍵をサーバーに登録し、認証時に認証デバイスで生成した
+WebAuthn認証は、事前に認証デバイスで生成した公開鍵をサーバーに登録し、認証時に認証デバイスで生成した
 署名を公開鍵で検証することで認証が成立する認証方式です。登録時にサーバーに送信される公開鍵やデバイスの構成情報を
-含むデータは構成証明（Attestation）と呼ばれ、認証時にサーバーに送信される署名を含んだデータは認証証明（Assertion）と呼ばれます。
+含むデータは構成証明（Attestation）と呼ばれ、認証時にサーバーに送信される署名を含んだデータはアサーション（Assertion）と呼ばれます。
 
 === 構成証明の検証
 
-認証デバイスの登録時に構成証明を検証する際は、 `WebAuthnRegistrationContextValidator#validate` を呼び出して下さい。
-呼び出す際は、 `WebAuthnRegistrationContext` のインスタンスを引数に指定する必要があります。
-
-`WebAuthnRegistrationContext` のコンストラクタの引数に指定する、 `clientDataJSON` と `attestationObject` はフロントエンド側で
-WebAuthn JS APIを実行して取得した値となります。何らかの方法でフロントエンド側からサーバー側に伝送し、指定してください。
-`serverProperty` はサーバー側から取得する値をまとめたパラメータです。 `ServerProperty` のコンストラクタを
-呼び出す際のパラメータには以下の値を指定して下さい。
+認証デバイスの登録時に構成証明を検証する際は、 `WebAuthnManager#parseRegistrationRequest` メソッドを用いて登録リクエストをパースしたうえで、
+得られた `WebAuthnRegistrationData` クラスの `validate` メソッドを実行してください。
+`WebAuthnManager#parseRegistrationRequest` メソッドの引数である `WebAuthnRegistrationRequest` のコンストラクタの引数に指定する、
+`clientDataJSON` と `attestationObject` はフロントエンド側でWebAuthn JS APIを実行して取得した値となります。
+何らかの方法でフロントエンド側からサーバー側に伝送し、指定してください。
+`WebAuthnRegistrationData` クラスの `validate` メソッドの引数である `WebAuthnRegistrationParameters`  のコンストラクタの引数に指定する、
+`serverProperty` はサーバー側から取得する値をまとめたパラメータです。
+`ServerProperty` のコンストラクタを呼び出す際のパラメータには以下の値を指定して下さい。
 
 - `origin` にはWebAuthnによる認証を提供するサイトのOriginを指定して下さい。WebAuthnでは、ブラウザが認識しているOriginを
 ClientDataに書き込んで署名を行います。WebAuthn4Jは書き込まれたOriginが指定されたOriginと合致するかを検証することで、
@@ -28,55 +29,68 @@ ClientDataに書き込んで署名を行います。WebAuthn4Jは書き込まれ
 `userVerificationRequired` は認証デバイスでのユーザーの本人性確認が必要かどうかを示すパラメータです。
 
 検証に失敗した場合は、 `ValidationException` のサブクラスの例外が発生します。
-検証に成功した場合は、 `WebAuthnRegistrationContextValidationResponse` が返却されます。
-返却された値から `Authenticator` インスタンスを作成し、データベース等へアプリケーション側で永続化して下さい。
+検証に成功した場合は、返却された値から `Authenticator` インスタンスを作成し、データベース等へアプリケーション側で永続化して下さい。
 認証時に必要となります。
 
 ```java
 // Client properties
-byte[] clientDataJSON    = null /* set clientDataJSON */;
 byte[] attestationObject = null /* set attestationObject */;
+byte[] clientDataJSON = null /* set clientDataJSON */;
+String clientExtensionJSON = null;  /* set clientExtensionJSON */;
+Set<String> transports = null /* set transports */;
 
 // Server properties
-Origin origin          = null /* set origin */;
-String rpId            = null /* set rpId */;
-Challenge challenge    = null /* set challenge */;
-byte[] tokenBindingId  = null /* set tokenBindingId */;
+Origin origin = null /* set origin */;
+String rpId = null /* set rpId */;
+Challenge challenge = null /* set challenge */;
+byte[] tokenBindingId = null /* set tokenBindingId */;
 ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
-WebAuthnRegistrationContext registrationContext = new WebAuthnRegistrationContext(clientDataJSON, attestationObject, serverProperty, false);
+// expectations
+boolean userVerificationRequired = false;
+boolean userPresenceRequired = true;
+List<String> expectedExtensionIds = Collections.emptyList();
 
-// WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator() は 構成証明ステートメントを
-// 検証しないWebAuthnRegistrationContextValidator インスタンスを返却します。これは大多数のWebアプリケーションに推奨の構成です。
-// エンタープライズ用途のWebアプリケーションで構成証明ステートメントの検証が必要な場合はWebAuthnRegistrationContextValidatorの
-// コンストラクタを使用し、使いたいvalidatorを指定してください
-WebAuthnRegistrationContextValidator webAuthnRegistrationContextValidator =
-        WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator();
+WebAuthnRegistrationRequest webAuthnRegistrationRequest = new WebAuthnRegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
+WebAuthnRegistrationParameters webAuthnRegistrationParameters = new WebAuthnRegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
+WebAuthnRegistrationData webAuthnRegistrationData;
+try{
+    webAuthnRegistrationData = webAuthnManager.parseRegistrationRequest(webAuthnRegistrationRequest);
+}
+catch (DataConversionException e){
+    // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
+    throw e;
+}
+try{
+    webAuthnRegistrationData.validate(webAuthnRegistrationParameters);
+}
+catch (ValidationException e){
+    // If you would like to handle WebAuthn data validation error, please catch ValidationException
+    throw e;
+}
 
-
-WebAuthnRegistrationContextValidationResponse response = webAuthnRegistrationContextValidator.validate(registrationContext);
-
-// アプリケーションの作法に則り、Authenticatorオブジェクトを永続化してください。認証時に使用されます。
+// please persist Authenticator object, which will be used in the authentication process.
 Authenticator authenticator =
         new AuthenticatorImpl( // You may create your own Authenticator implementation to save friendly authenticator name
-                response.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),
-                response.getAttestationObject().getAttestationStatement(),
-                response.getAttestationObject().getAuthenticatorData().getSignCount()
+                webAuthnRegistrationData.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),
+                webAuthnRegistrationData.getAttestationObject().getAttestationStatement(),
+                webAuthnRegistrationData.getAttestationObject().getAuthenticatorData().getSignCount()
         );
-save(authenticator); // アプリケーションの作法に則った、Authenticatorオブジェクトの永続化
+save(authenticator); // please persist authenticator in your manner
+
 
 ```
 
-=== 認証証明の検証
+=== アサーションの検証
 
-認証時に認証証明を検証する際は、 `WebAuthnAuthenticationContextValidator#validate` を呼び出して下さい。
-呼び出す際は、 `WebAuthnAuthenticationContext` と `Authenticator` のインスタンスを引数に指定する必要があります。
-
-`WebAuthnAuthenticationContext` のコンストラクタの引数に指定する、 `credentialId` と `clientDataJSON` 、
-`authenticatorData` 、 `signature` にはフロントエンド側でWebAuthn JS APIを実行して取得した値を設定してください。
+認証時にアサーションを検証する際は、  `WebAuthnManager#parseAuthenticationRequest` メソッドを用いて
+認証リクエストをパースしたうえで得られた `WebAuthnAuthenticationData` クラスの `validate` メソッドを実行してください。
+`WebAuthnManager#parseAuthenticationRequest` メソッドの引数である `WebAuthnAuthenticationRequest` の
+コンストラクタの引数に指定する、 `credentialId` と `userHandle` 、 `authenticatorData`  、 `clientDataJSON` 、`signature` は
+フロントエンド側でWebAuthn JS APIを実行して取得した値となります。
 何らかの方法でフロントエンド側からサーバー側に伝送し、指定してください。
-
-`serverProperty` はサーバー側から取得する値をまとめたパラメータです。
+`WebAuthnAuthenticationData` クラスの `validate` メソッドの引数である `WebAuthnAuthenticationParameters`  の
+コンストラクタの引数に指定する、 `serverProperty` はサーバー側から取得する値をまとめたパラメータです。
 
 `userVerificationRequired` は認証デバイスでのユーザーの本人性確認が必要かどうかを示すパラメータです。
 パスワード＋認証デバイスの「所持」による多要素認証を行う場合は、パスワードで本人性の確認が出来ている為 `false` で良いでしょう。
@@ -85,46 +99,70 @@ save(authenticator); // アプリケーションの作法に則った、Authenti
 `Authenticator` には、登録時に永続化した `Authenticator` を指定してください。
 
 検証に失敗した場合は、 `ValidationException` のサブクラスの例外が発生します。
-検証に成功した場合は、 `WebAuthnAuthenticationContextValidationResponse` が返却されます。
-`Authenticator` に紐づけたカウンタの値を更新してください。カウンタは万が一認証デバイスのクローンが
+検証後は、 `Authenticator` に紐づけたカウンタの値を更新してください。カウンタは万が一認証デバイスのクローンが
 作成された場合を検知するために用意されています。カウンタについて詳しくは
 https://www.w3.org/TR/webauthn-1/#sign-counter[WebAuthnの仕様書のカウンタの項] を参照して下さい。
 
 ```java
 // Client properties
-byte[] credentialId      = null /* set credentialId */;
-byte[] clientDataJSON    = null /* set clientDataJSON */;
+byte[] credentialId = null /* set credentialId */;
+byte[] userHandle = null /* set userHandle */;
 byte[] authenticatorData = null /* set authenticatorData */;
+byte[] clientDataJSON = null /* set clientDataJSON */;
+String clientExtensionJSON = null /* set clientExtensionJSON */;
 byte[] signature = null /* set signature */;
 
 // Server properties
-Origin origin          = null /* set origin */;
-String rpId            = null /* set rpId */;
-Challenge challenge    = null /* set challenge */;
-byte[] tokenBindingId  = null /* set tokenBindingId */;
+Origin origin = null /* set origin */;
+String rpId = null /* set rpId */;
+Challenge challenge = null /* set challenge */;
+byte[] tokenBindingId = null /* set tokenBindingId */;
 ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
-WebAuthnAuthenticationContext authenticationContext =
-        new WebAuthnAuthenticationContext(
+// expectations
+boolean userVerificationRequired = true;
+boolean userPresenceRequired = true;
+List<String> expectedExtensionIds = Collections.emptyList();
+
+Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
+
+WebAuthnAuthenticationRequest webAuthnAuthenticationRequest =
+        new WebAuthnAuthenticationRequest(
                 credentialId,
-                clientDataJSON,
+                userHandle,
                 authenticatorData,
-                signature,
+                clientDataJSON,
+                clientExtensionJSON,
+                signature
+        );
+WebAuthnAuthenticationParameters webAuthnAuthenticationParameters =
+        new WebAuthnAuthenticationParameters(
                 serverProperty,
-                true
+                authenticator,
+                userVerificationRequired,
+                userPresenceRequired,
+                expectedExtensionIds
         );
 
-Authenticator authenticator = load(); // 登録時に永続化したauthenticatorオブジェクトを読込
-
-WebAuthnAuthenticationContextValidator webAuthnAuthenticationContextValidator =
-        new WebAuthnAuthenticationContextValidator();
-
-WebAuthnAuthenticationContextValidationResponse response = webAuthnAuthenticationContextValidator.validate(authenticationContext, authenticator);
-
-// authenticatorのカウンタを更新
+WebAuthnAuthenticationData webAuthnAuthenticationData;
+try{
+    webAuthnAuthenticationData = webAuthnManager.parseAuthenticationRequest(webAuthnAuthenticationRequest);
+}
+catch (DataConversionException e){
+    // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
+    throw e;
+}
+try{
+    webAuthnAuthenticationData.validate(webAuthnAuthenticationParameters);
+}
+catch (ValidationException e){
+    // If you would like to handle WebAuthn data validation error, please catch ValidationException
+    throw e;
+}
+// please update the counter of the authenticator record
 updateCounter(
-        response.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
-        response.getAuthenticatorData().getSignCount()
+        webAuthnAuthenticationData.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
+        webAuthnAuthenticationData.getAuthenticatorData().getSignCount()
 );
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2002-2018 the original author or authors.
+# Copyright 2018 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/owasp/suppression.xml
+++ b/owasp/suppression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2002-2018 the original author or authors.
+  ~ Copyright 2018 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnManager.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnManager.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnManager.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j;
+
+import com.webauthn4j.converter.*;
+import com.webauthn4j.converter.exception.DataConversionException;
+import com.webauthn4j.converter.util.CborConverter;
+import com.webauthn4j.converter.util.JsonConverter;
+import com.webauthn4j.data.*;
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import com.webauthn4j.util.AssertUtil;
+import com.webauthn4j.validator.*;
+import com.webauthn4j.validator.attestation.statement.AttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.androidkey.NullAndroidKeyAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.androidsafetynet.NullAndroidSafetyNetAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.none.NoneAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.packed.NullPackedAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.tpm.NullTPMAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.u2f.NullFIDOU2FAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.certpath.NullCertPathTrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.ECDAATrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.NullECDAATrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.self.NullSelfAttestationTrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.self.SelfAttestationTrustworthinessValidator;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class WebAuthnManager {
+
+    // ~ Instance fields
+    // ================================================================================================
+
+    private final CollectedClientDataConverter collectedClientDataConverter;
+    private final AttestationObjectConverter attestationObjectConverter;
+    private final AuthenticatorDataConverter authenticatorDataConverter;
+    private final AuthenticatorTransportConverter authenticatorTransportConverter;
+    private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter;
+
+    private final WebAuthnRegistrationDataValidator webAuthnRegistrationDataValidator;
+    private final WebAuthnAuthenticationDataValidator webAuthnAuthenticationDataValidator;
+
+    public WebAuthnManager(List<AttestationStatementValidator> attestationStatementValidators,
+                           CertPathTrustworthinessValidator certPathTrustworthinessValidator,
+                           ECDAATrustworthinessValidator ecdaaTrustworthinessValidator,
+                           SelfAttestationTrustworthinessValidator selfAttestationTrustworthinessValidator,
+                           List<CustomRegistrationValidator> customRegistrationValidators,
+                           List<CustomAuthenticationValidator> customAuthenticationValidators,
+                           JsonConverter jsonConverter,
+                           CborConverter cborConverter) {
+        AssertUtil.notNull(attestationStatementValidators, "attestationStatementValidators must not be null");
+        AssertUtil.notNull(certPathTrustworthinessValidator, "certPathTrustworthinessValidator must not be null");
+        AssertUtil.notNull(ecdaaTrustworthinessValidator, "ecdaaTrustworthinessValidator must not be null");
+        AssertUtil.notNull(selfAttestationTrustworthinessValidator, "selfAttestationTrustworthinessValidator must not be null");
+        AssertUtil.notNull(customRegistrationValidators, "customRegistrationValidators must not be null");
+        AssertUtil.notNull(customAuthenticationValidators, "customAuthenticationValidators must not be null");
+        AssertUtil.notNull(jsonConverter, "jsonConverter must not be null");
+        AssertUtil.notNull(cborConverter, "cborConverter must not be null");
+
+        webAuthnRegistrationDataValidator = new WebAuthnRegistrationDataValidator(
+                attestationStatementValidators,
+                certPathTrustworthinessValidator,
+                ecdaaTrustworthinessValidator,
+                selfAttestationTrustworthinessValidator,
+                customRegistrationValidators,
+                jsonConverter,
+                cborConverter);
+
+        webAuthnAuthenticationDataValidator = new WebAuthnAuthenticationDataValidator(customAuthenticationValidators);
+
+        collectedClientDataConverter = new CollectedClientDataConverter(jsonConverter);
+        attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+        authenticatorDataConverter = new AuthenticatorDataConverter(cborConverter);
+        authenticatorTransportConverter = new AuthenticatorTransportConverter();
+        authenticationExtensionsClientOutputsConverter = new AuthenticationExtensionsClientOutputsConverter(jsonConverter);
+
+    }
+
+    // ~ Factory methods
+    // ========================================================================================================
+
+    /**
+     * Creates {@link WebAuthnManager} with non strict configuration
+     *
+     * @return configured {@link WebAuthnManager}
+     */
+    public static WebAuthnManager createNonStrictWebAuthnManager() {
+        return createNonStrictWebAuthnManager(new JsonConverter(), new CborConverter());
+    }
+
+    /**
+     * Creates {@link WebAuthnManager} with non strict configuration
+     *
+     * @return configured {@link WebAuthnManager}
+     */
+    public static WebAuthnManager createNonStrictWebAuthnManager(JsonConverter jsonConverter, CborConverter cborConverter) {
+        return new WebAuthnManager(
+                Arrays.asList(
+                        new NoneAttestationStatementValidator(),
+                        new NullFIDOU2FAttestationStatementValidator(),
+                        new NullPackedAttestationStatementValidator(),
+                        new NullTPMAttestationStatementValidator(),
+                        new NullAndroidKeyAttestationStatementValidator(),
+                        new NullAndroidSafetyNetAttestationStatementValidator()
+                ),
+                new NullCertPathTrustworthinessValidator(),
+                new NullECDAATrustworthinessValidator(),
+                new NullSelfAttestationTrustworthinessValidator(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                jsonConverter,
+                cborConverter
+        );
+    }
+
+
+    public WebAuthnRegistrationData parseRegistrationRequest(WebAuthnRegistrationRequest webAuthnRegistrationRequest) throws DataConversionException {
+
+        byte[] clientDataBytes = webAuthnRegistrationRequest.getClientDataJSON();
+        byte[] attestationObjectBytes = webAuthnRegistrationRequest.getAttestationObject();
+
+        CollectedClientData collectedClientData = collectedClientDataConverter.convert(clientDataBytes);
+        AttestationObject attestationObject = attestationObjectConverter.convert(attestationObjectBytes);
+        Set<AuthenticatorTransport> transports = authenticatorTransportConverter.convertSet(webAuthnRegistrationRequest.getTransports());
+        AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions =
+                authenticationExtensionsClientOutputsConverter.convert(webAuthnRegistrationRequest.getClientExtensionsJSON());
+
+        return new WebAuthnRegistrationData(
+                webAuthnRegistrationDataValidator,
+                attestationObject,
+                attestationObjectBytes,
+                collectedClientData,
+                clientDataBytes,
+                clientExtensions,
+                transports
+        );
+
+    }
+
+    public WebAuthnAuthenticationData parseAuthenticationRequest(WebAuthnAuthenticationRequest webAuthnAuthenticationRequest) throws DataConversionException{
+
+        byte[] credentialId = webAuthnAuthenticationRequest.getCredentialId();
+        byte[] signature = webAuthnAuthenticationRequest.getSignature();
+        byte[] userHandle = webAuthnAuthenticationRequest.getUserHandle();
+        byte[] clientDataBytes = webAuthnAuthenticationRequest.getClientDataJSON();
+        CollectedClientData collectedClientData = collectedClientDataConverter.convert(clientDataBytes);
+        byte[] authenticatorDataBytes = webAuthnAuthenticationRequest.getAuthenticatorData();
+        AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData = authenticatorDataConverter.convert(authenticatorDataBytes);
+
+        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions =
+                authenticationExtensionsClientOutputsConverter.convert(webAuthnAuthenticationRequest.getClientExtensionsJSON());
+
+        return new WebAuthnAuthenticationData(
+                webAuthnAuthenticationDataValidator,
+                credentialId,
+                userHandle,
+                authenticatorData,
+                authenticatorDataBytes,
+                collectedClientData,
+                clientDataBytes,
+                clientExtensions,
+                signature
+        );
+
+    }
+
+    public WebAuthnRegistrationDataValidator getWebAuthnRegistrationDataValidator() {
+        return webAuthnRegistrationDataValidator;
+    }
+
+    public WebAuthnAuthenticationDataValidator getWebAuthnAuthenticationDataValidator() {
+        return webAuthnAuthenticationDataValidator;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/AuthenticatorImpl.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/AuthenticatorImpl.java
@@ -21,6 +21,7 @@ import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import com.webauthn4j.util.CollectionUtil;
 import com.webauthn4j.util.ConstUtil;
 
 import java.util.*;
@@ -44,7 +45,7 @@ public class AuthenticatorImpl implements Authenticator {
                              Map<String, RegistrationExtensionAuthenticatorOutput> authenticatorExtensions) {
         this.attestedCredentialData = attestedCredentialData;
         this.attestationStatement = attestationStatement;
-        this.transports = Collections.unmodifiableSet(transports);
+        this.transports = CollectionUtil.unmodifiableSet(transports);
         this.clientExtensions = clientExtensions;
         this.authenticatorExtensions = authenticatorExtensions;
         setCounter(counter);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationContext.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationContext.java
@@ -16,9 +16,11 @@
 
 package com.webauthn4j.data;
 
+import com.webauthn4j.WebAuthnManager;
 import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.ArrayUtil;
 import com.webauthn4j.util.CollectionUtil;
+import com.webauthn4j.validator.WebAuthnAuthenticationContextValidator;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,7 +29,9 @@ import java.util.List;
 
 /**
  * WebAuthn authentication context
+ * @deprecated {@link WebAuthnAuthenticationContextValidator} is deprecated. please use {@link WebAuthnManager} instead.
  */
+@Deprecated
 public class WebAuthnAuthenticationContext extends AbstractWebAuthnContext {
 
     // ~ Instance fields

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationData.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationData.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationData.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.util.ArrayUtil;
+import com.webauthn4j.validator.WebAuthnAuthenticationDataValidator;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class WebAuthnAuthenticationData {
+
+    private final WebAuthnAuthenticationDataValidator webAuthnAuthenticationDataValidator;
+
+    private final byte[] credentialId;
+    private final byte[] userHandle;
+    private final AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData;
+    private final byte[] authenticatorDataBytes;
+    private final CollectedClientData collectedClientData;
+    private final byte[] collectedClientDataBytes;
+    private final AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions;
+    private final byte[] signature;
+
+    public WebAuthnAuthenticationData(
+            WebAuthnAuthenticationDataValidator webAuthnAuthenticationDataValidator,
+            byte[] credentialId,
+            byte[] userHandle,
+            AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData,
+            byte[] authenticatorDataBytes,
+            CollectedClientData collectedClientData,
+            byte[] collectedClientDataBytes,
+            AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions,
+            byte[] signature) {
+        this.webAuthnAuthenticationDataValidator = webAuthnAuthenticationDataValidator;
+        this.credentialId = ArrayUtil.clone(credentialId);
+        this.userHandle = ArrayUtil.clone(userHandle);
+        this.authenticatorData = authenticatorData;
+        this.authenticatorDataBytes = ArrayUtil.clone(authenticatorDataBytes);
+        this.collectedClientData = collectedClientData;
+        this.collectedClientDataBytes = ArrayUtil.clone(collectedClientDataBytes);
+        this.clientExtensions = clientExtensions;
+        this.signature = ArrayUtil.clone(signature);
+    }
+
+    public void validate(WebAuthnAuthenticationParameters webAuthnAuthenticationParameters){
+        webAuthnAuthenticationDataValidator.validate(this, webAuthnAuthenticationParameters);
+    }
+
+    public WebAuthnAuthenticationDataValidator getWebAuthnAuthenticationDataValidator() {
+        return webAuthnAuthenticationDataValidator;
+    }
+
+    public byte[] getCredentialId() {
+        return ArrayUtil.clone(credentialId);
+    }
+
+    public byte[] getUserHandle() {
+        return ArrayUtil.clone(userHandle);
+    }
+
+    public AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> getAuthenticatorData() {
+        return authenticatorData;
+    }
+
+    public byte[] getAuthenticatorDataBytes() {
+        return ArrayUtil.clone(authenticatorDataBytes);
+    }
+
+    public CollectedClientData getCollectedClientData() {
+        return collectedClientData;
+    }
+
+    public byte[] getCollectedClientDataBytes() {
+        return ArrayUtil.clone(collectedClientDataBytes);
+    }
+
+    public AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> getClientExtensions() {
+        return clientExtensions;
+    }
+
+    public byte[] getSignature() {
+        return ArrayUtil.clone(signature);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebAuthnAuthenticationData that = (WebAuthnAuthenticationData) o;
+        return Objects.equals(webAuthnAuthenticationDataValidator, that.webAuthnAuthenticationDataValidator) &&
+                Arrays.equals(credentialId, that.credentialId) &&
+                Arrays.equals(userHandle, that.userHandle) &&
+                Objects.equals(authenticatorData, that.authenticatorData) &&
+                Arrays.equals(authenticatorDataBytes, that.authenticatorDataBytes) &&
+                Objects.equals(collectedClientData, that.collectedClientData) &&
+                Arrays.equals(collectedClientDataBytes, that.collectedClientDataBytes) &&
+                Objects.equals(clientExtensions, that.clientExtensions) &&
+                Arrays.equals(signature, that.signature);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(webAuthnAuthenticationDataValidator, authenticatorData, collectedClientData, clientExtensions);
+        result = 31 * result + Arrays.hashCode(credentialId);
+        result = 31 * result + Arrays.hashCode(userHandle);
+        result = 31 * result + Arrays.hashCode(authenticatorDataBytes);
+        result = 31 * result + Arrays.hashCode(collectedClientDataBytes);
+        result = 31 * result + Arrays.hashCode(signature);
+        return result;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationParameters.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.util.CollectionUtil;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+public class WebAuthnAuthenticationParameters {
+
+    private final ServerProperty serverProperty;
+    private final Authenticator authenticator;
+
+    // verification condition
+    private final LocalDateTime timestamp;
+    private boolean userVerificationRequired;
+    private boolean userPresenceRequired;
+    private List<String> expectedExtensionIds;
+
+    public WebAuthnAuthenticationParameters(
+            ServerProperty serverProperty,
+            Authenticator authenticator,
+            LocalDateTime timestamp,
+            boolean userVerificationRequired,
+            boolean userPresenceRequired,
+            List<String> expectedExtensionIds) {
+        this.serverProperty = serverProperty;
+        this.authenticator = authenticator;
+        this.timestamp = timestamp;
+        this.userVerificationRequired = userVerificationRequired;
+        this.userPresenceRequired = userPresenceRequired;
+        this.expectedExtensionIds = CollectionUtil.unmodifiableList(expectedExtensionIds);
+    }
+
+    public WebAuthnAuthenticationParameters(
+            ServerProperty serverProperty,
+            Authenticator authenticator,
+            boolean userVerificationRequired,
+            boolean userPresenceRequired,
+            List<String> expectedExtensionIds) {
+        this(
+                serverProperty,
+                authenticator,
+                LocalDateTime.now(),
+                userVerificationRequired,
+                userPresenceRequired,
+                expectedExtensionIds
+        );
+    }
+
+    public WebAuthnAuthenticationParameters(
+            ServerProperty serverProperty,
+            Authenticator authenticator,
+            boolean userVerificationRequired,
+            boolean userPresenceRequired) {
+        this(
+                serverProperty,
+                authenticator,
+                userVerificationRequired,
+                userPresenceRequired,
+                null
+        );
+    }
+
+    public WebAuthnAuthenticationParameters(
+            ServerProperty serverProperty,
+            Authenticator authenticator,
+            boolean userVerificationRequired) {
+        this(
+                serverProperty,
+                authenticator,
+                userVerificationRequired,
+                true
+        );
+    }
+
+    public ServerProperty getServerProperty() {
+        return serverProperty;
+    }
+
+    public Authenticator getAuthenticator() {
+        return authenticator;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public boolean isUserVerificationRequired() {
+        return userVerificationRequired;
+    }
+
+    public boolean isUserPresenceRequired() {
+        return userPresenceRequired;
+    }
+
+    public List<String> getExpectedExtensionIds() {
+        return expectedExtensionIds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebAuthnAuthenticationParameters that = (WebAuthnAuthenticationParameters) o;
+        return userVerificationRequired == that.userVerificationRequired &&
+                userPresenceRequired == that.userPresenceRequired &&
+                Objects.equals(serverProperty, that.serverProperty) &&
+                Objects.equals(authenticator, that.authenticator) &&
+                Objects.equals(timestamp, that.timestamp) &&
+                Objects.equals(expectedExtensionIds, that.expectedExtensionIds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serverProperty, authenticator, timestamp, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationParameters.java
@@ -30,7 +30,6 @@ public class WebAuthnAuthenticationParameters {
     private final Authenticator authenticator;
 
     // verification condition
-    private final LocalDateTime timestamp;
     private boolean userVerificationRequired;
     private boolean userPresenceRequired;
     private List<String> expectedExtensionIds;
@@ -38,32 +37,14 @@ public class WebAuthnAuthenticationParameters {
     public WebAuthnAuthenticationParameters(
             ServerProperty serverProperty,
             Authenticator authenticator,
-            LocalDateTime timestamp,
             boolean userVerificationRequired,
             boolean userPresenceRequired,
             List<String> expectedExtensionIds) {
         this.serverProperty = serverProperty;
         this.authenticator = authenticator;
-        this.timestamp = timestamp;
         this.userVerificationRequired = userVerificationRequired;
         this.userPresenceRequired = userPresenceRequired;
         this.expectedExtensionIds = CollectionUtil.unmodifiableList(expectedExtensionIds);
-    }
-
-    public WebAuthnAuthenticationParameters(
-            ServerProperty serverProperty,
-            Authenticator authenticator,
-            boolean userVerificationRequired,
-            boolean userPresenceRequired,
-            List<String> expectedExtensionIds) {
-        this(
-                serverProperty,
-                authenticator,
-                LocalDateTime.now(),
-                userVerificationRequired,
-                userPresenceRequired,
-                expectedExtensionIds
-        );
     }
 
     public WebAuthnAuthenticationParameters(
@@ -100,10 +81,6 @@ public class WebAuthnAuthenticationParameters {
         return authenticator;
     }
 
-    public LocalDateTime getTimestamp() {
-        return timestamp;
-    }
-
     public boolean isUserVerificationRequired() {
         return userVerificationRequired;
     }
@@ -125,12 +102,11 @@ public class WebAuthnAuthenticationParameters {
                 userPresenceRequired == that.userPresenceRequired &&
                 Objects.equals(serverProperty, that.serverProperty) &&
                 Objects.equals(authenticator, that.authenticator) &&
-                Objects.equals(timestamp, that.timestamp) &&
                 Objects.equals(expectedExtensionIds, that.expectedExtensionIds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(serverProperty, authenticator, timestamp, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
+        return Objects.hash(serverProperty, authenticator, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationRequest.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationRequest.java
@@ -1,0 +1,85 @@
+package com.webauthn4j.data;
+
+import com.webauthn4j.util.ArrayUtil;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class WebAuthnAuthenticationRequest {
+
+    private final byte[] credentialId;
+    private final byte[] userHandle;
+    private final byte[] authenticatorData;
+    private final byte[] clientDataJSON;
+    private final String clientExtensionsJSON;
+    private final byte[] signature;
+
+    public WebAuthnAuthenticationRequest(byte[] credentialId, byte[] userHandle, byte[] authenticatorData, byte[] clientDataJSON, String clientExtensionsJSON, byte[] signature) {
+        this.credentialId = ArrayUtil.clone(credentialId);
+        this.userHandle = ArrayUtil.clone(userHandle);
+        this.authenticatorData = ArrayUtil.clone(authenticatorData);
+        this.clientDataJSON = ArrayUtil.clone(clientDataJSON);
+        this.clientExtensionsJSON = clientExtensionsJSON;
+        this.signature = ArrayUtil.clone(signature);
+    }
+
+    public WebAuthnAuthenticationRequest(byte[] credentialId, byte[] authenticatorData, byte[] clientDataJSON, String clientExtensionsJSON, byte[] signature) {
+        this(credentialId, null, authenticatorData, clientDataJSON, clientExtensionsJSON, signature);
+    }
+
+    public WebAuthnAuthenticationRequest(byte[] credentialId, byte[] userHandle, byte[] authenticatorData, byte[] clientDataJSON, byte[] signature) {
+        this(credentialId, userHandle, authenticatorData, clientDataJSON, null, signature);
+    }
+
+    public WebAuthnAuthenticationRequest(byte[] credentialId, byte[] authenticatorData, byte[] clientDataJSON, byte[] signature) {
+        this(credentialId, null, authenticatorData, clientDataJSON, signature);
+    }
+
+    public byte[] getCredentialId() {
+        return ArrayUtil.clone(credentialId);
+    }
+
+    public byte[] getUserHandle() {
+        return ArrayUtil.clone(userHandle);
+    }
+
+    public byte[] getAuthenticatorData() {
+        return ArrayUtil.clone(authenticatorData);
+    }
+
+    public byte[] getClientDataJSON() {
+        return ArrayUtil.clone(clientDataJSON);
+    }
+
+    public String getClientExtensionsJSON() {
+        return clientExtensionsJSON;
+    }
+
+    public byte[] getSignature() {
+        return ArrayUtil.clone(signature);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebAuthnAuthenticationRequest that = (WebAuthnAuthenticationRequest) o;
+        return Arrays.equals(credentialId, that.credentialId) &&
+                Arrays.equals(userHandle, that.userHandle) &&
+                Arrays.equals(authenticatorData, that.authenticatorData) &&
+                Arrays.equals(clientDataJSON, that.clientDataJSON) &&
+                Objects.equals(clientExtensionsJSON, that.clientExtensionsJSON) &&
+                Arrays.equals(signature, that.signature);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(clientExtensionsJSON);
+        result = 31 * result + Arrays.hashCode(credentialId);
+        result = 31 * result + Arrays.hashCode(userHandle);
+        result = 31 * result + Arrays.hashCode(authenticatorData);
+        result = 31 * result + Arrays.hashCode(clientDataJSON);
+        result = 31 * result + Arrays.hashCode(signature);
+        return result;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationRequest.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnAuthenticationRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.webauthn4j.data;
 
 import com.webauthn4j.util.ArrayUtil;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationContext.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationContext.java
@@ -16,9 +16,11 @@
 
 package com.webauthn4j.data;
 
+import com.webauthn4j.WebAuthnManager;
 import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.ArrayUtil;
 import com.webauthn4j.util.CollectionUtil;
+import com.webauthn4j.validator.WebAuthnRegistrationContextValidator;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,7 +29,9 @@ import java.util.Set;
 
 /**
  * WebAuthn registration context
+ * @deprecated {@link WebAuthnRegistrationContextValidator} is deprecated. please use {@link WebAuthnManager} instead.
  */
+@Deprecated
 public class WebAuthnRegistrationContext extends AbstractWebAuthnContext {
 
     // ~ Instance fields

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationData.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationData.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import com.webauthn4j.util.ArrayUtil;
+import com.webauthn4j.util.CollectionUtil;
+import com.webauthn4j.validator.WebAuthnRegistrationDataValidator;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+public class WebAuthnRegistrationData {
+
+    private final WebAuthnRegistrationDataValidator webAuthnRegistrationDataValidator;
+
+    private final AttestationObject attestationObject;
+    private final byte[] attestationObjectBytes;
+    private final CollectedClientData collectedClientData;
+    private final byte[] collectedClientDataBytes;
+    private final AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions;
+    private final Set<AuthenticatorTransport> transports;
+
+    public WebAuthnRegistrationData(
+            WebAuthnRegistrationDataValidator webAuthnRegistrationDataValidator,
+            AttestationObject attestationObject,
+            byte[] attestationObjectBytes,
+            CollectedClientData collectedClientData,
+            byte[] collectedClientDataBytes,
+            AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions,
+            Set<AuthenticatorTransport> transports) {
+        this.webAuthnRegistrationDataValidator = webAuthnRegistrationDataValidator;
+        this.attestationObject = attestationObject;
+        this.attestationObjectBytes = ArrayUtil.clone(attestationObjectBytes);
+        this.collectedClientData = collectedClientData;
+        this.collectedClientDataBytes = ArrayUtil.clone(collectedClientDataBytes);
+        this.clientExtensions = clientExtensions;
+        this.transports = CollectionUtil.unmodifiableSet(transports);
+    }
+
+    public void validate(WebAuthnRegistrationParameters webAuthnRegistrationParameters){
+        webAuthnRegistrationDataValidator.validate(this, webAuthnRegistrationParameters);
+    }
+
+    public WebAuthnRegistrationDataValidator getWebAuthnRegistrationDataValidator() {
+        return webAuthnRegistrationDataValidator;
+    }
+
+    public AttestationObject getAttestationObject() {
+        return attestationObject;
+    }
+
+    public byte[] getAttestationObjectBytes() {
+        return attestationObjectBytes;
+    }
+
+    public CollectedClientData getCollectedClientData() {
+        return collectedClientData;
+    }
+
+    public byte[] getCollectedClientDataBytes() {
+        return ArrayUtil.clone(collectedClientDataBytes);
+    }
+
+    public AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> getClientExtensions() {
+        return clientExtensions;
+    }
+
+    public Set<AuthenticatorTransport> getTransports() {
+        return transports;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebAuthnRegistrationData that = (WebAuthnRegistrationData) o;
+        return Objects.equals(webAuthnRegistrationDataValidator, that.webAuthnRegistrationDataValidator) &&
+                Objects.equals(attestationObject, that.attestationObject) &&
+                Arrays.equals(attestationObjectBytes, that.attestationObjectBytes) &&
+                Objects.equals(collectedClientData, that.collectedClientData) &&
+                Arrays.equals(collectedClientDataBytes, that.collectedClientDataBytes) &&
+                Objects.equals(clientExtensions, that.clientExtensions) &&
+                Objects.equals(transports, that.transports);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(webAuthnRegistrationDataValidator, attestationObject, collectedClientData, clientExtensions, transports);
+        result = 31 * result + Arrays.hashCode(attestationObjectBytes);
+        result = 31 * result + Arrays.hashCode(collectedClientDataBytes);
+        return result;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationData.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationParameters.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.util.CollectionUtil;
+
+import java.util.List;
+import java.util.Objects;
+
+public class WebAuthnRegistrationParameters {
+
+    // server property
+    private final ServerProperty serverProperty;
+
+    // verification condition
+    private final boolean userVerificationRequired;
+    private final boolean userPresenceRequired;
+    private final List<String> expectedExtensionIds;
+
+    public WebAuthnRegistrationParameters(ServerProperty serverProperty, boolean userVerificationRequired, boolean userPresenceRequired, List<String> expectedExtensionIds) {
+        this.serverProperty = serverProperty;
+        this.userVerificationRequired = userVerificationRequired;
+        this.userPresenceRequired = userPresenceRequired;
+        this.expectedExtensionIds = CollectionUtil.unmodifiableList(expectedExtensionIds);
+    }
+
+    public WebAuthnRegistrationParameters(ServerProperty serverProperty, boolean userVerificationRequired, boolean userPresenceRequired) {
+        this(serverProperty, userVerificationRequired, userPresenceRequired, null);
+    }
+
+    public WebAuthnRegistrationParameters(ServerProperty serverProperty, boolean userVerificationRequired) {
+        this(serverProperty, userVerificationRequired, true);
+    }
+
+    public ServerProperty getServerProperty() {
+        return serverProperty;
+    }
+
+    public boolean isUserVerificationRequired() {
+        return userVerificationRequired;
+    }
+
+    public boolean isUserPresenceRequired() {
+        return userPresenceRequired;
+    }
+
+    public List<String> getExpectedExtensionIds() {
+        return expectedExtensionIds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebAuthnRegistrationParameters that = (WebAuthnRegistrationParameters) o;
+        return userVerificationRequired == that.userVerificationRequired &&
+                userPresenceRequired == that.userPresenceRequired &&
+                Objects.equals(serverProperty, that.serverProperty) &&
+                Objects.equals(expectedExtensionIds, that.expectedExtensionIds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serverProperty, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationRequest.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationRequest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.util.ArrayUtil;
+import com.webauthn4j.util.CollectionUtil;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+public class WebAuthnRegistrationRequest {
+
+    // ~ Instance fields
+    // ================================================================================================
+
+    // user inputs
+    private final byte[] attestationObject;
+    private final byte[] clientDataJSON;
+    private final String clientExtensionsJSON;
+    private final Set<String> transports;
+
+    public WebAuthnRegistrationRequest(byte[] attestationObject, byte[] clientDataJSON, String clientExtensionsJSON, Set<String> transports) {
+        this.attestationObject = ArrayUtil.clone(attestationObject);
+        this.clientDataJSON = ArrayUtil.clone(clientDataJSON);
+        this.clientExtensionsJSON = clientExtensionsJSON;
+        this.transports = CollectionUtil.unmodifiableSet(transports);
+    }
+
+    public WebAuthnRegistrationRequest(byte[] attestationObject, byte[] clientDataJSON, String clientExtensionsJSON) {
+        this(attestationObject, clientDataJSON, clientExtensionsJSON, null);
+    }
+
+    public WebAuthnRegistrationRequest(byte[] attestationObject, byte[] clientDataJSON, Set<String> transports) {
+        this(attestationObject, clientDataJSON, null, transports);
+    }
+
+    public WebAuthnRegistrationRequest(byte[] attestationObject, byte[] clientDataJSON) {
+        this(attestationObject, clientDataJSON, null, null);
+    }
+
+    public byte[] getAttestationObject() {
+        return ArrayUtil.clone(attestationObject);
+    }
+
+    public byte[] getClientDataJSON() {
+        return ArrayUtil.clone(clientDataJSON);
+    }
+
+    public String getClientExtensionsJSON() {
+        return clientExtensionsJSON;
+    }
+
+    public Set<String> getTransports() {
+        return transports;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebAuthnRegistrationRequest that = (WebAuthnRegistrationRequest) o;
+        return Arrays.equals(attestationObject, that.attestationObject) &&
+                Arrays.equals(clientDataJSON, that.clientDataJSON) &&
+                Objects.equals(clientExtensionsJSON, that.clientExtensionsJSON) &&
+                Objects.equals(transports, that.transports);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(clientExtensionsJSON, transports);
+        result = 31 * result + Arrays.hashCode(attestationObject);
+        result = 31 * result + Arrays.hashCode(clientDataJSON);
+        return result;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationRequest.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/WebAuthnRegistrationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AssertionSignatureValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AssertionSignatureValidator.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.validator;
 
 import com.webauthn4j.data.WebAuthnAuthenticationContext;
+import com.webauthn4j.data.WebAuthnAuthenticationData;
 import com.webauthn4j.data.attestation.authenticator.COSEKey;
 import com.webauthn4j.data.attestation.statement.SignatureAlgorithm;
 import com.webauthn4j.util.MessageDigestUtil;
@@ -37,18 +38,18 @@ class AssertionSignatureValidator {
     // ~ Methods
     // ========================================================================================================
 
-    public void validate(WebAuthnAuthenticationContext webAuthnAuthenticationContext, COSEKey coseKey) {
-        byte[] signedData = getSignedData(webAuthnAuthenticationContext);
-        byte[] signature = webAuthnAuthenticationContext.getSignature();
+    public void validate(WebAuthnAuthenticationData webAuthnAuthenticationData, COSEKey coseKey) {
+        byte[] signedData = getSignedData(webAuthnAuthenticationData);
+        byte[] signature = webAuthnAuthenticationData.getSignature();
         if (!verifySignature(coseKey, signature, signedData)) {
             throw new BadSignatureException("Assertion signature is not valid.");
         }
     }
 
-    private byte[] getSignedData(WebAuthnAuthenticationContext webAuthnAuthenticationContext) {
+    private byte[] getSignedData(WebAuthnAuthenticationData webAuthnAuthenticationData) {
         MessageDigest messageDigest = MessageDigestUtil.createSHA256();
-        byte[] rawAuthenticatorData = webAuthnAuthenticationContext.getAuthenticatorData();
-        byte[] clientDataHash = messageDigest.digest(webAuthnAuthenticationContext.getClientDataJSON());
+        byte[] rawAuthenticatorData = webAuthnAuthenticationData.getAuthenticatorDataBytes();
+        byte[] clientDataHash = messageDigest.digest(webAuthnAuthenticationData.getCollectedClientDataBytes());
         return ByteBuffer.allocate(rawAuthenticatorData.length + clientDataHash.length).put(rawAuthenticatorData).put(clientDataHash).array();
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationObject.java
@@ -33,7 +33,6 @@ public class AuthenticationObject {
 
     private final Authenticator authenticator;
 
-    private final LocalDateTime timestamp;
 
     @SuppressWarnings("squid:S00107")
     public AuthenticationObject(
@@ -44,32 +43,7 @@ public class AuthenticationObject {
             byte[] authenticatorDataBytes,
             AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions,
             ServerProperty serverProperty,
-            Authenticator authenticator
-    ) {
-
-        this(
-                credentialId,
-                collectedClientData,
-                collectedClientDataBytes,
-                authenticatorData,
-                authenticatorDataBytes,
-                clientExtensions,
-                serverProperty,
-                authenticator,
-                LocalDateTime.now(Clock.systemUTC()));
-    }
-
-    @SuppressWarnings("squid:S00107")
-    public AuthenticationObject(
-            byte[] credentialId,
-            CollectedClientData collectedClientData,
-            byte[] collectedClientDataBytes,
-            AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData,
-            byte[] authenticatorDataBytes,
-            AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions,
-            ServerProperty serverProperty,
-            Authenticator authenticator,
-            LocalDateTime timestamp) {
+            Authenticator authenticator) {
         this.credentialId = credentialId;
         this.collectedClientData = collectedClientData;
         this.collectedClientDataBytes = collectedClientDataBytes;
@@ -78,7 +52,6 @@ public class AuthenticationObject {
         this.clientExtensions = clientExtensions;
         this.serverProperty = serverProperty;
         this.authenticator = authenticator;
-        this.timestamp = timestamp;
     }
 
     public byte[] getCredentialId() {
@@ -113,10 +86,6 @@ public class AuthenticationObject {
         return authenticator;
     }
 
-    public LocalDateTime getTimestamp() {
-        return this.timestamp;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -129,13 +98,12 @@ public class AuthenticationObject {
                 Arrays.equals(authenticatorDataBytes, that.authenticatorDataBytes) &&
                 Objects.equals(clientExtensions, that.clientExtensions) &&
                 Objects.equals(serverProperty, that.serverProperty) &&
-                Objects.equals(authenticator, that.authenticator) &&
-                Objects.equals(timestamp, that.timestamp);
+                Objects.equals(authenticator, that.authenticator);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(collectedClientData, authenticatorData, clientExtensions, serverProperty, authenticator, timestamp);
+        int result = Objects.hash(collectedClientData, authenticatorData, clientExtensions, serverProperty, authenticator);
         result = 31 * result + Arrays.hashCode(credentialId);
         result = 31 * result + Arrays.hashCode(collectedClientDataBytes);
         result = 31 * result + Arrays.hashCode(authenticatorDataBytes);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
@@ -16,8 +16,7 @@
 
 package com.webauthn4j.validator;
 
-import com.webauthn4j.data.WebAuthnAuthenticationContext;
-import com.webauthn4j.data.WebAuthnRegistrationContext;
+import com.webauthn4j.data.*;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
@@ -48,7 +47,71 @@ class BeanAssertUtil {
     // ~ Static Methods
     // ========================================================================================================
 
-    public static void validate(WebAuthnAuthenticationContext webAuthnAuthenticationContext) {
+
+    public static void validate(WebAuthnRegistrationData webAuthnRegistrationData) {
+        if (webAuthnRegistrationData == null) {
+            throw new ConstraintViolationException("webAuthnRegistrationData must not be null");
+        }
+
+        validate(webAuthnRegistrationData.getAttestationObject());
+
+        if (webAuthnRegistrationData.getAttestationObjectBytes() == null) {
+            throw new ConstraintViolationException("attestationObjectBytes must not be null");
+        }
+        validateAuthenticationExtensionsClientOutputs(webAuthnRegistrationData.getClientExtensions());
+
+        validate(webAuthnRegistrationData.getCollectedClientData());
+
+        if (webAuthnRegistrationData.getCollectedClientDataBytes() == null) {
+            throw new ConstraintViolationException("collectedClientData must not be null");
+        }
+        if (webAuthnRegistrationData.getTransports() == null) {
+            throw new ConstraintViolationException("transports must not be null");
+        }
+    }
+
+
+    public static void validate(WebAuthnRegistrationParameters webAuthnRegistrationParameters) {
+        if (webAuthnRegistrationParameters == null) {
+            throw new ConstraintViolationException("webAuthnRegistrationParameters must not be null");
+        }
+        validate(webAuthnRegistrationParameters.getServerProperty());
+    }
+
+    public static void validate(WebAuthnAuthenticationData webAuthnAuthenticationData) {
+        if (webAuthnAuthenticationData == null) {
+            throw new ConstraintViolationException("webAuthnRegistrationData must not be null");
+        }
+
+        if (webAuthnAuthenticationData.getCredentialId() == null) {
+            throw new ConstraintViolationException("credentialId must not be null");
+        }
+        if (webAuthnAuthenticationData.getSignature() == null) {
+            throw new ConstraintViolationException("signature must not be null");
+        }
+        if (webAuthnAuthenticationData.getCollectedClientData() == null) {
+            throw new ConstraintViolationException("collectedClientData must not be null");
+        }
+        validate(webAuthnAuthenticationData.getCollectedClientData());
+        if (webAuthnAuthenticationData.getCollectedClientDataBytes() == null) {
+            throw new ConstraintViolationException("collectedClientData must not be null");
+        }
+        validate(webAuthnAuthenticationData.getAuthenticatorData());
+        if (webAuthnAuthenticationData.getAuthenticatorDataBytes() == null) {
+            throw new ConstraintViolationException("authenticatorDataBytes must not be null");
+        }
+        validateAuthenticationExtensionsClientOutputs(webAuthnAuthenticationData.getClientExtensions());
+    }
+
+    public static void validate(WebAuthnAuthenticationParameters webAuthnAuthenticationParameters) {
+        if (webAuthnAuthenticationParameters == null) {
+            throw new ConstraintViolationException("webAuthnAuthenticationParameters must not be null");
+        }
+        validate(webAuthnAuthenticationParameters.getServerProperty());
+    }
+
+
+    public static void validate(com.webauthn4j.data.WebAuthnAuthenticationContext webAuthnAuthenticationContext) {
 
         if (webAuthnAuthenticationContext == null) {
             throw new ConstraintViolationException("webAuthnAuthenticationContext must not be null");
@@ -218,5 +281,6 @@ class BeanAssertUtil {
         }
         coseKey.validate();
     }
+
 
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
@@ -53,6 +53,10 @@ class BeanAssertUtil {
             throw new ConstraintViolationException("webAuthnRegistrationData must not be null");
         }
 
+        if (webAuthnRegistrationData.getWebAuthnRegistrationDataValidator() == null) {
+            throw new ConstraintViolationException("webAuthnRegistrationDataValidator must not be null");
+        }
+
         validate(webAuthnRegistrationData.getAttestationObject());
 
         if (webAuthnRegistrationData.getAttestationObjectBytes() == null) {
@@ -64,9 +68,6 @@ class BeanAssertUtil {
 
         if (webAuthnRegistrationData.getCollectedClientDataBytes() == null) {
             throw new ConstraintViolationException("collectedClientData must not be null");
-        }
-        if (webAuthnRegistrationData.getTransports() == null) {
-            throw new ConstraintViolationException("transports must not be null");
         }
     }
 
@@ -81,6 +82,10 @@ class BeanAssertUtil {
     public static void validate(WebAuthnAuthenticationData webAuthnAuthenticationData) {
         if (webAuthnAuthenticationData == null) {
             throw new ConstraintViolationException("webAuthnRegistrationData must not be null");
+        }
+
+        if (webAuthnAuthenticationData.getWebAuthnAuthenticationDataValidator() == null) {
+            throw new ConstraintViolationException("webAuthnAuthenticationDataValidator must not be null");
         }
 
         if (webAuthnAuthenticationData.getCredentialId() == null) {
@@ -106,6 +111,9 @@ class BeanAssertUtil {
     public static void validate(WebAuthnAuthenticationParameters webAuthnAuthenticationParameters) {
         if (webAuthnAuthenticationParameters == null) {
             throw new ConstraintViolationException("webAuthnAuthenticationParameters must not be null");
+        }
+        if (webAuthnAuthenticationParameters.getAuthenticator() == null) {
+            throw new ConstraintViolationException("authenticator must not be null");
         }
         validate(webAuthnAuthenticationParameters.getServerProperty());
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidationResponse.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidationResponse.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.validator;
 
+import com.webauthn4j.WebAuthnManager;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.client.CollectedClientData;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput;
@@ -25,7 +26,9 @@ import java.util.Objects;
 
 /**
  * Envelope class for WebAuthnAuthenticationContext validation result
+ * @deprecated {@link WebAuthnAuthenticationContextValidator} is deprecated. please use {@link WebAuthnManager} instead.
  */
+@Deprecated
 public class WebAuthnAuthenticationContextValidationResponse {
 
     // ~ Instance fields

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
@@ -16,29 +16,28 @@
 
 package com.webauthn4j.validator;
 
+import com.webauthn4j.WebAuthnManager;
 import com.webauthn4j.authenticator.Authenticator;
-import com.webauthn4j.converter.AuthenticationExtensionsClientOutputsConverter;
-import com.webauthn4j.converter.AuthenticatorDataConverter;
-import com.webauthn4j.converter.CollectedClientDataConverter;
 import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.CborConverter;
 import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.data.WebAuthnAuthenticationContext;
+import com.webauthn4j.data.WebAuthnAuthenticationData;
+import com.webauthn4j.data.WebAuthnAuthenticationParameters;
+import com.webauthn4j.data.WebAuthnAuthenticationRequest;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
-import com.webauthn4j.data.client.ClientDataType;
-import com.webauthn4j.data.client.CollectedClientData;
-import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
-import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
-import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput;
-import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
-import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.util.exception.WebAuthnException;
-import com.webauthn4j.validator.exception.*;
+import com.webauthn4j.validator.attestation.trustworthiness.certpath.NullCertPathTrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.NullECDAATrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.self.NullSelfAttestationTrustworthinessValidator;
+import com.webauthn4j.validator.exception.ConstraintViolationException;
+import com.webauthn4j.validator.exception.ValidationException;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Validates the specified {@link WebAuthnAuthenticationContext} instance
@@ -48,19 +47,8 @@ public class WebAuthnAuthenticationContextValidator {
     //~ Instance fields
     // ================================================================================================
 
-    private final AuthenticatorDataConverter authenticatorDataConverter;
-    private final CollectedClientDataConverter collectedClientDataConverter;
-    private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter;
-
-    private final ChallengeValidator challengeValidator = new ChallengeValidator();
-    private final OriginValidator originValidator = new OriginValidator();
-    private final TokenBindingValidator tokenBindingValidator = new TokenBindingValidator();
-    private final RpIdHashValidator rpIdHashValidator = new RpIdHashValidator();
-    private final AssertionSignatureValidator assertionSignatureValidator = new AssertionSignatureValidator();
-    private final ExtensionValidator extensionValidator = new ExtensionValidator();
-    private final List<CustomAuthenticationValidator> customAuthenticationValidators = new ArrayList<>();
-
-    private MaliciousCounterValueHandler maliciousCounterValueHandler = new DefaultMaliciousCounterValueHandler();
+    private final WebAuthnManager webAuthnManager;
+    private List<CustomAuthenticationValidator> customAuthenticationValidators = new ArrayList<>();
 
     // ~ Constructor
     // ========================================================================================================
@@ -73,9 +61,16 @@ public class WebAuthnAuthenticationContextValidator {
         AssertUtil.notNull(jsonConverter, "jsonConverter must not be null");
         AssertUtil.notNull(cborConverter, "cborConverter must not be null");
 
-        this.authenticatorDataConverter = new AuthenticatorDataConverter(cborConverter);
-        this.collectedClientDataConverter = new CollectedClientDataConverter(jsonConverter);
-        this.authenticationExtensionsClientOutputsConverter = new AuthenticationExtensionsClientOutputsConverter(jsonConverter);
+        webAuthnManager = new WebAuthnManager(
+                Collections.emptyList(),
+                new NullCertPathTrustworthinessValidator(),
+                new NullECDAATrustworthinessValidator(),
+                new NullSelfAttestationTrustworthinessValidator(),
+                Collections.emptyList(),
+                customAuthenticationValidators,
+                jsonConverter,
+                cborConverter
+        );
     }
 
     // ~ Methods
@@ -94,142 +89,29 @@ public class WebAuthnAuthenticationContextValidator {
     @SuppressWarnings("squid:RedundantThrowsDeclarationCheck")
     public WebAuthnAuthenticationContextValidationResponse validate(WebAuthnAuthenticationContext authenticationContext, Authenticator authenticator) throws WebAuthnException {
 
-        BeanAssertUtil.validate(authenticationContext);
-
-        byte[] credentialId = authenticationContext.getCredentialId();
-
-        //spec| Step1
-        //spec| If the allowCredentials option was given when this authentication ceremony was initiated,
-        //spec| verify that credential.id identifies one of the public key credentials that were listed in allowCredentials.
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
-
-        //spec| Step2
-        //spec| Identify the user being authenticated and verify that this user is the owner of the public key credential source credentialSource identified by credential.id:
-
-        //spec| If the user was identified before the authentication ceremony was initiated,
-        //spec| verify that the identified user is the owner of credentialSource.
-        //spec| If credential.response.userHandle is present,
-        //spec| verify that this value identifies the same user as was previously identified.
-        //spec| If the user was not identified before the authentication ceremony was initiated,
-        //spec| verify that credential.response.userHandle is present, and that the user identified by this value is the owner of credentialSource.
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
-
-        //spec| Step3
-        //spec| Using credential’s id attribute (or the corresponding rawId, if base64url encoding is inappropriate for your use case),
-        //spec| look up the corresponding credential public key.
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
-
-        //spec| Step4
-        //spec| Let cData, aData and sig denote the value of credential’s response's clientDataJSON, authenticatorData,
-        //spec| and signature respectively.
-        byte[] cData = authenticationContext.getClientDataJSON();
-        byte[] aData = authenticationContext.getAuthenticatorData();
-
-        //spec| Step5
-        //spec| Let JSONtext be the result of running UTF-8 decode on the value of cData.
-        //spec| Step6
-        //spec| Let C, the client data claimed as used for the signature, be the result of running an implementation-specific JSON parser on JSONtext.
-
-        //      (In the spec, claimed as "C", but use "collectedClientData" here)
-        CollectedClientData collectedClientData = collectedClientDataConverter.convert(cData);
-
-        AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData = authenticatorDataConverter.convert(aData);
-        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions =
-                authenticationExtensionsClientOutputsConverter.convert(authenticationContext.getClientExtensionsJSON());
-        ServerProperty serverProperty = authenticationContext.getServerProperty();
-
-        BeanAssertUtil.validate(collectedClientData);
-        BeanAssertUtil.validate(authenticatorData);
-        BeanAssertUtil.validate(serverProperty);
-
-        validateAuthenticatorData(authenticatorData);
-
-        AuthenticationObject authenticationObject = new AuthenticationObject(
-                credentialId, collectedClientData, cData, authenticatorData, aData, clientExtensions,
-                authenticationContext.getServerProperty(),
-                authenticator
+        WebAuthnAuthenticationRequest webAuthnAuthenticationRequest = new WebAuthnAuthenticationRequest(
+                authenticationContext.getCredentialId(),
+                authenticationContext.getUserHandle(),
+                authenticationContext.getAuthenticatorData(),
+                authenticationContext.getClientDataJSON(),
+                authenticationContext.getClientExtensionsJSON(),
+                authenticationContext.getSignature()
         );
+        WebAuthnAuthenticationParameters webAuthnAuthenticationParameters = new WebAuthnAuthenticationParameters(
+                authenticationContext.getServerProperty(),
+                authenticator,
+                LocalDateTime.now(),
+                authenticationContext.isUserVerificationRequired(),
+                authenticationContext.isUserPresenceRequired()  ,
+                authenticationContext.getExpectedExtensionIds()
+        );
+        WebAuthnAuthenticationData webAuthnAuthenticationData = webAuthnManager.parseAuthenticationRequest(webAuthnAuthenticationRequest);
+        webAuthnAuthenticationData.validate(webAuthnAuthenticationParameters);
 
-        //spec| Step7
-        //spec| Verify that the value of C.type is the string webauthn.get.
-        if (!Objects.equals(collectedClientData.getType(), ClientDataType.GET)) {
-            throw new MaliciousDataException("ClientData.type must be 'get' on authentication, but it isn't.");
-        }
-
-        //spec| Step8
-        //spec| Verify that the value of C.challenge matches the challenge that was sent to the authenticator in
-        //spec| the PublicKeyCredentialRequestOptions passed to the get() call.
-        challengeValidator.validate(collectedClientData, serverProperty);
-
-        //spec| Step9
-        //spec| Verify that the value of C.origin matches the Relying Party's origin.
-        originValidator.validate(collectedClientData, serverProperty);
-
-        //spec| Step10
-        //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
-        //spec| which the attestation was obtained. If Token Binding was used on that TLS connection,
-        //spec| also verify that C.tokenBinding.id matches the base64url encoding of the Token Binding ID for the connection.
-        tokenBindingValidator.validate(collectedClientData.getTokenBinding(), serverProperty.getTokenBindingId());
-
-        //spec| Step11
-        //spec| Verify that the rpIdHash in aData is the SHA-256 hash of the RP ID expected by the Relying Party.
-        rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
-
-        //spec| Step12
-        //spec| Verify that the User Present bit of the flags in authData is set.
-        if (authenticationContext.isUserPresenceRequired() && !authenticatorData.isFlagUP()) {
-            throw new UserNotPresentException("Validator is configured to check user present, but UP flag in authenticatorData is not set.");
-        }
-
-        //spec| Step13
-        //spec| If user verification is required for this assertion, verify that the User Verified bit of the flags in aData is set.
-        if (authenticationContext.isUserVerificationRequired() && !authenticatorData.isFlagUV()) {
-            throw new UserNotVerifiedException("Validator is configured to check user verified, but UV flag in authenticatorData is not set.");
-        }
-
-        //spec| Step14
-        //spec| Verify that the values of the client extension outputs in clientExtensionResults and the authenticator
-        //spec| extension outputs in the extensions in authData are as expected, considering the client extension input
-        //spec| values that were given as the extensions option in the get() call. In particular, any extension identifier
-        //spec| values in the clientExtensionResults and the extensions in authData MUST be also be present as extension
-        //spec| identifier values in the extensions member of options, i.e., no extensions are present that were not requested.
-        //spec| In the general case, the meaning of "are as expected" is specific to the Relying Party and which extensions are in use.
-        AuthenticationExtensionsAuthenticatorOutputs<AuthenticationExtensionAuthenticatorOutput> authenticationExtensionsAuthenticatorOutputs = authenticatorData.getExtensions();
-        List<String> expectedExtensionIdentifiers = authenticationContext.getExpectedExtensionIds();
-        extensionValidator.validate(clientExtensions, authenticationExtensionsAuthenticatorOutputs, expectedExtensionIdentifiers);
-
-        //spec| Using the credential public key, validate that sig is a valid signature over
-        //spec| the binary concatenation of the authenticatorData and the hash of the collectedClientData.
-        assertionSignatureValidator.validate(authenticationContext, authenticator.getAttestedCredentialData().getCOSEKey());
-
-        //spec| Step17
-        //spec| If the signature counter value adata.signCount is nonzero or the value stored in conjunction with
-        //spec| credential’s id attribute is nonzero, then run the following sub-step:
-        long presentedCounter = authenticatorData.getSignCount();
-        long storedCounter = authenticator.getCounter();
-        if (presentedCounter > 0 || storedCounter > 0) {
-            //spec| If the signature counter value adata.signCount is
-            //spec| greater than the signature counter value stored in conjunction with credential’s id attribute.
-            if (presentedCounter > storedCounter) {
-
-                //spec| Update the stored signature counter value, associated with credential’s id attribute, to be the value of authData.signCount.
-
-                //      (caller need to update the signature counter value based on the value set in the Authenticator instance)
-                authenticator.setCounter(presentedCounter);
-            }
-            //spec| less than or equal to the signature counter value stored in conjunction with credential’s id attribute.
-            else {
-                maliciousCounterValueHandler.maliciousCounterValueDetected(authenticationContext, authenticator);
-            }
-        }
-
-        for (CustomAuthenticationValidator customAuthenticationValidator : customAuthenticationValidators) {
-            customAuthenticationValidator.validate(authenticationObject);
-        }
-
-        //spec| Step18
-        //spec| If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the authentication ceremony.
-        return new WebAuthnAuthenticationContextValidationResponse(collectedClientData, authenticatorData, clientExtensions);
+        return new WebAuthnAuthenticationContextValidationResponse(
+                webAuthnAuthenticationData.getCollectedClientData(),
+                webAuthnAuthenticationData.getAuthenticatorData(),
+                webAuthnAuthenticationData.getClientExtensions());
     }
 
     void validateAuthenticatorData(AuthenticatorData authenticatorData) {
@@ -239,12 +121,12 @@ public class WebAuthnAuthenticationContextValidator {
     }
 
     public MaliciousCounterValueHandler getMaliciousCounterValueHandler() {
-        return maliciousCounterValueHandler;
+        return webAuthnManager.getWebAuthnAuthenticationDataValidator().getMaliciousCounterValueHandler();
     }
 
     public void setMaliciousCounterValueHandler(MaliciousCounterValueHandler maliciousCounterValueHandler) {
         AssertUtil.notNull(maliciousCounterValueHandler, "maliciousCounterValueHandler must not be null");
-        this.maliciousCounterValueHandler = maliciousCounterValueHandler;
+        webAuthnManager.getWebAuthnAuthenticationDataValidator().setMaliciousCounterValueHandler(maliciousCounterValueHandler);
     }
 
     public List<CustomAuthenticationValidator> getCustomAuthenticationValidators() {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
@@ -102,7 +102,6 @@ public class WebAuthnAuthenticationContextValidator {
         WebAuthnAuthenticationParameters webAuthnAuthenticationParameters = new WebAuthnAuthenticationParameters(
                 authenticationContext.getServerProperty(),
                 authenticator,
-                LocalDateTime.now(),
                 authenticationContext.isUserVerificationRequired(),
                 authenticationContext.isUserPresenceRequired()  ,
                 authenticationContext.getExpectedExtensionIds()

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
@@ -41,7 +41,9 @@ import java.util.List;
 
 /**
  * Validates the specified {@link WebAuthnAuthenticationContext} instance
+ * @deprecated {@link WebAuthnAuthenticationContextValidator} is deprecated. please use {@link WebAuthnManager} instead.
  */
+@Deprecated
 public class WebAuthnAuthenticationContextValidator {
 
     //~ Instance fields

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidator.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.validator;
+
+import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.data.WebAuthnAuthenticationData;
+import com.webauthn4j.data.WebAuthnAuthenticationParameters;
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.data.client.ClientDataType;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.util.AssertUtil;
+import com.webauthn4j.validator.exception.ConstraintViolationException;
+import com.webauthn4j.validator.exception.MaliciousDataException;
+import com.webauthn4j.validator.exception.UserNotPresentException;
+import com.webauthn4j.validator.exception.UserNotVerifiedException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class WebAuthnAuthenticationDataValidator {
+
+    private final ChallengeValidator challengeValidator = new ChallengeValidator();
+    private final OriginValidator originValidator = new OriginValidator();
+    private final TokenBindingValidator tokenBindingValidator = new TokenBindingValidator();
+    private final RpIdHashValidator rpIdHashValidator = new RpIdHashValidator();
+    private final AssertionSignatureValidator assertionSignatureValidator = new AssertionSignatureValidator();
+    private final ExtensionValidator extensionValidator = new ExtensionValidator();
+
+    private final List<CustomAuthenticationValidator> customAuthenticationValidators;
+
+    private MaliciousCounterValueHandler maliciousCounterValueHandler = new DefaultMaliciousCounterValueHandler();
+
+    public WebAuthnAuthenticationDataValidator(List<CustomAuthenticationValidator> customAuthenticationValidators) {
+        this.customAuthenticationValidators = customAuthenticationValidators;
+    }
+
+    public WebAuthnAuthenticationDataValidator() {
+        this.customAuthenticationValidators = new ArrayList<>();
+    }
+
+    public void validate(WebAuthnAuthenticationData webAuthnAuthenticationData, WebAuthnAuthenticationParameters webAuthnAuthenticationParameters) {
+
+        BeanAssertUtil.validate(webAuthnAuthenticationData);
+        BeanAssertUtil.validate(webAuthnAuthenticationParameters);
+
+        //spec| Step1
+        //spec| If the allowCredentials option was given when this authentication ceremony was initiated,
+        //spec| verify that credential.id identifies one of the public key credentials that were listed in allowCredentials.
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+
+        //spec| Step2
+        //spec| Identify the user being authenticated and verify that this user is the owner of the public key credential source credentialSource identified by credential.id:
+
+        //spec| If the user was identified before the authentication ceremony was initiated,
+        //spec| verify that the identified user is the owner of credentialSource.
+        //spec| If credential.response.userHandle is present,
+        //spec| verify that this value identifies the same user as was previously identified.
+        //spec| If the user was not identified before the authentication ceremony was initiated,
+        //spec| verify that credential.response.userHandle is present, and that the user identified by this value is the owner of credentialSource.
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+
+        //spec| Step3
+        //spec| Using credential’s id attribute (or the corresponding rawId, if base64url encoding is inappropriate for your use case),
+        //spec| look up the corresponding credential public key.
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+
+        //spec| Step4
+        //spec| Let cData, aData and sig denote the value of credential’s response's clientDataJSON, authenticatorData,
+        //spec| and signature respectively.
+        byte[] cData = webAuthnAuthenticationData.getCollectedClientDataBytes();
+        byte[] aData = webAuthnAuthenticationData.getAuthenticatorDataBytes();
+
+        //spec| Step5
+        //spec| Let JSONtext be the result of running UTF-8 decode on the value of cData.
+        //spec| Step6
+        //spec| Let C, the client data claimed as used for the signature, be the result of running an implementation-specific JSON parser on JSONtext.
+
+        //      (In the spec, claimed as "C", but use "collectedClientData" here)
+        CollectedClientData collectedClientData = webAuthnAuthenticationData.getCollectedClientData();
+
+        AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData = webAuthnAuthenticationData.getAuthenticatorData();
+        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = webAuthnAuthenticationData.getClientExtensions();
+        ServerProperty serverProperty = webAuthnAuthenticationParameters.getServerProperty();
+
+        BeanAssertUtil.validate(collectedClientData);
+        BeanAssertUtil.validate(authenticatorData);
+        BeanAssertUtil.validate(serverProperty);
+
+        validateAuthenticatorData(authenticatorData);
+
+        byte[] credentialId = webAuthnAuthenticationData.getCredentialId();
+        Authenticator authenticator = webAuthnAuthenticationParameters.getAuthenticator();
+        LocalDateTime timestamp = webAuthnAuthenticationParameters.getTimestamp();
+
+        AuthenticationObject authenticationObject = new AuthenticationObject(
+                credentialId, collectedClientData, cData, authenticatorData, aData, clientExtensions,
+                serverProperty, authenticator, timestamp
+        );
+
+        //spec| Step7
+        //spec| Verify that the value of C.type is the string webauthn.get.
+        if (!Objects.equals(collectedClientData.getType(), ClientDataType.GET)) {
+            throw new MaliciousDataException("ClientData.type must be 'get' on authentication, but it isn't.");
+        }
+
+        //spec| Step8
+        //spec| Verify that the value of C.challenge matches the challenge that was sent to the authenticator in
+        //spec| the PublicKeyCredentialRequestOptions passed to the get() call.
+        challengeValidator.validate(collectedClientData, serverProperty);
+
+        //spec| Step9
+        //spec| Verify that the value of C.origin matches the Relying Party's origin.
+        originValidator.validate(collectedClientData, serverProperty);
+
+        //spec| Step10
+        //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
+        //spec| which the attestation was obtained. If Token Binding was used on that TLS connection,
+        //spec| also verify that C.tokenBinding.id matches the base64url encoding of the Token Binding ID for the connection.
+        tokenBindingValidator.validate(collectedClientData.getTokenBinding(), serverProperty.getTokenBindingId());
+
+        //spec| Step11
+        //spec| Verify that the rpIdHash in aData is the SHA-256 hash of the RP ID expected by the Relying Party.
+        rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
+
+        //spec| Step12
+        //spec| Verify that the User Present bit of the flags in authData is set.
+        if (webAuthnAuthenticationParameters.isUserPresenceRequired() && !authenticatorData.isFlagUP()) {
+            throw new UserNotPresentException("Validator is configured to check user present, but UP flag in authenticatorData is not set.");
+        }
+
+        //spec| Step13
+        //spec| If user verification is required for this assertion, verify that the User Verified bit of the flags in aData is set.
+        if (webAuthnAuthenticationParameters.isUserVerificationRequired() && !authenticatorData.isFlagUV()) {
+            throw new UserNotVerifiedException("Validator is configured to check user verified, but UV flag in authenticatorData is not set.");
+        }
+
+        //spec| Step14
+        //spec| Verify that the values of the client extension outputs in clientExtensionResults and the authenticator
+        //spec| extension outputs in the extensions in authData are as expected, considering the client extension input
+        //spec| values that were given as the extensions option in the get() call. In particular, any extension identifier
+        //spec| values in the clientExtensionResults and the extensions in authData MUST be also be present as extension
+        //spec| identifier values in the extensions member of options, i.e., no extensions are present that were not requested.
+        //spec| In the general case, the meaning of "are as expected" is specific to the Relying Party and which extensions are in use.
+        AuthenticationExtensionsAuthenticatorOutputs<AuthenticationExtensionAuthenticatorOutput> authenticationExtensionsAuthenticatorOutputs = authenticatorData.getExtensions();
+        List<String> expectedExtensionIdentifiers = webAuthnAuthenticationParameters.getExpectedExtensionIds();
+        extensionValidator.validate(clientExtensions, authenticationExtensionsAuthenticatorOutputs, expectedExtensionIdentifiers);
+
+        //spec| Using the credential public key, validate that sig is a valid signature over
+        //spec| the binary concatenation of the authenticatorData and the hash of the collectedClientData.
+        assertionSignatureValidator.validate(webAuthnAuthenticationData, authenticator.getAttestedCredentialData().getCOSEKey());
+
+        //spec| Step17
+        //spec| If the signature counter value adata.signCount is nonzero or the value stored in conjunction with
+        //spec| credential’s id attribute is nonzero, then run the following sub-step:
+        long presentedCounter = authenticatorData.getSignCount();
+        long storedCounter = authenticator.getCounter();
+        if (presentedCounter > 0 || storedCounter > 0) {
+            //spec| If the signature counter value adata.signCount is
+            //spec| greater than the signature counter value stored in conjunction with credential’s id attribute.
+            if (presentedCounter > storedCounter) {
+
+                //spec| Update the stored signature counter value, associated with credential’s id attribute, to be the value of authData.signCount.
+
+                //      (caller need to update the signature counter value based on the value set in the Authenticator instance)
+                authenticator.setCounter(presentedCounter);
+            }
+            //spec| less than or equal to the signature counter value stored in conjunction with credential’s id attribute.
+            else {
+                maliciousCounterValueHandler.maliciousCounterValueDetected(null, authenticator);
+            }
+        }
+
+        for (CustomAuthenticationValidator customAuthenticationValidator : customAuthenticationValidators) {
+            customAuthenticationValidator.validate(authenticationObject);
+        }
+
+        //spec| Step18
+        //spec| If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the authentication ceremony.
+
+
+
+    }
+
+
+    void validateAuthenticatorData(AuthenticatorData authenticatorData) {
+        if (authenticatorData.getAttestedCredentialData() != null) {
+            throw new ConstraintViolationException("attestedCredentialData must be null on authentication");
+        }
+    }
+
+    public MaliciousCounterValueHandler getMaliciousCounterValueHandler() {
+        return maliciousCounterValueHandler;
+    }
+
+    public void setMaliciousCounterValueHandler(MaliciousCounterValueHandler maliciousCounterValueHandler) {
+        AssertUtil.notNull(maliciousCounterValueHandler, "maliciousCounterValueHandler must not be null");
+        this.maliciousCounterValueHandler = maliciousCounterValueHandler;
+    }
+
+    public List<CustomAuthenticationValidator> getCustomAuthenticationValidators() {
+        return customAuthenticationValidators;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidator.java
@@ -111,11 +111,10 @@ public class WebAuthnAuthenticationDataValidator {
 
         byte[] credentialId = webAuthnAuthenticationData.getCredentialId();
         Authenticator authenticator = webAuthnAuthenticationParameters.getAuthenticator();
-        LocalDateTime timestamp = webAuthnAuthenticationParameters.getTimestamp();
 
         AuthenticationObject authenticationObject = new AuthenticationObject(
                 credentialId, collectedClientData, cData, authenticatorData, aData, clientExtensions,
-                serverProperty, authenticator, timestamp
+                serverProperty, authenticator
         );
 
         //spec| Step7

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidationResponse.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidationResponse.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.validator;
 
+import com.webauthn4j.WebAuthnManager;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.client.CollectedClientData;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
@@ -25,7 +26,9 @@ import java.util.Objects;
 
 /**
  * Envelope class for WebAuthnRegistrationContext validation result
+ * @deprecated {@link WebAuthnRegistrationContextValidator} is deprecated. please use {@link WebAuthnManager} instead.
  */
+@Deprecated
 public class WebAuthnRegistrationContextValidationResponse {
 
     // ~ Instance fields

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
@@ -17,24 +17,13 @@
 package com.webauthn4j.validator;
 
 
-import com.webauthn4j.converter.AttestationObjectConverter;
-import com.webauthn4j.converter.AuthenticationExtensionsClientOutputsConverter;
-import com.webauthn4j.converter.AuthenticatorTransportConverter;
-import com.webauthn4j.converter.CollectedClientDataConverter;
+import com.webauthn4j.data.WebAuthnRegistrationData;
+import com.webauthn4j.WebAuthnManager;
+import com.webauthn4j.data.WebAuthnRegistrationParameters;
+import com.webauthn4j.data.WebAuthnRegistrationRequest;
 import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.CborConverter;
 import com.webauthn4j.converter.util.JsonConverter;
-import com.webauthn4j.data.AuthenticatorTransport;
-import com.webauthn4j.data.WebAuthnRegistrationContext;
-import com.webauthn4j.data.attestation.AttestationObject;
-import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
-import com.webauthn4j.data.client.ClientDataType;
-import com.webauthn4j.data.client.CollectedClientData;
-import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
-import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
-import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
-import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
-import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.util.exception.WebAuthnException;
 import com.webauthn4j.validator.attestation.statement.AttestationStatementValidator;
@@ -51,32 +40,24 @@ import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.NullECDAATrust
 import com.webauthn4j.validator.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.self.NullSelfAttestationTrustworthinessValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.self.SelfAttestationTrustworthinessValidator;
-import com.webauthn4j.validator.exception.*;
+import com.webauthn4j.validator.exception.ValidationException;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
- * Validates the specified {@link WebAuthnRegistrationContext} instance
+ * Validates the specified {@link com.webauthn4j.data.WebAuthnRegistrationContext} instance
  */
 public class WebAuthnRegistrationContextValidator {
 
     // ~ Instance fields
     // ================================================================================================
 
-    private final CollectedClientDataConverter collectedClientDataConverter;
-    private final AttestationObjectConverter attestationObjectConverter;
-    private final AuthenticatorTransportConverter authenticatorTransportConverter;
-    private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter;
-
-    private final ChallengeValidator challengeValidator = new ChallengeValidator();
-    private final OriginValidator originValidator = new OriginValidator();
-    private final TokenBindingValidator tokenBindingValidator = new TokenBindingValidator();
-    private final RpIdHashValidator rpIdHashValidator = new RpIdHashValidator();
-    private final ExtensionValidator extensionValidator = new ExtensionValidator();
     private final List<CustomRegistrationValidator> customRegistrationValidators = new ArrayList<>();
 
-    private final AttestationValidator attestationValidator;
-
+    private final WebAuthnManager webAuthnManager;
 
     // ~ Constructor
     // ========================================================================================================
@@ -140,17 +121,15 @@ public class WebAuthnRegistrationContextValidator {
         AssertUtil.notNull(jsonConverter, "jsonConverter must not be null");
         AssertUtil.notNull(cborConverter, "cborConverter must not be null");
 
-
-        collectedClientDataConverter = new CollectedClientDataConverter(jsonConverter);
-        attestationObjectConverter = new AttestationObjectConverter(cborConverter);
-        authenticatorTransportConverter = new AuthenticatorTransportConverter();
-        authenticationExtensionsClientOutputsConverter = new AuthenticationExtensionsClientOutputsConverter(jsonConverter);
-
-        this.attestationValidator = new AttestationValidator(
+        this.webAuthnManager = new WebAuthnManager(
                 attestationStatementValidators,
                 certPathTrustworthinessValidator,
                 ecdaaTrustworthinessValidator,
-                selfAttestationTrustworthinessValidator);
+                selfAttestationTrustworthinessValidator,
+                customRegistrationValidators,
+                Collections.emptyList(),
+                jsonConverter,
+                cborConverter);
     }
 
 
@@ -197,142 +176,39 @@ public class WebAuthnRegistrationContextValidator {
     /**
      * validates WebAuthn registration request
      *
-     * @param registrationContext registration context
+     * @param webAuthnRegistrationContext registration context
      * @return validation result
      * @throws DataConversionException if the input cannot be parsed
      * @throws ValidationException     if the input is not valid from the point of WebAuthn validation steps
      * @throws WebAuthnException       if WebAuthn error occurred
      */
     @SuppressWarnings("squid:RedundantThrowsDeclarationCheck")
-    public WebAuthnRegistrationContextValidationResponse validate(WebAuthnRegistrationContext registrationContext) throws WebAuthnException {
+    public WebAuthnRegistrationContextValidationResponse validate(com.webauthn4j.data.WebAuthnRegistrationContext webAuthnRegistrationContext) throws WebAuthnException {
 
-        BeanAssertUtil.validate(registrationContext);
-
-        byte[] clientDataBytes = registrationContext.getClientDataJSON();
-        byte[] attestationObjectBytes = registrationContext.getAttestationObject();
-
-        CollectedClientData collectedClientData = collectedClientDataConverter.convert(clientDataBytes);
-        AttestationObject attestationObject = attestationObjectConverter.convert(attestationObjectBytes);
-        Set<AuthenticatorTransport> transports = authenticatorTransportConverter.convertSet(registrationContext.getTransports());
-        AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions =
-                authenticationExtensionsClientOutputsConverter.convert(registrationContext.getClientExtensionsJSON());
-
-        BeanAssertUtil.validate(collectedClientData);
-        BeanAssertUtil.validate(attestationObject);
-        BeanAssertUtil.validateAuthenticationExtensionsClientOutputs(clientExtensions);
-
-        validateAuthenticatorDataField(attestationObject.getAuthenticatorData());
-
-        byte[] authenticatorDataBytes = attestationObjectConverter.extractAuthenticatorData(attestationObjectBytes);
-
-        RegistrationObject registrationObject = new RegistrationObject(
-                collectedClientData,
-                clientDataBytes,
-                attestationObject,
-                attestationObjectBytes,
-                authenticatorDataBytes,
-                transports,
-                clientExtensions,
-                registrationContext.getServerProperty()
+        WebAuthnRegistrationRequest webAuthnRegistrationRequest = new WebAuthnRegistrationRequest(
+                webAuthnRegistrationContext.getAttestationObject(),
+                webAuthnRegistrationContext.getClientDataJSON(),
+                webAuthnRegistrationContext.getClientExtensionsJSON(),
+                webAuthnRegistrationContext.getTransports()
+        );
+        WebAuthnRegistrationParameters webAuthnRegistrationParameters = new WebAuthnRegistrationParameters(
+                webAuthnRegistrationContext.getServerProperty(),
+                webAuthnRegistrationContext.isUserVerificationRequired(),
+                webAuthnRegistrationContext.isUserPresenceRequired(),
+                webAuthnRegistrationContext.getExpectedExtensionIds()
         );
 
-        AuthenticatorData<RegistrationExtensionAuthenticatorOutput> authenticatorData = attestationObject.getAuthenticatorData();
-        ServerProperty serverProperty = registrationContext.getServerProperty();
+        WebAuthnRegistrationData webAuthnRegistrationData = webAuthnManager.parseRegistrationRequest(webAuthnRegistrationRequest);
+        webAuthnRegistrationData.validate(webAuthnRegistrationParameters);
 
-        //spec| Step3
-        //spec| Verify that the value of C.type is webauthn.create.
-        if (!Objects.equals(collectedClientData.getType(), ClientDataType.CREATE)) {
-            throw new MaliciousDataException("ClientData.type must be 'create' on registration, but it isn't.");
-        }
-
-        //spec| Step4
-        //spec| Verify that the value of C.challenge matches the challenge that was sent to the authenticator in the create() call.
-        challengeValidator.validate(collectedClientData, serverProperty);
-
-        //spec| Step5
-        //spec| Verify that the value of C.origin matches the Relying Party's origin.
-        originValidator.validate(collectedClientData, serverProperty);
-
-        //spec| Step6
-        //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
-        //spec| which the assertion was obtained. If Token Binding was used on that TLS connection, also verify that
-        //spec| C.tokenBinding.id matches the base64url encoding of the Token Binding ID for the connection.
-        tokenBindingValidator.validate(collectedClientData.getTokenBinding(), serverProperty.getTokenBindingId());
-
-        //spec| Step7
-        //spec| Compute the hash of response.clientDataJSON using SHA-256.
-
-        //spec| Step8
-        //spec| Perform CBOR decoding on the attestationObject field of the AuthenticatorAttestationResponse structure to
-        //spec| obtain the attestation statement format fmt, the authenticator data authData, and the attestation statement attStmt.
-
-        //spec| Step9
-        //spec| Verify that the RP ID hash in authData is indeed the SHA-256 hash of the RP ID expected by the RP.
-        rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
-
-
-        //spec| Step10, 11
-        validateUVUPFlags(authenticatorData, registrationContext.isUserVerificationRequired(), registrationContext.isUserPresenceRequired());
-
-        //spec| Step12
-        //spec| Verify that the values of the client extension outputs in clientExtensionResults and the authenticator
-        //spec| extension outputs in the extensions in authData are as expected, considering the client extension input
-        //spec| values that were given as the extensions option in the create() call. In particular, any extension identifier
-        //spec| values in the clientExtensionResults and the extensions in authData MUST be also be present as extension
-        //spec| identifier values in the extensions member of options, i.e., no extensions are present that were not requested.
-        //spec| In the general case, the meaning of "are as expected" is specific to the Relying Party and which extensions are in use.
-        AuthenticationExtensionsAuthenticatorOutputs<RegistrationExtensionAuthenticatorOutput> authenticationExtensionsAuthenticatorOutputs = authenticatorData.getExtensions();
-        List<String> expectedExtensionIdentifiers = registrationContext.getExpectedExtensionIds();
-        extensionValidator.validate(clientExtensions, authenticationExtensionsAuthenticatorOutputs, expectedExtensionIdentifiers);
-
-        //spec| Step13-16,19
-        attestationValidator.validate(registrationObject);
-
-        //spec| Step17
-        //spec| Check that the credentialId is not yet registered to any other user. If registration is requested for
-        //spec| a credential that is already registered to a different user, the Relying Party SHOULD fail this registration
-        //spec| ceremony, or it MAY decide to accept the registration, e.g. while deleting the older registration.
-
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
-
-        //spec| Step18
-        //spec| If the attestation statement attStmt verified successfully and is found to be trustworthy,
-        //spec| then register the new credential with the account that was denoted in the options.user passed to create(),
-        //spec| by associating it with the credential ID and credential public key contained in authData’s attestation data,
-        //spec| as appropriate for the Relying Party's systems.
-
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
-
-        // validate with custom logic
-        for (CustomRegistrationValidator customRegistrationValidator : customRegistrationValidators) {
-            customRegistrationValidator.validate(registrationObject);
-        }
-
-        return new WebAuthnRegistrationContextValidationResponse(collectedClientData, attestationObject, clientExtensions);
-    }
-
-    void validateAuthenticatorDataField(AuthenticatorData authenticatorData) {
-        // attestedCredentialData must be present on registration
-        if (authenticatorData.getAttestedCredentialData() == null) {
-            throw new ConstraintViolationException("attestedCredentialData must not be null on registration");
-        }
-    }
-
-    void validateUVUPFlags(AuthenticatorData authenticatorData, boolean isUserVerificationRequired, boolean isUserPresenceRequired) {
-        //spec| Step10
-        //spec| If user verification is required for this registration, verify that the User Verified bit of the flags in authData is set.
-        if (isUserVerificationRequired && !authenticatorData.isFlagUV()) {
-            throw new UserNotVerifiedException("Validator is configured to check user verified, but UV flag in authenticatorData is not set.");
-        }
-
-        //spec| Step11
-        //spec| Verify that the User Present bit of the flags in authData is set.
-        if (isUserPresenceRequired && !authenticatorData.isFlagUP()) {
-            throw new UserNotPresentException("Validator is configured to check user present, but UP flag in authenticatorData is not set.");
-        }
+        return new WebAuthnRegistrationContextValidationResponse(
+                webAuthnRegistrationData.getCollectedClientData(),
+                webAuthnRegistrationData.getAttestationObject(),
+                webAuthnRegistrationData.getClientExtensions());
     }
 
     public List<CustomRegistrationValidator> getCustomRegistrationValidators() {
         return customRegistrationValidators;
     }
+
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidator.java
@@ -49,7 +49,9 @@ import java.util.List;
 
 /**
  * Validates the specified {@link com.webauthn4j.data.WebAuthnRegistrationContext} instance
+ * @deprecated {@link WebAuthnRegistrationContextValidator} is deprecated. please use {@link WebAuthnManager} instead.
  */
+@Deprecated
 public class WebAuthnRegistrationContextValidator {
 
     // ~ Instance fields

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidator.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.validator;
+
+import com.webauthn4j.data.WebAuthnRegistrationData;
+import com.webauthn4j.converter.AttestationObjectConverter;
+import com.webauthn4j.converter.util.CborConverter;
+import com.webauthn4j.converter.util.JsonConverter;
+import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.WebAuthnRegistrationParameters;
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.data.client.ClientDataType;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.util.AssertUtil;
+import com.webauthn4j.validator.attestation.statement.AttestationStatementValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.ECDAATrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.self.SelfAttestationTrustworthinessValidator;
+import com.webauthn4j.validator.exception.ConstraintViolationException;
+import com.webauthn4j.validator.exception.MaliciousDataException;
+import com.webauthn4j.validator.exception.UserNotPresentException;
+import com.webauthn4j.validator.exception.UserNotVerifiedException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class WebAuthnRegistrationDataValidator {
+
+    // ~ Instance fields
+    // ================================================================================================
+
+    private final ChallengeValidator challengeValidator = new ChallengeValidator();
+    private final OriginValidator originValidator = new OriginValidator();
+    private final TokenBindingValidator tokenBindingValidator = new TokenBindingValidator();
+    private final RpIdHashValidator rpIdHashValidator = new RpIdHashValidator();
+    private final ExtensionValidator extensionValidator = new ExtensionValidator();
+
+    private final List<CustomRegistrationValidator> customRegistrationValidators = new ArrayList<>();
+
+    private final AttestationValidator attestationValidator;
+
+    private final AttestationObjectConverter attestationObjectConverter;
+
+    public WebAuthnRegistrationDataValidator(
+            List<AttestationStatementValidator> attestationStatementValidators,
+            CertPathTrustworthinessValidator certPathTrustworthinessValidator,
+            ECDAATrustworthinessValidator ecdaaTrustworthinessValidator,
+            SelfAttestationTrustworthinessValidator selfAttestationTrustworthinessValidator,
+            List<CustomRegistrationValidator> customRegistrationValidators,
+            JsonConverter jsonConverter,
+            CborConverter cborConverter
+    ) {
+        AssertUtil.notNull(attestationStatementValidators, "attestationStatementValidators must not be null");
+        AssertUtil.notNull(certPathTrustworthinessValidator, "certPathTrustworthinessValidator must not be null");
+        AssertUtil.notNull(ecdaaTrustworthinessValidator, "ecdaaTrustworthinessValidator must not be null");
+        AssertUtil.notNull(selfAttestationTrustworthinessValidator, "selfAttestationTrustworthinessValidator must not be null");
+        AssertUtil.notNull(customRegistrationValidators, "customRegistrationValidators must not be null");
+        AssertUtil.notNull(jsonConverter, "jsonConverter must not be null");
+        AssertUtil.notNull(cborConverter, "cborConverter must not be null");
+
+        attestationObjectConverter = new AttestationObjectConverter(cborConverter);
+
+        this.attestationValidator = new AttestationValidator(
+                attestationStatementValidators,
+                certPathTrustworthinessValidator,
+                ecdaaTrustworthinessValidator,
+                selfAttestationTrustworthinessValidator);
+    }
+
+
+    public void validate(WebAuthnRegistrationData webAuthnRegistrationData, WebAuthnRegistrationParameters webAuthnRegistrationParameters) {
+
+        BeanAssertUtil.validate(webAuthnRegistrationData);
+        BeanAssertUtil.validate(webAuthnRegistrationParameters);
+
+        byte[] clientDataBytes = webAuthnRegistrationData.getCollectedClientDataBytes();
+        byte[] attestationObjectBytes = webAuthnRegistrationData.getAttestationObjectBytes();
+
+        CollectedClientData collectedClientData = webAuthnRegistrationData.getCollectedClientData();
+        AttestationObject attestationObject = webAuthnRegistrationData.getAttestationObject();
+        Set<AuthenticatorTransport> transports = webAuthnRegistrationData.getTransports();
+        AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions = webAuthnRegistrationData.getClientExtensions();
+
+        validateAuthenticatorDataField(attestationObject.getAuthenticatorData());
+
+        byte[] authenticatorDataBytes = attestationObjectConverter.extractAuthenticatorData(attestationObjectBytes);
+        ServerProperty serverProperty = webAuthnRegistrationParameters.getServerProperty();
+
+        RegistrationObject registrationObject = new RegistrationObject(
+                collectedClientData,
+                clientDataBytes,
+                attestationObject,
+                attestationObjectBytes,
+                authenticatorDataBytes,
+                transports,
+                clientExtensions,
+                serverProperty
+        );
+
+        AuthenticatorData<RegistrationExtensionAuthenticatorOutput> authenticatorData = attestationObject.getAuthenticatorData();
+
+        //spec| Step3
+        //spec| Verify that the value of C.type is webauthn.create.
+        if (!Objects.equals(collectedClientData.getType(), ClientDataType.CREATE)) {
+            throw new MaliciousDataException("ClientData.type must be 'create' on registration, but it isn't.");
+        }
+
+        //spec| Step4
+        //spec| Verify that the value of C.challenge matches the challenge that was sent to the authenticator in the create() call.
+        challengeValidator.validate(collectedClientData, serverProperty);
+
+        //spec| Step5
+        //spec| Verify that the value of C.origin matches the Relying Party's origin.
+        originValidator.validate(collectedClientData, serverProperty);
+
+        //spec| Step6
+        //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
+        //spec| which the assertion was obtained. If Token Binding was used on that TLS connection, also verify that
+        //spec| C.tokenBinding.id matches the base64url encoding of the Token Binding ID for the connection.
+        tokenBindingValidator.validate(collectedClientData.getTokenBinding(), serverProperty.getTokenBindingId());
+
+        //spec| Step7
+        //spec| Compute the hash of response.clientDataJSON using SHA-256.
+
+        //spec| Step8
+        //spec| Perform CBOR decoding on the attestationObject field of the AuthenticatorAttestationResponse structure to
+        //spec| obtain the attestation statement format fmt, the authenticator data authData, and the attestation statement attStmt.
+
+        //spec| Step9
+        //spec| Verify that the RP ID hash in authData is indeed the SHA-256 hash of the RP ID expected by the RP.
+        rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
+
+
+        //spec| Step10, 11
+        validateUVUPFlags(authenticatorData, webAuthnRegistrationParameters.isUserVerificationRequired(), webAuthnRegistrationParameters.isUserPresenceRequired());
+
+        //spec| Step12
+        //spec| Verify that the values of the client extension outputs in clientExtensionResults and the authenticator
+        //spec| extension outputs in the extensions in authData are as expected, considering the client extension input
+        //spec| values that were given as the extensions option in the create() call. In particular, any extension identifier
+        //spec| values in the clientExtensionResults and the extensions in authData MUST be also be present as extension
+        //spec| identifier values in the extensions member of options, i.e., no extensions are present that were not requested.
+        //spec| In the general case, the meaning of "are as expected" is specific to the Relying Party and which extensions are in use.
+        AuthenticationExtensionsAuthenticatorOutputs<RegistrationExtensionAuthenticatorOutput> authenticationExtensionsAuthenticatorOutputs = authenticatorData.getExtensions();
+        List<String> expectedExtensionIdentifiers = webAuthnRegistrationParameters.getExpectedExtensionIds();
+        extensionValidator.validate(clientExtensions, authenticationExtensionsAuthenticatorOutputs, expectedExtensionIdentifiers);
+
+        //spec| Step13-16,19
+        attestationValidator.validate(registrationObject);
+
+        //spec| Step17
+        //spec| Check that the credentialId is not yet registered to any other user. If registration is requested for
+        //spec| a credential that is already registered to a different user, the Relying Party SHOULD fail this registration
+        //spec| ceremony, or it MAY decide to accept the registration, e.g. while deleting the older registration.
+
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+
+        //spec| Step18
+        //spec| If the attestation statement attStmt verified successfully and is found to be trustworthy,
+        //spec| then register the new credential with the account that was denoted in the options.user passed to create(),
+        //spec| by associating it with the credential ID and credential public key contained in authData’s attestation data,
+        //spec| as appropriate for the Relying Party's systems.
+
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+
+        // validate with custom logic
+        for (CustomRegistrationValidator customRegistrationValidator : customRegistrationValidators) {
+            customRegistrationValidator.validate(registrationObject);
+        }
+    }
+
+    void validateAuthenticatorDataField(AuthenticatorData authenticatorData) {
+        // attestedCredentialData must be present on registration
+        if (authenticatorData.getAttestedCredentialData() == null) {
+            throw new ConstraintViolationException("attestedCredentialData must not be null on registration");
+        }
+    }
+
+    void validateUVUPFlags(AuthenticatorData authenticatorData, boolean isUserVerificationRequired, boolean isUserPresenceRequired) {
+        //spec| Step10
+        //spec| If user verification is required for this registration, verify that the User Verified bit of the flags in authData is set.
+        if (isUserVerificationRequired && !authenticatorData.isFlagUV()) {
+            throw new UserNotVerifiedException("Validator is configured to check user verified, but UV flag in authenticatorData is not set.");
+        }
+
+        //spec| Step11
+        //spec| Verify that the User Present bit of the flags in authData is set.
+        if (isUserPresenceRequired && !authenticatorData.isFlagUP()) {
+            throw new UserNotPresentException("Validator is configured to check user present, but UP flag in authenticatorData is not set.");
+        }
+    }
+
+    public List<CustomRegistrationValidator> getCustomRegistrationValidators() {
+        return customRegistrationValidators;
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnManagerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnManagerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnManagerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebAuthnManagerTest {
+
+    @Test
+    void createNonStrictWebAuthnManager_test(){
+        assertThat(WebAuthnManager.createNonStrictWebAuthnManager()).isNotNull();
+    }
+
+    @Test
+    void getter_test(){
+        WebAuthnManager webAuthnManager = WebAuthnManager.createNonStrictWebAuthnManager();
+        assertThat(webAuthnManager.getWebAuthnRegistrationDataValidator()).isNotNull();
+        assertThat(webAuthnManager.getWebAuthnAuthenticationDataValidator()).isNotNull();
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/authenticator/AuthenticatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/authenticator/AuthenticatorTest.java
@@ -26,6 +26,7 @@ import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenti
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
 import com.webauthn4j.test.TestAttestationStatementUtil;
 import com.webauthn4j.test.TestDataUtil;
+import com.webauthn4j.util.CollectionUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -72,7 +73,7 @@ class AuthenticatorTest {
                 @JsonProperty("authenticatorExtensions") Map<String, RegistrationExtensionAuthenticatorOutput> authenticatorExtensions) {
             this.attestedCredentialData = attestedCredentialData;
             this.attestationStatement = attestationStatement;
-            this.transports = Collections.unmodifiableSet(transports);
+            this.transports = CollectionUtil.unmodifiableSet(transports);
             this.clientExtensions = clientExtensions;
             this.authenticatorExtensions = authenticatorExtensions;
             setCounter(counter);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationDataTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationDataTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationDataTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.validator.WebAuthnAuthenticationDataValidator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+
+class WebAuthnAuthenticationDataTest {
+
+    @Test
+    void equals_hashCode_test(){
+
+        WebAuthnAuthenticationDataValidator webAuthnAuthenticationDataValidator = mock(WebAuthnAuthenticationDataValidator.class);
+        byte[] credentialId = new byte[32];
+        byte[] userHandle = new byte[32];
+        AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData = null;
+        byte[] authenticatorDataBytes = new byte[64];
+        CollectedClientData collectedClientData = mock(CollectedClientData.class);
+        byte[] collectedClientDataBytes = new byte[128];
+        String clientExtensionJSON = "";
+        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> authenticationExtensionsClientOutputs = null;
+        byte[] signature = new byte[32];
+
+        WebAuthnAuthenticationData instanceA = new WebAuthnAuthenticationData(
+                webAuthnAuthenticationDataValidator,
+                credentialId,
+                userHandle,
+                authenticatorData,
+                authenticatorDataBytes,
+                collectedClientData,
+                collectedClientDataBytes,
+                authenticationExtensionsClientOutputs,
+                signature
+        );
+        WebAuthnAuthenticationData instanceB = new WebAuthnAuthenticationData(
+                webAuthnAuthenticationDataValidator,
+                credentialId,
+                userHandle,
+                authenticatorData,
+                authenticatorDataBytes,
+                collectedClientData,
+                collectedClientDataBytes,
+                authenticationExtensionsClientOutputs,
+                signature
+        );
+
+        assertThat(instanceA).isEqualTo(instanceB);
+        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationParametersTest.java
@@ -22,7 +22,7 @@ import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.server.ServerProperty;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -68,7 +68,6 @@ class WebAuthnAuthenticationParametersTest {
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
         Authenticator authenticator = null;
-        LocalDateTime timestamp = LocalDateTime.now();
 
         // expectations
         boolean userVerificationRequired = true;
@@ -79,7 +78,6 @@ class WebAuthnAuthenticationParametersTest {
                 new WebAuthnAuthenticationParameters(
                         serverProperty,
                         authenticator,
-                        timestamp,
                         userVerificationRequired,
                         userPresenceRequired,
                         expectedExtensionIds
@@ -88,7 +86,6 @@ class WebAuthnAuthenticationParametersTest {
                 new WebAuthnAuthenticationParameters(
                         serverProperty,
                         authenticator,
-                        timestamp,
                         userVerificationRequired,
                         userPresenceRequired,
                         expectedExtensionIds

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationParametersTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.data.client.Origin;
+import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.server.ServerProperty;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebAuthnAuthenticationParametersTest {
+
+    @Test
+    void constructor_test(){
+        // Server properties
+        Origin origin = null /* set origin */;
+        String rpId = null /* set rpId */;
+        Challenge challenge = null /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        Authenticator authenticator = null;
+
+        // expectations
+        boolean userVerificationRequired = true;
+
+        WebAuthnAuthenticationParameters webAuthnAuthenticationParameters =
+                new WebAuthnAuthenticationParameters(
+                        serverProperty,
+                        authenticator,
+                        userVerificationRequired
+                );
+
+        assertThat(webAuthnAuthenticationParameters.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(webAuthnAuthenticationParameters.getAuthenticator()).isEqualTo(authenticator);
+        assertThat(webAuthnAuthenticationParameters.isUserVerificationRequired()).isEqualTo(userVerificationRequired);
+        assertThat(webAuthnAuthenticationParameters.isUserPresenceRequired()).isTrue();
+        assertThat(webAuthnAuthenticationParameters.getExpectedExtensionIds()).isNull();
+    }
+
+    @Test
+    void equals_hashCode_test(){
+        // Server properties
+        Origin origin = null /* set origin */;
+        String rpId = null /* set rpId */;
+        Challenge challenge = null /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        Authenticator authenticator = null;
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        // expectations
+        boolean userVerificationRequired = true;
+        boolean userPresenceRequired = true;
+        List<String> expectedExtensionIds = Collections.emptyList();
+
+        WebAuthnAuthenticationParameters instanceA =
+                new WebAuthnAuthenticationParameters(
+                        serverProperty,
+                        authenticator,
+                        timestamp,
+                        userVerificationRequired,
+                        userPresenceRequired,
+                        expectedExtensionIds
+                );
+        WebAuthnAuthenticationParameters instanceB =
+                new WebAuthnAuthenticationParameters(
+                        serverProperty,
+                        authenticator,
+                        timestamp,
+                        userVerificationRequired,
+                        userPresenceRequired,
+                        expectedExtensionIds
+                );
+
+        assertThat(instanceA).isEqualTo(instanceB);
+        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationRequestTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationRequestTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnAuthenticationRequestTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebAuthnAuthenticationRequestTest {
+
+    @Test
+    void equals_hashCode_test(){
+        // Client properties
+        byte[] credentialId = null /* set credentialId */;
+        byte[] userHandle = null /* set userHandle */;
+        byte[] authenticatorData = null /* set authenticatorData */;
+        byte[] clientDataJSON = null /* set clientDataJSON */;
+        String clientExtensionJSON = null /* set clientExtensionJSON */;
+        byte[] signature = null /* set signature */;
+
+        WebAuthnAuthenticationRequest instanceA =
+                new WebAuthnAuthenticationRequest(
+                        credentialId,
+                        userHandle,
+                        authenticatorData,
+                        clientDataJSON,
+                        clientExtensionJSON,
+                        signature
+                );
+        WebAuthnAuthenticationRequest instanceB =
+                new WebAuthnAuthenticationRequest(
+                        credentialId,
+                        userHandle,
+                        authenticatorData,
+                        clientDataJSON,
+                        clientExtensionJSON,
+                        signature
+                );
+
+        assertThat(instanceA).isEqualTo(instanceB);
+        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+    }
+
+
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationDataTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationDataTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import com.webauthn4j.validator.WebAuthnRegistrationDataValidator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class WebAuthnRegistrationDataTest {
+
+    @Test
+    void equals_hashCode_test(){
+
+        WebAuthnRegistrationDataValidator webAuthnRegistrationDataValidator = mock(WebAuthnRegistrationDataValidator.class);
+        AttestationObject attestationObject = mock(AttestationObject.class);
+        byte[] attestationObjectBytes = new byte[32];
+        CollectedClientData collectedClientData = mock(CollectedClientData.class);
+        byte[] collectedClientDataBytes = new byte[128];
+        String clientExtensionJSON = "";
+        AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = null;
+        Set<AuthenticatorTransport> transports = Collections.emptySet();
+
+        WebAuthnRegistrationData instanceA = new WebAuthnRegistrationData(
+                webAuthnRegistrationDataValidator,
+                attestationObject,
+                attestationObjectBytes,
+                collectedClientData,
+                collectedClientDataBytes,
+                authenticationExtensionsClientOutputs,
+                transports
+        );
+        WebAuthnRegistrationData instanceB = new WebAuthnRegistrationData(
+                webAuthnRegistrationDataValidator,
+                attestationObject,
+                attestationObjectBytes,
+                collectedClientData,
+                collectedClientDataBytes,
+                authenticationExtensionsClientOutputs,
+                transports
+        );
+
+        assertThat(instanceA).isEqualTo(instanceB);
+        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationDataTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationParametersTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+
+import com.webauthn4j.data.client.Origin;
+import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.server.ServerProperty;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebAuthnRegistrationParametersTest {
+
+    @Test
+    void equals_hashCode_test(){
+        // Server properties
+        Origin origin = null /* set origin */;
+        String rpId = null /* set rpId */;
+        Challenge challenge = null /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        // expectations
+        boolean userVerificationRequired = true;
+
+        WebAuthnRegistrationParameters instanceA =
+                new WebAuthnRegistrationParameters(
+                        serverProperty,
+                        userVerificationRequired
+                );
+        WebAuthnRegistrationParameters instanceB =
+                new WebAuthnRegistrationParameters(
+                        serverProperty,
+                        userVerificationRequired
+                );
+
+        assertThat(instanceA).isEqualTo(instanceB);
+        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationRequestTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationRequestTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/WebAuthnRegistrationRequestTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebAuthnRegistrationRequestTest {
+
+    @Test
+    void constructor_test(){
+        // Client properties
+        byte[] attestationObject = new byte[32];
+        byte[] clientDataJSON = new byte[64];
+        String clientExtensionJSON = "{}";  /* set clientExtensionJSON */;
+        Set<String> transports = Collections.singleton("USB");
+
+        WebAuthnRegistrationRequest webAuthnRegistrationRequest = new WebAuthnRegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
+        assertThat(webAuthnRegistrationRequest.getAttestationObject()).isEqualTo(attestationObject);
+        assertThat(webAuthnRegistrationRequest.getClientDataJSON()).isEqualTo(clientDataJSON);
+        assertThat(webAuthnRegistrationRequest.getClientExtensionsJSON()).isEqualTo(clientExtensionJSON);
+        assertThat(webAuthnRegistrationRequest.getTransports()).isEqualTo(transports);
+    }
+
+    @Test
+    void equals_hashCode_test(){
+        // Client properties
+        byte[] attestationObject = null /* set attestationObject */;
+        byte[] clientDataJSON = null /* set clientDataJSON */;
+
+        WebAuthnRegistrationRequest instanceA = new WebAuthnRegistrationRequest(attestationObject, clientDataJSON);
+        WebAuthnRegistrationRequest instanceB = new WebAuthnRegistrationRequest(attestationObject, clientDataJSON);
+
+        assertThat(instanceA).isEqualTo(instanceB);
+        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationObjectTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationObjectTest.java
@@ -52,7 +52,6 @@ class AuthenticationObjectTest {
         AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
         Authenticator authenticator = TestDataUtil.createAuthenticator();
-        LocalDateTime timestamp = LocalDateTime.now();
         AuthenticationObject authenticationObject = new AuthenticationObject(
                 credentialId,
                 clientData,
@@ -61,8 +60,7 @@ class AuthenticationObjectTest {
                 authenticatorDataBytes,
                 clientExtensions,
                 serverProperty,
-                authenticator,
-                timestamp
+                authenticator
         );
 
         assertAll(
@@ -73,8 +71,7 @@ class AuthenticationObjectTest {
                 () -> assertThat(authenticationObject.getAuthenticatorDataBytes()).isEqualTo(authenticatorDataBytes),
                 () -> assertThat(authenticationObject.getClientExtensions()).isEqualTo(clientExtensions),
                 () -> assertThat(authenticationObject.getServerProperty()).isEqualTo(serverProperty),
-                () -> assertThat(authenticationObject.getAuthenticator()).isEqualTo(authenticator),
-                () -> assertThat(authenticationObject.getTimestamp()).isEqualTo(timestamp)
+                () -> assertThat(authenticationObject.getAuthenticator()).isEqualTo(authenticator)
         );
     }
 
@@ -89,7 +86,6 @@ class AuthenticationObjectTest {
         AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
         Authenticator authenticator = TestDataUtil.createAuthenticator();
-        LocalDateTime timestamp = LocalDateTime.now();
 
         AuthenticationObject instanceA = new AuthenticationObject(
                 credentialId,
@@ -99,8 +95,7 @@ class AuthenticationObjectTest {
                 authenticatorDataBytes,
                 clientExtensions,
                 serverProperty,
-                authenticator,
-                timestamp
+                authenticator
         );
 
         AuthenticationObject instanceB = new AuthenticationObject(
@@ -111,8 +106,7 @@ class AuthenticationObjectTest {
                 authenticatorDataBytes,
                 clientExtensions,
                 serverProperty,
-                authenticator,
-                timestamp
+                authenticator
         );
 
         assertAll(

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
@@ -16,22 +16,434 @@
 
 package com.webauthn4j.validator;
 
-import com.webauthn4j.data.WebAuthnAuthenticationContext;
-import com.webauthn4j.data.WebAuthnRegistrationContext;
+import com.webauthn4j.data.*;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.client.*;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
 import com.webauthn4j.test.TestAttestationStatementUtil;
 import com.webauthn4j.test.TestDataUtil;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 class BeanAssertUtilTest {
+
+    @Test
+    void validate_WebAuthnRegistrationData_test(){
+        WebAuthnRegistrationData webAuthnRegistrationData = new WebAuthnRegistrationData(
+                mock(WebAuthnRegistrationDataValidator.class),
+                TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.CREATE),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new HashSet<>()
+        );
+        BeanAssertUtil.validate(webAuthnRegistrationData);
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationData_with_null_test(){
+        assertThrows(ConstraintViolationException.class,
+            ()-> BeanAssertUtil.validate((WebAuthnRegistrationData)null)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationData_with_webAuthnRegistrationDataValidator_null_test(){
+        WebAuthnRegistrationData webAuthnRegistrationData = new WebAuthnRegistrationData(
+                null,
+                TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.CREATE),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new HashSet<>()
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnRegistrationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationData_with_attestationObject_null_test(){
+        WebAuthnRegistrationData webAuthnRegistrationData = new WebAuthnRegistrationData(
+                mock(WebAuthnRegistrationDataValidator.class),
+                null,
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.CREATE),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new HashSet<>()
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnRegistrationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationData_with_attestationObjectBytes_null_test(){
+        WebAuthnRegistrationData webAuthnRegistrationData = new WebAuthnRegistrationData(
+                mock(WebAuthnRegistrationDataValidator.class),
+                TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement(),
+                null,
+                TestDataUtil.createClientData(ClientDataType.CREATE),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new HashSet<>()
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnRegistrationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationData_with_collectedClientData_null_test(){
+        WebAuthnRegistrationData webAuthnRegistrationData = new WebAuthnRegistrationData(
+                mock(WebAuthnRegistrationDataValidator.class),
+                TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement(),
+                new byte[32],
+                null,
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new HashSet<>()
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnRegistrationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationData_with_clientDataBytes_null_test(){
+        WebAuthnRegistrationData webAuthnRegistrationData = new WebAuthnRegistrationData(
+                mock(WebAuthnRegistrationDataValidator.class),
+                TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.CREATE),
+                null,
+                new AuthenticationExtensionsClientOutputs<>(),
+                new HashSet<>()
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnRegistrationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationData_with_clientExtensions_null_test(){
+        WebAuthnRegistrationData webAuthnRegistrationData = new WebAuthnRegistrationData(
+                mock(WebAuthnRegistrationDataValidator.class),
+                TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.CREATE),
+                new byte[32],
+                null,
+                new HashSet<>()
+        );
+        assertDoesNotThrow(
+                ()-> BeanAssertUtil.validate(webAuthnRegistrationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationData_with_transports_null_test(){
+        WebAuthnRegistrationData webAuthnRegistrationData = new WebAuthnRegistrationData(
+                mock(WebAuthnRegistrationDataValidator.class),
+                TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.CREATE),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                null
+        );
+        assertDoesNotThrow(
+                ()-> BeanAssertUtil.validate(webAuthnRegistrationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationParameters_test(){
+        WebAuthnRegistrationParameters webAuthnRegistrationParameters = new WebAuthnRegistrationParameters(
+                TestDataUtil.createServerProperty(),
+                true
+        );
+        BeanAssertUtil.validate(webAuthnRegistrationParameters);
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationParameters_with_null_test(){
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate((WebAuthnRegistrationParameters)null)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnRegistrationParameters_with_serverProperty_null_test(){
+        WebAuthnRegistrationParameters webAuthnRegistrationParameters = new WebAuthnRegistrationParameters(
+                null,
+                true
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnRegistrationParameters)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationData_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                mock(WebAuthnAuthenticationDataValidator.class),
+                new byte[32],
+                new byte[32],
+                TestDataUtil.createAuthenticatorData(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.GET),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new byte[32]
+        );
+        BeanAssertUtil.validate(webAuthnAuthenticationData);
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationData_with_null_test(){
+
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate((WebAuthnAuthenticationData)null)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationData_with_webAuthnAuthenticationDataValidator_null_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                null,
+                new byte[32],
+                new byte[32],
+                TestDataUtil.createAuthenticatorData(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.GET),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new byte[32]
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationData_with_credentialId_null_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                mock(WebAuthnAuthenticationDataValidator.class),
+                null,
+                new byte[32],
+                TestDataUtil.createAuthenticatorData(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.GET),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new byte[32]
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationData_with_userHandle_null_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                mock(WebAuthnAuthenticationDataValidator.class),
+                new byte[32],
+                null,
+                TestDataUtil.createAuthenticatorData(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.GET),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new byte[32]
+        );
+        assertDoesNotThrow(
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationData_with_authenticatorData_null_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                mock(WebAuthnAuthenticationDataValidator.class),
+                new byte[32],
+                new byte[32],
+                null,
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.GET),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new byte[32]
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationData)
+        );
+    }
+    @Test
+    void validate_WebAuthnAuthenticationData_with_authenticatorDataBytes_null_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                mock(WebAuthnAuthenticationDataValidator.class),
+                new byte[32],
+                new byte[32],
+                TestDataUtil.createAuthenticatorData(),
+                null,
+                TestDataUtil.createClientData(ClientDataType.GET),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new byte[32]
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationData_with_collectedClientData_null_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                mock(WebAuthnAuthenticationDataValidator.class),
+                new byte[32],
+                new byte[32],
+                TestDataUtil.createAuthenticatorData(),
+                new byte[32],
+                null,
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                new byte[32]
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationData)
+        );
+    }
+
+
+    @Test
+    void validate_WebAuthnAuthenticationData_with_clientDataBytes_null_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                mock(WebAuthnAuthenticationDataValidator.class),
+                new byte[32],
+                new byte[32],
+                TestDataUtil.createAuthenticatorData(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.GET),
+                null,
+                new AuthenticationExtensionsClientOutputs<>(),
+                new byte[32]
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationData_with_clientExtensions_null_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                mock(WebAuthnAuthenticationDataValidator.class),
+                new byte[32],
+                new byte[32],
+                TestDataUtil.createAuthenticatorData(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.GET),
+                new byte[32],
+                null,
+                new byte[32]
+        );
+        assertDoesNotThrow(
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationData)
+        );
+    }
+
+
+    @Test
+    void validate_WebAuthnAuthenticationData_with_signature_null_test(){
+        WebAuthnAuthenticationData webAuthnAuthenticationData = new WebAuthnAuthenticationData(
+                mock(WebAuthnAuthenticationDataValidator.class),
+                new byte[32],
+                new byte[32],
+                TestDataUtil.createAuthenticatorData(),
+                new byte[32],
+                TestDataUtil.createClientData(ClientDataType.GET),
+                new byte[32],
+                new AuthenticationExtensionsClientOutputs<>(),
+                null
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationData)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationParameters_test(){
+        WebAuthnAuthenticationParameters webAuthnAuthenticationParameters = new WebAuthnAuthenticationParameters(
+                TestDataUtil.createServerProperty(),
+                TestDataUtil.createAuthenticator(),
+                true,
+                true,
+                new ArrayList<>()
+        );
+        BeanAssertUtil.validate(webAuthnAuthenticationParameters);
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationParameters_with_null_test(){
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate((WebAuthnAuthenticationParameters)null)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationParameters_with_serverProperty_null_test(){
+        WebAuthnAuthenticationParameters webAuthnAuthenticationParameters = new WebAuthnAuthenticationParameters(
+                null,
+                TestDataUtil.createAuthenticator(),
+                true,
+                true,
+                new ArrayList<>()
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationParameters)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationParameters_with_authenticator_null_test(){
+        WebAuthnAuthenticationParameters webAuthnAuthenticationParameters = new WebAuthnAuthenticationParameters(
+                TestDataUtil.createServerProperty(),
+                null,
+                true,
+                true,
+                new ArrayList<>()
+        );
+        assertThrows(ConstraintViolationException.class,
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationParameters)
+        );
+    }
+
+    @Test
+    void validate_WebAuthnAuthenticationParameters_with_expectedExtensionIds_null_test(){
+        WebAuthnAuthenticationParameters webAuthnAuthenticationParameters = new WebAuthnAuthenticationParameters(
+                TestDataUtil.createServerProperty(),
+                TestDataUtil.createAuthenticator(),
+                true,
+                true,
+                null
+        );
+        assertDoesNotThrow(
+                ()-> BeanAssertUtil.validate(webAuthnAuthenticationParameters)
+        );
+    }
 
     @Test
     void validate_WebAuthnAuthenticationContext_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
@@ -143,8 +143,9 @@ class BeanAssertUtilTest {
 
     @Test
     void validate_WebAuthnRegistrationContext_with_null_test() {
+        WebAuthnRegistrationContext nullValue = null;
         assertThrows(ConstraintViolationException.class,
-                () -> BeanAssertUtil.validate((WebAuthnRegistrationContext) null)
+                () -> BeanAssertUtil.validate(nullValue)
         );
     }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidatorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.validator;
+
+import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.validator.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WebAuthnAuthenticationDataValidatorTest {
+
+    private WebAuthnAuthenticationDataValidator target = new WebAuthnAuthenticationDataValidator();
+
+    @Test
+    void validateAuthenticatorData_with_non_null_AttestedCredentialData() {
+        AuthenticatorData authenticatorData = mock(AuthenticatorData.class);
+        AttestedCredentialData attestedCredentialData = mock(AttestedCredentialData.class);
+        when(authenticatorData.getAttestedCredentialData()).thenReturn(attestedCredentialData);
+        assertThatThrownBy(()-> target.validateAuthenticatorData(authenticatorData)).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void getCustomAuthenticationValidators() {
+        CustomAuthenticationValidator customAuthenticationValidator = mock(CustomAuthenticationValidator.class);
+        target.getCustomAuthenticationValidators().add(customAuthenticationValidator);
+        assertThat(target.getCustomAuthenticationValidators()).contains(customAuthenticationValidator);
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnRegistrationContextValidatorTest.java
@@ -17,20 +17,15 @@
 package com.webauthn4j.validator;
 
 
-import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.ECDAATrustworthinessValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.self.SelfAttestationTrustworthinessValidator;
-import com.webauthn4j.validator.exception.ConstraintViolationException;
-import com.webauthn4j.validator.exception.UserNotPresentException;
-import com.webauthn4j.validator.exception.UserNotVerifiedException;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 class WebAuthnRegistrationContextValidatorTest {
@@ -42,7 +37,6 @@ class WebAuthnRegistrationContextValidatorTest {
 
     @Test
     void constructor_test() {
-
         WebAuthnRegistrationContextValidator validator1 = new WebAuthnRegistrationContextValidator(
                 Collections.emptyList(),
                 certPathTrustworthinessValidatorMock,
@@ -60,45 +54,11 @@ class WebAuthnRegistrationContextValidatorTest {
                 selfAttestationTrustworthinessValidator);
 
         assertAll(
-                () -> assertThat(validator1).hasFieldOrProperty("attestationValidator").isNotNull(),
-                () -> assertThat(validator2).hasFieldOrProperty("attestationValidator").isNotNull(),
-                () -> assertThat(validator3).hasFieldOrProperty("attestationValidator").isNotNull()
+                () -> assertThat(validator1).hasFieldOrProperty("webAuthnManager").isNotNull(),
+                () -> assertThat(validator2).hasFieldOrProperty("webAuthnManager").isNotNull(),
+                () -> assertThat(validator3).hasFieldOrProperty("webAuthnManager").isNotNull()
         );
     }
 
-    @Test
-    void validateAuthenticatorDataField_test() {
-        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
-        assertThrows(ConstraintViolationException.class,
-                () -> WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateAuthenticatorDataField(authenticatorData)
-        );
-    }
 
-    @Test
-    void validateUVUPFlags_not_required_test() {
-        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
-        WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, false, false);
-    }
-
-    @Test
-    void validateUVUPFlags_required_test() {
-        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) (AuthenticatorData.BIT_UP | AuthenticatorData.BIT_UV), 0);
-        WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, true, true);
-    }
-
-    @Test
-    void validateUVUPFlags_UserNotVerifiedException_test() {
-        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
-        assertThrows(UserNotVerifiedException.class,
-                () -> WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, true, false)
-        );
-    }
-
-    @Test
-    void validateUVUPFlags_UserNotPresentException_test() {
-        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
-        assertThrows(UserNotPresentException.class,
-                () -> WebAuthnRegistrationContextValidator.createNonStrictRegistrationContextValidator().validateUVUPFlags(authenticatorData, false, true)
-        );
-    }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidatorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.validator;
+
+import com.webauthn4j.converter.util.CborConverter;
+import com.webauthn4j.converter.util.JsonConverter;
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.validator.attestation.statement.androidkey.NullAndroidKeyAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.androidsafetynet.NullAndroidSafetyNetAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.none.NoneAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.packed.NullPackedAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.tpm.NullTPMAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.u2f.NullFIDOU2FAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.certpath.NullCertPathTrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.NullECDAATrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.self.NullSelfAttestationTrustworthinessValidator;
+import com.webauthn4j.validator.exception.ConstraintViolationException;
+import com.webauthn4j.validator.exception.UserNotPresentException;
+import com.webauthn4j.validator.exception.UserNotVerifiedException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class WebAuthnRegistrationDataValidatorTest {
+
+    private WebAuthnRegistrationDataValidator target;
+
+    public WebAuthnRegistrationDataValidatorTest(){
+        JsonConverter jsonConverter = new JsonConverter();
+        CborConverter cborConverter = jsonConverter.getCborConverter();
+
+        target = new WebAuthnRegistrationDataValidator(Arrays.asList(
+                new NoneAttestationStatementValidator(),
+                new NullFIDOU2FAttestationStatementValidator(),
+                new NullPackedAttestationStatementValidator(),
+                new NullTPMAttestationStatementValidator(),
+                new NullAndroidKeyAttestationStatementValidator(),
+                new NullAndroidSafetyNetAttestationStatementValidator()
+        ),
+                new NullCertPathTrustworthinessValidator(),
+                new NullECDAATrustworthinessValidator(),
+                new NullSelfAttestationTrustworthinessValidator(),
+                Collections.emptyList(),
+                jsonConverter,
+                cborConverter);
+    }
+
+    @Test
+    void validateAuthenticatorDataField_test() {
+        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
+        assertThrows(ConstraintViolationException.class,
+                () -> target.validateAuthenticatorDataField(authenticatorData)
+        );
+    }
+
+    @Test
+    void validateUVUPFlags_not_required_test() {
+        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
+        target.validateUVUPFlags(authenticatorData, false, false);
+    }
+
+    @Test
+    void validateUVUPFlags_required_test() {
+        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) (AuthenticatorData.BIT_UP | AuthenticatorData.BIT_UV), 0);
+        target.validateUVUPFlags(authenticatorData, true, true);
+    }
+
+    @Test
+    void validateUVUPFlags_UserNotVerifiedException_test() {
+        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
+        assertThrows(UserNotVerifiedException.class,
+                () -> target.validateUVUPFlags(authenticatorData, true, false)
+        );
+    }
+
+    @Test
+    void validateUVUPFlags_UserNotPresentException_test() {
+        AuthenticatorData authenticatorData = new AuthenticatorData(null, (byte) 0, 0);
+        assertThrows(UserNotPresentException.class,
+                () -> target.validateUVUPFlags(authenticatorData, false, true)
+        );
+    }
+
+    @Test
+    void getCustomRegistrationValidators() {
+        CustomRegistrationValidator customRegistrationValidator = mock(CustomRegistrationValidator.class);
+        target.getCustomRegistrationValidators().add(customRegistrationValidator);
+        assertThat(target.getCustomRegistrationValidators()).contains(customRegistrationValidator);
+    }
+}

--- a/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import com.webauthn4j.WebAuthnManager;
+import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.authenticator.AuthenticatorImpl;
+import com.webauthn4j.converter.exception.DataConversionException;
+import com.webauthn4j.data.*;
+import com.webauthn4j.data.client.Origin;
+import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.validator.exception.ValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class WebAuthnManagerSample {
+
+    private Logger logger = LoggerFactory.getLogger(WebAuthnManagerSample.class);
+
+    private WebAuthnManager webAuthnManager;
+
+    public WebAuthnManagerSample(){
+        // WebAuthnManager.createNonStrictWebAuthnManager() returns a WebAuthnManager instance
+        // which doesn't validate an attestation statement. It is recommended configuration for most web application.
+        // If you are building enterprise web application and need to validate the attestation statement, use the constructor of
+        // WebAuthnManager and provide validators you like
+        webAuthnManager = WebAuthnManager.createNonStrictWebAuthnManager();
+    }
+
+    public void registrationValidationSample() {
+
+        // Client properties
+        byte[] attestationObject = null /* set attestationObject */;
+        byte[] clientDataJSON = null /* set clientDataJSON */;
+        String clientExtensionJSON = null;  /* set clientExtensionJSON */;
+        Set<String> transports = null /* set transports */;
+
+        // Server properties
+        Origin origin = null /* set origin */;
+        String rpId = null /* set rpId */;
+        Challenge challenge = null /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        // expectations
+        boolean userVerificationRequired = false;
+        boolean userPresenceRequired = true;
+        List<String> expectedExtensionIds = Collections.emptyList();
+
+        WebAuthnRegistrationRequest webAuthnRegistrationRequest = new WebAuthnRegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
+        WebAuthnRegistrationParameters webAuthnRegistrationParameters = new WebAuthnRegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
+        WebAuthnRegistrationData webAuthnRegistrationData;
+        try{
+            webAuthnRegistrationData = webAuthnManager.parseRegistrationRequest(webAuthnRegistrationRequest);
+        }
+        catch (DataConversionException e){
+            // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
+            throw e;
+        }
+        try{
+            webAuthnRegistrationData.validate(webAuthnRegistrationParameters);
+        }
+        catch (ValidationException e){
+            // If you would like to handle WebAuthn data validation error, please catch ValidationException
+            throw e;
+        }
+
+        // please persist Authenticator object, which will be used in the authentication process.
+        Authenticator authenticator =
+                new AuthenticatorImpl( // You may create your own Authenticator implementation to save friendly authenticator name
+                        webAuthnRegistrationData.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),
+                        webAuthnRegistrationData.getAttestationObject().getAttestationStatement(),
+                        webAuthnRegistrationData.getAttestationObject().getAuthenticatorData().getSignCount()
+                );
+        save(authenticator); // please persist authenticator in your manner
+    }
+
+
+    public void athenticationValidationSample() {
+        // Client properties
+        byte[] credentialId = null /* set credentialId */;
+        byte[] userHandle = null /* set userHandle */;
+        byte[] authenticatorData = null /* set authenticatorData */;
+        byte[] clientDataJSON = null /* set clientDataJSON */;
+        String clientExtensionJSON = null /* set clientExtensionJSON */;
+        byte[] signature = null /* set signature */;
+
+        // Server properties
+        Origin origin = null /* set origin */;
+        String rpId = null /* set rpId */;
+        Challenge challenge = null /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        // expectations
+        boolean userVerificationRequired = true;
+        boolean userPresenceRequired = true;
+        List<String> expectedExtensionIds = Collections.emptyList();
+
+        Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
+
+        WebAuthnAuthenticationRequest webAuthnAuthenticationRequest =
+                new WebAuthnAuthenticationRequest(
+                        credentialId,
+                        userHandle,
+                        authenticatorData,
+                        clientDataJSON,
+                        clientExtensionJSON,
+                        signature
+                );
+        WebAuthnAuthenticationParameters webAuthnAuthenticationParameters =
+                new WebAuthnAuthenticationParameters(
+                        serverProperty,
+                        authenticator,
+                        userVerificationRequired,
+                        userPresenceRequired,
+                        expectedExtensionIds
+                );
+
+        WebAuthnAuthenticationData webAuthnAuthenticationData;
+        try{
+            webAuthnAuthenticationData = webAuthnManager.parseAuthenticationRequest(webAuthnAuthenticationRequest);
+        }
+        catch (DataConversionException e){
+            // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
+            throw e;
+        }
+        try{
+            webAuthnAuthenticationData.validate(webAuthnAuthenticationParameters);
+        }
+        catch (ValidationException e){
+            // If you would like to handle WebAuthn data validation error, please catch ValidationException
+            throw e;
+        }
+        // please update the counter of the authenticator record
+        updateCounter(
+                webAuthnAuthenticationData.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
+                webAuthnAuthenticationData.getAuthenticatorData().getSignCount()
+        );
+    }
+
+
+    private void save(Authenticator authenticator) {
+        // please persist in your manner
+    }
+
+    private Authenticator load(byte[] credentialId) {
+        return null; // please load authenticator in your manner
+    }
+
+    private void updateCounter(byte[] credentialId, long signCount) {
+        // please update the counter of the authenticator record
+    }
+}

--- a/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webauthn4j-core/src/test/java/sample/WebAuthnRegistrationContextValidatorSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnRegistrationContextValidatorSample.java
@@ -30,7 +30,7 @@ import com.webauthn4j.validator.WebAuthnRegistrationContextValidator;
 
 import java.util.Set;
 
-class Sample {
+class WebAuthnRegistrationContextValidatorSample {
 
     public void registrationValidationSample() {
         // Client properties


### PR DESCRIPTION
As existing `ContextValidator(s)` does data parse and validation in the same method call ( `ContextValidator#validate` ), caller cannot access the parsed data when an error occurred in the validation phase. 
To resolve this issue, introduce `WebAuthnManager` class which splits data parse phase and data validation phase into two dedicated method call.

Sample code:
```java

WebAuthnRegistrationRequest webAuthnRegistrationRequest = new WebAuthnRegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
WebAuthnRegistrationParameters webAuthnRegistrationParameters = new WebAuthnRegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
WebAuthnRegistrationData webAuthnRegistrationData;
try{
    // data parse phase
    webAuthnRegistrationData = webAuthnManager.parseRegistrationRequest(webAuthnRegistrationRequest);
}
catch (DataConversionException e){
    // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
    throw e;
}
try{
    // data validation phase
    webAuthnRegistrationData.validate(webAuthnRegistrationParameters);
}
catch (ValidationException e){
    // If you would like to handle WebAuthn data validation error, please catch ValidationException
    throw e;
}
```

`WebAuthnManager` deprecates existing `WebAuthnRegistrationContextValidator` and `WebAuthnAuthenticationContextValidator`. These classes will be removed by 1.0 GA.
