### PR TITLE
Reduce dependencies exposure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ allprojects {
 subprojects {
 
     apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'jacoco'
     apply plugin: 'com.jfrog.bintray'

--- a/webauthn4j-core/build.gradle
+++ b/webauthn4j-core/build.gradle
@@ -24,17 +24,22 @@ test {
 }
 
 dependencies {
-    compile project(':webauthn4j-util')
-    compile("org.slf4j:slf4j-api")
-    compile("org.apache.kerby:kerby-asn1")
+    api project(':webauthn4j-util')
+    implementation("org.slf4j:slf4j-api")
+    implementation("org.apache.kerby:kerby-asn1")
+
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
 
     //Test
-    testCompile project(':webauthn4j-test')
-    testCompile('ch.qos.logback:logback-classic')
-    testCompile('org.projectlombok:lombok')
-    testCompile('org.mockito:mockito-core')
-    testCompile('org.assertj:assertj-core')
-    testCompile("org.springframework:spring-core")
-    testCompile('org.junit.jupiter:junit-jupiter-api')
+    testImplementation project(':webauthn4j-test')
+    testImplementation("org.bouncycastle:bcprov-jdk15on")
+    testImplementation("org.bouncycastle:bcpkix-jdk15on")
+    testImplementation('ch.qos.logback:logback-classic')
+    testImplementation('org.projectlombok:lombok')
+    testImplementation('org.mockito:mockito-core')
+    testImplementation('org.assertj:assertj-core')
+    testImplementation("org.springframework:spring-core")
+    testImplementation('org.junit.jupiter:junit-jupiter-api')
     testRuntime('org.junit.jupiter:junit-jupiter-engine')
 }

--- a/webauthn4j-metadata/build.gradle
+++ b/webauthn4j-metadata/build.gradle
@@ -24,19 +24,23 @@ test {
 }
 
 dependencies {
-    compile project(':webauthn4j-core')
+    api project(':webauthn4j-core')
 
-    compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("org.slf4j:slf4j-api")
+
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
     //Test
-    testCompile('ch.qos.logback:logback-classic')
-    testCompile('org.projectlombok:lombok')
-    testCompile('org.mockito:mockito-core')
-    testCompile('org.assertj:assertj-core')
-    testCompile('org.junit.jupiter:junit-jupiter-api')
-    testRuntime('org.junit.jupiter:junit-jupiter-engine')
+    testImplementation project(':webauthn4j-test')
 
-    testCompile project(':webauthn4j-test')
+    testImplementation('ch.qos.logback:logback-classic')
+    testImplementation('org.projectlombok:lombok')
+    testImplementation('org.mockito:mockito-core')
+    testImplementation('org.assertj:assertj-core')
+    testImplementation('org.junit.jupiter:junit-jupiter-api')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine')
 
 }
 

--- a/webauthn4j-test/build.gradle
+++ b/webauthn4j-test/build.gradle
@@ -24,20 +24,24 @@ test {
 }
 
 dependencies {
-    compile project(':webauthn4j-core')
-    compile project(':webauthn4j-metadata')
+    implementation project(':webauthn4j-core')
+    implementation project(':webauthn4j-metadata')
 
-    compile("org.springframework:spring-core")
-    compile("org.bouncycastle:bcprov-jdk15on")
-    compile("org.bouncycastle:bcpkix-jdk15on")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
+
+    implementation("org.springframework:spring-core")
+    implementation("org.bouncycastle:bcprov-jdk15on")
+    implementation("org.bouncycastle:bcpkix-jdk15on")
 
     //Test
-    testCompile('ch.qos.logback:logback-classic')
-    testCompile('org.projectlombok:lombok')
-    testCompile('org.mockito:mockito-core')
-    testCompile('org.assertj:assertj-core')
-    testCompile('org.junit.jupiter:junit-jupiter-api')
+    testImplementation('ch.qos.logback:logback-classic')
+    testImplementation('org.projectlombok:lombok')
+    testImplementation('org.mockito:mockito-core')
+    testImplementation('org.assertj:assertj-core')
+    testImplementation('org.junit.jupiter:junit-jupiter-api')
     testRuntime('org.junit.jupiter:junit-jupiter-engine')
+
 }
 
 sonarqube {

--- a/webauthn4j-util/build.gradle
+++ b/webauthn4j-util/build.gradle
@@ -25,16 +25,18 @@ test {
 
 dependencies {
 
-    compile("com.fasterxml.jackson.core:jackson-databind")
-    compile("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
 
     //Test
-    testCompile project(':webauthn4j-test')
-    testCompile('ch.qos.logback:logback-classic')
-    testCompile('org.projectlombok:lombok')
-    testCompile('org.mockito:mockito-core')
-    testCompile('org.assertj:assertj-core')
-    testCompile('org.junit.jupiter:junit-jupiter-api')
+    testImplementation project(':webauthn4j-test')
+    implementation("org.bouncycastle:bcprov-jdk15on")
+    implementation("org.bouncycastle:bcpkix-jdk15on")
+    testImplementation('ch.qos.logback:logback-classic')
+    testImplementation('org.projectlombok:lombok')
+    testImplementation('org.mockito:mockito-core')
+    testImplementation('org.assertj:assertj-core')
+    testImplementation('org.junit.jupiter:junit-jupiter-api')
     testRuntime('org.junit.jupiter:junit-jupiter-engine')
 
 }


### PR DESCRIPTION
by using gradle api/implementation dependency definition.
Now the transitive dependencies are not exposed to the library user.

These transitive dependencies are removed:
- `org.slf4j:slf4j-api`
- `org.apache.kerby:kerby-asn1`
- `com.fasterxml.jackson.core:jackson-databind`
- `com.fasterxml.jackson.dataformat:jackson-dataformat-cbor`
- `com.fasterxml.jackson.datatype:jackson-datatype-jsr310`