### PR TITLE
Rename MaliciousDataException

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationContextValidator.java
@@ -113,6 +113,7 @@ public class WebAuthnAuthenticationContextValidator {
                 webAuthnAuthenticationData.getCollectedClientData(),
                 webAuthnAuthenticationData.getAuthenticatorData(),
                 webAuthnAuthenticationData.getClientExtensions());
+
     }
 
     void validateAuthenticatorData(AuthenticatorData authenticatorData) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnAuthenticationDataValidator.java
@@ -29,11 +29,10 @@ import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutput
 import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
-import com.webauthn4j.validator.exception.MaliciousDataException;
+import com.webauthn4j.validator.exception.InconsistentClientDataTypeException;
 import com.webauthn4j.validator.exception.UserNotPresentException;
 import com.webauthn4j.validator.exception.UserNotVerifiedException;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -120,7 +119,7 @@ public class WebAuthnAuthenticationDataValidator {
         //spec| Step7
         //spec| Verify that the value of C.type is the string webauthn.get.
         if (!Objects.equals(collectedClientData.getType(), ClientDataType.GET)) {
-            throw new MaliciousDataException("ClientData.type must be 'get' on authentication, but it isn't.");
+            throw new InconsistentClientDataTypeException("ClientData.type must be 'get' on authentication, but it isn't.");
         }
 
         //spec| Step8

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/WebAuthnRegistrationDataValidator.java
@@ -16,11 +16,11 @@
 
 package com.webauthn4j.validator;
 
-import com.webauthn4j.data.WebAuthnRegistrationData;
 import com.webauthn4j.converter.AttestationObjectConverter;
 import com.webauthn4j.converter.util.CborConverter;
 import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.WebAuthnRegistrationData;
 import com.webauthn4j.data.WebAuthnRegistrationParameters;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
@@ -37,7 +37,7 @@ import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTru
 import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.ECDAATrustworthinessValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.self.SelfAttestationTrustworthinessValidator;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
-import com.webauthn4j.validator.exception.MaliciousDataException;
+import com.webauthn4j.validator.exception.InconsistentClientDataTypeException;
 import com.webauthn4j.validator.exception.UserNotPresentException;
 import com.webauthn4j.validator.exception.UserNotVerifiedException;
 
@@ -124,7 +124,7 @@ public class WebAuthnRegistrationDataValidator {
         //spec| Step3
         //spec| Verify that the value of C.type is webauthn.create.
         if (!Objects.equals(collectedClientData.getType(), ClientDataType.CREATE)) {
-            throw new MaliciousDataException("ClientData.type must be 'create' on registration, but it isn't.");
+            throw new InconsistentClientDataTypeException("ClientData.type must be 'create' on registration, but it isn't.");
         }
 
         //spec| Step4

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/exception/InconsistentClientDataTypeException.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/exception/InconsistentClientDataTypeException.java
@@ -17,18 +17,18 @@
 package com.webauthn4j.validator.exception;
 
 /**
- * Thrown if malicious data is specified
+ * Thrown if inconsistent type is specified for client data
  */
-public class MaliciousDataException extends ValidationException {
-    public MaliciousDataException(String message, Throwable cause) {
+public class InconsistentClientDataTypeException extends ValidationException {
+    public InconsistentClientDataTypeException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    public MaliciousDataException(String message) {
+    public InconsistentClientDataTypeException(String message) {
         super(message);
     }
 
-    public MaliciousDataException(Throwable cause) {
+    public InconsistentClientDataTypeException(Throwable cause) {
         super(cause);
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/exception/InconsistentClientDataTypeExceptionTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/exception/InconsistentClientDataTypeExceptionTest.java
@@ -22,15 +22,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SuppressWarnings("ThrowableNotThrown")
-class MaliciousDataExceptionTest {
+class InconsistentClientDataTypeExceptionTest {
 
     private RuntimeException cause = new RuntimeException();
 
     @Test
     void test() {
-        MaliciousDataException exception1 = new MaliciousDataException("dummy", cause);
-        MaliciousDataException exception2 = new MaliciousDataException("dummy");
-        MaliciousDataException exception3 = new MaliciousDataException(cause);
+        InconsistentClientDataTypeException exception1 = new InconsistentClientDataTypeException("dummy", cause);
+        InconsistentClientDataTypeException exception2 = new InconsistentClientDataTypeException("dummy");
+        InconsistentClientDataTypeException exception3 = new InconsistentClientDataTypeException(cause);
 
         assertAll(
                 () -> assertThat(exception1.getMessage()).isEqualTo("dummy"),

--- a/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorAuthenticationValidationTest.java
@@ -155,7 +155,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 );
         Authenticator authenticator = TestDataUtil.createAuthenticator(attestationObject);
 
-        assertThrows(MaliciousDataException.class,
+        assertThrows(InconsistentClientDataTypeException.class,
                 () -> target.validate(authenticationContext, authenticator)
         );
     }

--- a/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorRegistrationValidationTest.java
@@ -192,7 +192,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         Set<String> transports = authenticatorTransportConverter.convertSetToStringSet(registrationRequest.getTransports());
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
         WebAuthnRegistrationContext registrationContext = new WebAuthnRegistrationContext(registrationRequest.getClientDataJSON(), registrationRequest.getAttestationObject(), transports, serverProperty, false);
-        assertThrows(MaliciousDataException.class,
+        assertThrows(InconsistentClientDataTypeException.class,
                 () -> target.validate(registrationContext)
         );
     }

--- a/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorAuthenticationValidationTest.java
@@ -195,7 +195,7 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
                         true
                 );
         Authenticator authenticator = TestDataUtil.createAuthenticator(attestationObject);
-        assertThrows(MaliciousDataException.class,
+        assertThrows(InconsistentClientDataTypeException.class,
                 () -> target.validate(authenticationContext, authenticator)
         );
     }


### PR DESCRIPTION
to `InconsistentClientDataTypeException` as `MaliciousDataException` is too generic name for its usage.