### PR TITLE
Add ResidentKeyRequirement enum

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticatorSelectionCriteria.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticatorSelectionCriteria.java
@@ -38,17 +38,45 @@ public class AuthenticatorSelectionCriteria implements Serializable {
 
     @SuppressWarnings("UnusedAssignment")
     private boolean requireResidentKey = false;
+
+    private ResidentKeyRequirement residentKey = null;
+
     @SuppressWarnings("UnusedAssignment")
     private UserVerificationRequirement userVerification = UserVerificationRequirement.PREFERRED;
 
+    /**
+     * Constructor for Jackson deserializer
+     */
     @JsonCreator
     public AuthenticatorSelectionCriteria(
             @JsonProperty("authenticatorAttachment") AuthenticatorAttachment authenticatorAttachment,
             @JsonProperty("requireResidentKey") boolean requireResidentKey,
+            @JsonProperty("residentKey") ResidentKeyRequirement residentKey,
             @JsonProperty("userVerification") UserVerificationRequirement userVerification) {
         this.authenticatorAttachment = authenticatorAttachment;
         this.requireResidentKey = requireResidentKey;
+        this.residentKey = residentKey;
         this.userVerification = userVerification;
+    }
+
+    /**
+     * Constructor for WebAuthn Level2 spec
+     */
+    public AuthenticatorSelectionCriteria(
+            AuthenticatorAttachment authenticatorAttachment,
+            ResidentKeyRequirement residentKey,
+            UserVerificationRequirement userVerification) {
+        this(authenticatorAttachment, false, residentKey, userVerification);
+    }
+
+    /**
+     * Constructor for WebAuthn Level1 spec backward-compatibility
+     */
+    public AuthenticatorSelectionCriteria(
+            AuthenticatorAttachment authenticatorAttachment,
+            boolean requireResidentKey,
+            UserVerificationRequirement userVerification) {
+        this(authenticatorAttachment, requireResidentKey, null, userVerification);
     }
 
     public AuthenticatorAttachment getAuthenticatorAttachment() {
@@ -57,6 +85,10 @@ public class AuthenticatorSelectionCriteria implements Serializable {
 
     public boolean isRequireResidentKey() {
         return requireResidentKey;
+    }
+
+    public ResidentKeyRequirement getResidentKey() {
+        return residentKey;
     }
 
     public UserVerificationRequirement getUserVerification() {
@@ -70,12 +102,12 @@ public class AuthenticatorSelectionCriteria implements Serializable {
         AuthenticatorSelectionCriteria that = (AuthenticatorSelectionCriteria) o;
         return requireResidentKey == that.requireResidentKey &&
                 authenticatorAttachment == that.authenticatorAttachment &&
+                residentKey == that.residentKey &&
                 userVerification == that.userVerification;
     }
 
     @Override
     public int hashCode() {
-
-        return Objects.hash(authenticatorAttachment, requireResidentKey, userVerification);
+        return Objects.hash(authenticatorAttachment, requireResidentKey, residentKey, userVerification);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/ResidentKeyRequirement.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/ResidentKeyRequirement.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+/**
+ * This enumeration’s values describe the Relying Party's requirements for client-side discoverable credentials (formerly known as resident credentials or resident keys)
+ * @see <a href="https://www.w3.org/TR/2019/WD-webauthn-2-20191126/#enum-residentKeyRequirement">
+ * §5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a>
+ */
+public enum ResidentKeyRequirement {
+
+    DISCOURAGED("discouraged"),
+    PREFERRED("preferred"),
+    REQUIRED("required");
+
+    private String value;
+
+    ResidentKeyRequirement(String value) {
+        this.value = value;
+    }
+
+    public static ResidentKeyRequirement create(String value) {
+        if (value == null) {
+            return null;
+        }
+        switch (value) {
+            case "discouraged":
+                return DISCOURAGED;
+            case "preferred":
+                return PREFERRED;
+            case "required":
+                return REQUIRED;
+            default:
+                throw new IllegalArgumentException("value '" + value + "' is out of range");
+        }
+    }
+
+    @JsonCreator
+    private static ResidentKeyRequirement deserialize(String value) throws InvalidFormatException {
+        try {
+            return create(value);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidFormatException(null, "value is out of range", value, ResidentKeyRequirement.class);
+        }
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticatorSelectionCriteriaTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticatorSelectionCriteriaTest.java
@@ -24,12 +24,37 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class AuthenticatorSelectionCriteriaTest {
 
     @Test
-    void getter_test() {
+    void webauthn_level2_compatible_constructor_test() {
+        AuthenticatorSelectionCriteria authenticatorSelectionCriteria
+                = new AuthenticatorSelectionCriteria(AuthenticatorAttachment.CROSS_PLATFORM, ResidentKeyRequirement.REQUIRED, UserVerificationRequirement.REQUIRED);
+        assertAll(
+                () -> assertThat(authenticatorSelectionCriteria.getAuthenticatorAttachment()).isEqualTo(AuthenticatorAttachment.CROSS_PLATFORM),
+                () -> assertThat(authenticatorSelectionCriteria.isRequireResidentKey()).isEqualTo(false), // inconsistent configuration is possible by design. consumer code must care it
+                () -> assertThat(authenticatorSelectionCriteria.getResidentKey()).isEqualTo(ResidentKeyRequirement.REQUIRED),
+                () -> assertThat(authenticatorSelectionCriteria.getUserVerification()).isEqualTo(UserVerificationRequirement.REQUIRED)
+        );
+    }
+
+    @Test
+    void webauthn_level1_compatible_constructor_test() {
         AuthenticatorSelectionCriteria authenticatorSelectionCriteria
                 = new AuthenticatorSelectionCriteria(AuthenticatorAttachment.CROSS_PLATFORM, true, UserVerificationRequirement.REQUIRED);
         assertAll(
                 () -> assertThat(authenticatorSelectionCriteria.getAuthenticatorAttachment()).isEqualTo(AuthenticatorAttachment.CROSS_PLATFORM),
                 () -> assertThat(authenticatorSelectionCriteria.isRequireResidentKey()).isEqualTo(true),
+                () -> assertThat(authenticatorSelectionCriteria.getResidentKey()).isEqualTo(null),
+                () -> assertThat(authenticatorSelectionCriteria.getUserVerification()).isEqualTo(UserVerificationRequirement.REQUIRED)
+        );
+    }
+
+    @Test
+    void getter_test() {
+        AuthenticatorSelectionCriteria authenticatorSelectionCriteria
+                = new AuthenticatorSelectionCriteria(AuthenticatorAttachment.CROSS_PLATFORM, true, ResidentKeyRequirement.REQUIRED, UserVerificationRequirement.REQUIRED);
+        assertAll(
+                () -> assertThat(authenticatorSelectionCriteria.getAuthenticatorAttachment()).isEqualTo(AuthenticatorAttachment.CROSS_PLATFORM),
+                () -> assertThat(authenticatorSelectionCriteria.isRequireResidentKey()).isEqualTo(true),
+                () -> assertThat(authenticatorSelectionCriteria.getResidentKey()).isEqualTo(ResidentKeyRequirement.REQUIRED),
                 () -> assertThat(authenticatorSelectionCriteria.getUserVerification()).isEqualTo(UserVerificationRequirement.REQUIRED)
         );
     }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/ResidentKeyRequirementTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/ResidentKeyRequirementTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResidentKeyRequirementTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void create_test() {
+        assertAll(
+                () -> assertThat(ResidentKeyRequirement.create(null)).isNull(),
+                () -> assertThat(ResidentKeyRequirement.create("discouraged")).isEqualTo(ResidentKeyRequirement.DISCOURAGED),
+                () -> assertThat(ResidentKeyRequirement.create("preferred")).isEqualTo(ResidentKeyRequirement.PREFERRED),
+                () -> assertThat(ResidentKeyRequirement.create("required")).isEqualTo(ResidentKeyRequirement.REQUIRED)
+        );
+    }
+
+    @Test
+    public void create_invalid_value_test() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ResidentKeyRequirement.create("invalid")
+        );
+    }
+
+    @Test
+    public void getValue_test() {
+        assertThat(ResidentKeyRequirement.REQUIRED.getValue()).isEqualTo("required");
+    }
+
+    @Test
+    public void deserialize_test() throws IOException {
+        ResidentKeyRequirementTest.TestDTO dto = objectMapper.readValue("{\"residentKey\": \"required\"}", ResidentKeyRequirementTest.TestDTO.class);
+        assertThat(dto.residentKey).isEqualTo(ResidentKeyRequirement.REQUIRED);
+    }
+
+    @Test
+    public void deserialize_test_with_invalid() {
+        assertThrows(InvalidFormatException.class,
+                () -> objectMapper.readValue("{\"residentKey\": \"invalid\"}", ResidentKeyRequirementTest.TestDTO.class)
+        );
+    }
+
+    public static class TestDTO {
+        public ResidentKeyRequirement residentKey;
+    }
+
+
+}


### PR DESCRIPTION
New enum `ResidentKeyRequirement` is introduced from WebAuthn Level2 WD1, which is used in `AuthenticatorSelectionCriteria`. This change reflect it.
https://www.w3.org/TR/2019/WD-webauthn-2-20191126/#sctn-credential-storage-modality

This PR addresses #268