### PR TITLE
Fix documentation - use credentialId from authenticationData in authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ catch (ValidationException e){
 }
 // please update the counter of the authenticator record
 updateCounter(
-        authenticationData.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
+        authenticationData.getCredentialId(),
         authenticationData.getAuthenticatorData().getSignCount()
 );
 

--- a/docs/src/reference/asciidoc/en/quick-start.adoc
+++ b/docs/src/reference/asciidoc/en/quick-start.adoc
@@ -157,7 +157,7 @@ catch (ValidationException e){
 }
 // please update the counter of the authenticator record
 updateCounter(
-        authenticationData.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
+        authenticationData.getCredentialId(),
         authenticationData.getAuthenticatorData().getSignCount()
 );
 

--- a/docs/src/reference/asciidoc/ja/quick-start.adoc
+++ b/docs/src/reference/asciidoc/ja/quick-start.adoc
@@ -160,7 +160,7 @@ catch (ValidationException e){
 }
 // please update the counter of the authenticator record
 updateCounter(
-        authenticationData.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
+        authenticationData.getCredentialId(),
         authenticationData.getAuthenticatorData().getSignCount()
 );
 ```

--- a/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
@@ -150,7 +150,7 @@ public class WebAuthnManagerSample {
         }
         // please update the counter of the authenticator record
         updateCounter(
-                authenticationData.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
+                authenticationData.getCredentialId(),
                 authenticationData.getAuthenticatorData().getSignCount()
         );
     }
@@ -166,5 +166,7 @@ public class WebAuthnManagerSample {
 
     private void updateCounter(byte[] credentialId, long signCount) {
         // please update the counter of the authenticator record
+        // authenticator should be resolved using following comparision:
+        // Arrays.equals(authenticator.getAttestedCredentialData().getCredentialId(), credentialId)
     }
 }

--- a/webauthn4j-core/src/test/java/sample/WebAuthnRegistrationContextValidatorSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnRegistrationContextValidatorSample.java
@@ -107,7 +107,7 @@ class RegistrationContextValidatorSample {
 
         // please update the counter of the authenticator record
         updateCounter(
-                response.getAuthenticatorData().getAttestedCredentialData().getCredentialId(),
+                response.getCredentialId(),
                 response.getAuthenticatorData().getSignCount()
         );
     }
@@ -123,5 +123,7 @@ class RegistrationContextValidatorSample {
 
     private void updateCounter(byte[] credentialId, long signCount) {
         // please update the counter of the authenticator record
+        // authenticator should be resolved using following comparision:
+        // Arrays.equals(authenticator.getAttestedCredentialData().getCredentialId(), credentialId)
     }
 }


### PR DESCRIPTION
Fix documentation - use credentialId from authenticationData instead of attestedCredentialData in authentication flow

As per specification "For assertion signatures, the AT flag MUST NOT be set and the attestedCredentialData MUST NOT be included."
https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data