### PR TITLE
Correct FIDO U2F signature varidation error message

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/u2f/FIDOU2FAttestationStatementValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/u2f/FIDOU2FAttestationStatementValidator.java
@@ -89,9 +89,9 @@ public class FIDOU2FAttestationStatementValidator extends AbstractStatementValid
             if (verifier.verify(signature)) {
                 return;
             }
-            throw new BadSignatureException("`sig` in attestation statement is not valid signature over the concatenation of authenticatorData and clientDataHash.");
+            throw new BadSignatureException("`sig` in attestation statement is not valid signature. Please refer U2F Raw Message Formats. https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html");
         } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException e) {
-            throw new BadSignatureException("`sig` in attestation statement is not valid signature over the concatenation of authenticatorData and clientDataHash.");
+            throw new BadSignatureException("`sig` in attestation statement is not valid signature. Please refer U2F Raw Message Formats. https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html");
         }
     }
 


### PR DESCRIPTION
As U2F signature is not calculated over autenticatorData and
clientDataHash, message is corrected.