### PR TITLE
Align unknown extension handling to WebAuthn Level2 draft1

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
@@ -47,6 +47,7 @@ public class WebAuthnCBORModule extends SimpleModule {
         this.addDeserializer(COSEKeyEnvelope.class, new COSEKeyEnvelopeDeserializer());
         this.addDeserializer(AuthenticatorData.class, new AuthenticatorDataDeserializer(objectConverter));
         this.addDeserializer(ExtensionAuthenticatorOutput.class, new ExtensionAuthenticatorOutputDeserializer());
+        this.addDeserializer(UnknownExtensionAuthenticatorOutput.class, new UnknownExtensionAuthenticatorOutputDeserializer());
         this.addDeserializer(TPMSAttest.class, new TPMSAttestDeserializer());
         this.addDeserializer(TPMTPublic.class, new TPMTPublicDeserializer());
         this.addDeserializer(X509Certificate.class, new X509CertificateDeserializer());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
@@ -65,6 +65,7 @@ public class WebAuthnCBORModule extends SimpleModule {
         this.addSerializer(TPMTPublic.class, new TPMTPublicSerializer());
         this.addSerializer(X509Certificate.class, new X509CertificateSerializer());
 
+        // attestation statements
         this.registerSubtypes(new NamedType(FIDOU2FAttestationStatement.class, FIDOU2FAttestationStatement.FORMAT));
         this.registerSubtypes(new NamedType(PackedAttestationStatement.class, PackedAttestationStatement.FORMAT));
         this.registerSubtypes(new NamedType(AndroidKeyAttestationStatement.class, AndroidKeyAttestationStatement.FORMAT));
@@ -72,6 +73,7 @@ public class WebAuthnCBORModule extends SimpleModule {
         this.registerSubtypes(new NamedType(TPMAttestationStatement.class, TPMAttestationStatement.FORMAT));
         this.registerSubtypes(new NamedType(NoneAttestationStatement.class, NoneAttestationStatement.FORMAT));
 
+        // authenticator extension outputs
         this.registerSubtypes(new NamedType(GenericTransactionAuthorizationExtensionAuthenticatorOutput.class, GenericTransactionAuthorizationExtensionAuthenticatorOutput.ID));
         this.registerSubtypes(new NamedType(LocationExtensionAuthenticatorOutput.class, LocationExtensionAuthenticatorOutput.ID));
         this.registerSubtypes(new NamedType(SimpleTransactionAuthorizationExtensionAuthenticatorOutput.class, SimpleTransactionAuthorizationExtensionAuthenticatorOutput.ID));

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
@@ -41,6 +41,8 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(Challenge.class, new ChallengeDeserializer());
         this.addDeserializer(ExtensionClientInput.class, new ExtensionClientInputDeserializer());
         this.addDeserializer(ExtensionClientOutput.class, new ExtensionClientOutputDeserializer());
+        this.addDeserializer(UnknownExtensionClientInput.class, new UnknownExtensionClientInputDeserializer());
+        this.addDeserializer(UnknownExtensionClientOutput.class, new UnknownExtensionClientOutputDeserializer());
         this.addDeserializer(JWS.class, new JWSDeserializer(objectConverter));
         this.addDeserializer(X509Certificate.class, new X509CertificateDeserializer());
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
@@ -48,9 +48,11 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addSerializer(JWS.class, new JWSSerializer());
         this.addSerializer(X509Certificate.class, new X509CertificateSerializer());
 
+        // client extension inputs
         this.registerSubtypes(new NamedType(FIDOAppIDExtensionClientInput.class, FIDOAppIDExtensionClientInput.ID));
         this.registerSubtypes(new NamedType(SupportedExtensionsExtensionClientInput.class, SupportedExtensionsExtensionClientInput.ID));
 
+        // client extension outputs
         this.registerSubtypes(new NamedType(AuthenticatorSelectionExtensionClientOutput.class, AuthenticatorSelectionExtensionClientOutput.ID));
         this.registerSubtypes(new NamedType(BiometricAuthenticatorPerformanceBoundsExtensionClientOutput.class, BiometricAuthenticatorPerformanceBoundsExtensionClientOutput.ID));
         this.registerSubtypes(new NamedType(FIDOAppIDExtensionClientOutput.class, FIDOAppIDExtensionClientOutput.ID));

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/ExtensionAuthenticatorOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/ExtensionAuthenticatorOutputDeserializer.java
@@ -20,11 +20,13 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClassResolver;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.webauthn4j.data.extension.authenticator.ExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.authenticator.UnknownExtensionAuthenticatorOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -33,7 +35,9 @@ import java.util.Objects;
 /**
  * Jackson Deserializer for {@link ExtensionAuthenticatorOutput}
  */
-public class ExtensionAuthenticatorOutputDeserializer extends StdDeserializer<ExtensionAuthenticatorOutput> {
+public class ExtensionAuthenticatorOutputDeserializer extends StdDeserializer<ExtensionAuthenticatorOutput<?>> {
+
+    private transient Logger logger = LoggerFactory.getLogger(ExtensionAuthenticatorOutputDeserializer.class);
 
     public ExtensionAuthenticatorOutputDeserializer() {
         super(ExtensionAuthenticatorOutput.class);
@@ -43,7 +47,7 @@ public class ExtensionAuthenticatorOutputDeserializer extends StdDeserializer<Ex
      * {@inheritDoc}
      */
     @Override
-    public ExtensionAuthenticatorOutput deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public ExtensionAuthenticatorOutput<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
 
         String name = p.getParsingContext().getCurrentName();
         if (name == null) {
@@ -56,10 +60,11 @@ public class ExtensionAuthenticatorOutputDeserializer extends StdDeserializer<Ex
 
         for (NamedType namedType : namedTypes) {
             if (Objects.equals(namedType.getName(), name)) {
-                return (ExtensionAuthenticatorOutput) ctxt.readValue(p, namedType.getType());
+                return (ExtensionAuthenticatorOutput<?>) ctxt.readValue(p, namedType.getType());
             }
         }
 
-        throw new InvalidFormatException(p, "value is out of range", name, ExtensionAuthenticatorOutput.class);
+        logger.warn("Unknown extension '{}' is contained.", name);
+        return ctxt.readValue(p, UnknownExtensionAuthenticatorOutput.class);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionAuthenticatorOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionAuthenticatorOutputDeserializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.webauthn4j.data.extension.authenticator.UnknownExtensionAuthenticatorOutput;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class UnknownExtensionAuthenticatorOutputDeserializer extends StdDeserializer<UnknownExtensionAuthenticatorOutput> {
+
+    public UnknownExtensionAuthenticatorOutputDeserializer() {
+        super(UnknownExtensionAuthenticatorOutput.class);
+    }
+
+    @Override
+    public UnknownExtensionAuthenticatorOutput deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        Serializable value = ctxt.readValue(p, Serializable.class);
+        return new UnknownExtensionAuthenticatorOutput(p.getCurrentName(), value);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionClientInputDeserializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.webauthn4j.data.extension.client.UnknownExtensionClientInput;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class UnknownExtensionClientInputDeserializer extends StdDeserializer<UnknownExtensionClientInput> {
+
+    public UnknownExtensionClientInputDeserializer() {
+        super(UnknownExtensionClientInput.class);
+    }
+
+    @Override
+    public UnknownExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        Serializable value = ctxt.readValue(p, Serializable.class);
+        return new UnknownExtensionClientInput(p.getCurrentName(), value);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionClientOutputDeserializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.webauthn4j.data.extension.client.UnknownExtensionClientOutput;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class UnknownExtensionClientOutputDeserializer extends StdDeserializer<UnknownExtensionClientOutput> {
+
+    public UnknownExtensionClientOutputDeserializer() {
+        super(UnknownExtensionClientOutput.class);
+    }
+
+    @Override
+    public UnknownExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        Serializable value = ctxt.readValue(p, Serializable.class);
+        return new UnknownExtensionClientOutput(p.getCurrentName(), value);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/UnknownExtensionAuthenticatorOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/UnknownExtensionAuthenticatorOutput.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.authenticator;
+
+import com.webauthn4j.data.extension.AbstractExtensionOutput;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Container for unknown extension authenticator output
+ * DO NOT rely on this class to peek in the extension data from user code, because this class won't be used
+ * when a specialized class for the extension is introduced. If you would like to peek an extension data when it is not
+ * supported, please register your own container class for the the extension to the underlying {@link com.fasterxml.jackson.databind.ObjectMapper}.
+ */
+public class UnknownExtensionAuthenticatorOutput
+        extends AbstractExtensionOutput<Serializable>
+        implements AuthenticationExtensionAuthenticatorOutput<Serializable>  {
+
+    private String name;
+
+    public UnknownExtensionAuthenticatorOutput(String name, Serializable value) {
+        super(value);
+        this.name = name;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UnknownExtensionAuthenticatorOutput that = (UnknownExtensionAuthenticatorOutput) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/UnknownExtensionClientInput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/UnknownExtensionClientInput.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.data.extension.AbstractExtensionInput;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class UnknownExtensionClientInput extends AbstractExtensionInput<Serializable> implements RegistrationExtensionClientInput<Serializable> {
+
+    private String name;
+
+    public UnknownExtensionClientInput(String name, Serializable value) {
+        super(value);
+        this.name = name;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UnknownExtensionClientInput that = (UnknownExtensionClientInput) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/UnknownExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/UnknownExtensionClientOutput.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.data.extension.AbstractExtensionOutput;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class UnknownExtensionClientOutput extends AbstractExtensionOutput<Serializable> implements RegistrationExtensionClientOutput<Serializable> {
+
+    private String name;
+
+    public UnknownExtensionClientOutput(String name, Serializable value) {
+        super(value);
+        this.name = name;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UnknownExtensionClientOutput that = (UnknownExtensionClientOutput) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name);
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverterTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.converter;
 
-import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientInputs;
 import com.webauthn4j.data.extension.client.ExtensionClientInput;
@@ -27,7 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class AuthenticationExtensionsClientInputsConverterTest {
 
@@ -63,7 +62,7 @@ class AuthenticationExtensionsClientInputsConverterTest {
     @Test
     void convert_with_invalid_extension_test() {
         String source = "{\"invalid\":\"\"}";
-        assertThrows(DataConversionException.class,
+        assertDoesNotThrow(
                 () -> authenticationExtensionsClientInputsConverter.convert(source)
         );
     }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionAuthenticatorOutputDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionAuthenticatorOutputDeserializerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer;
+
+import com.webauthn4j.converter.util.CborConverter;
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
+import com.webauthn4j.data.extension.authenticator.UnknownExtensionAuthenticatorOutput;
+import com.webauthn4j.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class UnknownExtensionAuthenticatorOutputDeserializerTest {
+
+    private ObjectConverter objectConverter = new ObjectConverter();
+    private CborConverter cborConverter = objectConverter.getCborConverter();
+
+    @Test
+    void test() {
+
+
+        //Given
+        byte[] input = HexUtil.decode("A16A756E6578706563746564F5"); // {"unexpected": true}
+
+        //When
+        AuthenticationExtensionsAuthenticatorOutputs result = cborConverter.readValue(input, AuthenticationExtensionsAuthenticatorOutputs.class);
+
+        //Then
+        assertAll(
+                ()-> assertThat(result.get("unexpected")).isInstanceOf(UnknownExtensionAuthenticatorOutput.class),
+                ()-> assertThat(((UnknownExtensionAuthenticatorOutput)result.get("unexpected")).getIdentifier()).isEqualTo("unexpected"),
+                ()-> assertThat(((UnknownExtensionAuthenticatorOutput)result.get("unexpected")).getValue()).isEqualTo(true)
+        );
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionClientInputDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionClientInputDeserializerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer;
+
+import com.webauthn4j.converter.util.JsonConverter;
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientInputs;
+import com.webauthn4j.data.extension.client.UnknownExtensionClientInput;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class UnknownExtensionClientInputDeserializerTest {
+
+    private ObjectConverter objectConverter = new ObjectConverter();
+    private JsonConverter jsonConverter = objectConverter.getJsonConverter();
+
+    @Test
+    void test() {
+
+
+        //Given
+        String input = "{\"unexpected\": true}";
+
+        //When
+        AuthenticationExtensionsClientInputs result = jsonConverter.readValue(input, AuthenticationExtensionsClientInputs.class);
+
+        //Then
+        assertAll(
+                ()-> assertThat(result.get("unexpected")).isInstanceOf(UnknownExtensionClientInput.class),
+                ()-> assertThat(((UnknownExtensionClientInput)result.get("unexpected")).getIdentifier()).isEqualTo("unexpected"),
+                ()-> assertThat(((UnknownExtensionClientInput)result.get("unexpected")).getValue()).isEqualTo(true)
+        );
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionClientOutputSerializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/UnknownExtensionClientOutputSerializerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer;
+
+import com.webauthn4j.converter.util.JsonConverter;
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.data.extension.client.UnknownExtensionClientOutput;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class UnknownExtensionClientOutputSerializerTest {
+
+    private ObjectConverter objectConverter = new ObjectConverter();
+    private JsonConverter jsonConverter = objectConverter.getJsonConverter();
+
+    @Test
+    void test() {
+
+
+        //Given
+        String input = "{\"unexpected\": true}";
+
+        //When
+        AuthenticationExtensionsClientOutputs result = jsonConverter.readValue(input, AuthenticationExtensionsClientOutputs.class);
+
+        //Then
+        assertAll(
+                ()-> assertThat(result.get("unexpected")).isInstanceOf(UnknownExtensionClientOutput.class),
+                ()-> assertThat(((UnknownExtensionClientOutput)result.get("unexpected")).getIdentifier()).isEqualTo("unexpected"),
+                ()-> assertThat(((UnknownExtensionClientOutput)result.get("unexpected")).getValue()).isEqualTo(true)
+        );
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/authenticator/UnknownExtensionAuthenticatorOutputTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/authenticator/UnknownExtensionAuthenticatorOutputTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.authenticator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnknownExtensionAuthenticatorOutputTest {
+
+    @Test
+    void equals_hashCode_test(){
+        UnknownExtensionAuthenticatorOutput instanceA = new UnknownExtensionAuthenticatorOutput("unknown", true);
+        UnknownExtensionAuthenticatorOutput instanceB = new UnknownExtensionAuthenticatorOutput("unknown", true);
+        assertThat(instanceA).isEqualTo(instanceB);
+        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/UnknownExtensionClientInputTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/UnknownExtensionClientInputTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnknownExtensionClientInputTest {
+
+    @Test
+    void equals_hashCode_test(){
+        UnknownExtensionClientInput instanceA = new UnknownExtensionClientInput("unknown", true);
+        UnknownExtensionClientInput instanceB = new UnknownExtensionClientInput("unknown", true);
+        assertThat(instanceA).isEqualTo(instanceB);
+        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+    }
+
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/UnknownExtensionClientOutputTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/UnknownExtensionClientOutputTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnknownExtensionClientOutputTest {
+
+    @Test
+    void equals_hashCode_test(){
+        UnknownExtensionClientOutput instanceA = new UnknownExtensionClientOutput("unknown", true);
+        UnknownExtensionClientOutput instanceB = new UnknownExtensionClientOutput("unknown", true);
+        assertThat(instanceA).isEqualTo(instanceB);
+        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+    }
+
+}

--- a/webauthn4j-util/src/main/java/com/webauthn4j/util/HexUtil.java
+++ b/webauthn4j-util/src/main/java/com/webauthn4j/util/HexUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.util;
+
+
+public class HexUtil {
+
+    private static final String HEX_CHARS = "0123456789ABCDEF";
+    private static final char[] HEX_CHAR_ARRAY = HEX_CHARS.toCharArray();
+
+    private HexUtil() {
+    }
+
+    public static byte[] decode(String source) {
+        source = source.toUpperCase();
+        int sourceLength = source.length();
+        if(sourceLength % 2 != 0){
+            throw new IllegalArgumentException("source length must be even-length.");
+        }
+        byte[] bytes = new byte[sourceLength/2];
+        char[] sourceChars = source.toCharArray();
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) ((HEX_CHARS.indexOf(sourceChars[i*2]) << 4) + HEX_CHARS.indexOf(sourceChars[i*2 + 1]));
+        }
+
+        return bytes;
+    }
+
+    public static String encodeToString(byte[] source) {
+        StringBuilder stringBuilder = new StringBuilder(source.length * 2);
+        for (byte item : source) {
+            stringBuilder.append(HEX_CHAR_ARRAY[(item >> 4) & 0xF]);
+            stringBuilder.append(HEX_CHAR_ARRAY[(item & 0xF)]);
+        }
+        return stringBuilder.toString();
+    }
+
+}


### PR DESCRIPTION
When an unknown extension is included in the serialized data, `DataConversionException` was thrown (https://github.com/webauthn4j/webauthn4j/blob/0.11.0.RELEASE/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverterTest.java#L64-L68) while deserializing.

In W3C WebAuthn spec level1, it was requested to reject unintended extension (https://www.w3.org/TR/webauthn/#registering-a-new-credential), but in level2 spec, rejecting unintended extension is left to relying party decision (https://www.w3.org/TR/2019/WD-webauthn-2-20191126/#sctn-registering-a-new-credential).

Since rejecting unknown extension is not welcomed ( https://github.com/webauthn4j/webauthn4j/issues/260 ), this PR changes the behavior.
Now `DataConversionException` won't be thrown in the case, and `UnknownExtensionAuthenticatorOutput` | `UnknownExtensionClientInput` | `UnknownExtensionClientOutput` class is included in the deserialized data.
