### PR TITLE
Bugfix: CredentialPropertiesExtensionClientOutput

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/CredentialPropertiesExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/CredentialPropertiesExtensionClientOutput.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 public class CredentialPropertiesExtensionClientOutput
         extends AbstractExtensionOutput<CredentialPropertiesExtensionClientOutput.CredentialPropertiesOutput>
-        implements AuthenticationExtensionClientOutput<CredentialPropertiesExtensionClientOutput.CredentialPropertiesOutput> {
+        implements RegistrationExtensionClientOutput<CredentialPropertiesExtensionClientOutput.CredentialPropertiesOutput> {
 
     public static final String ID = "credProps";
 


### PR DESCRIPTION
As credProps is a registration extension, CredentialPropertiesExtensionClientOutput must implement RegistrationExtensionClientOutput