### PR TITLE
Deprecate removed extensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,9 @@ subprojects {
     }
 
     tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:unchecked" << "-Werror" << "-Xlint:deprecation"
+        options.compilerArgs << "-Xlint:unchecked"
+        options.compilerArgs << "-Werror"
+        // options.compilerArgs << "-Xlint:deprecation" //TODO: uncomment when deprecated extensions are removed
     }
 
     check.dependsOn dependencyCheckAnalyze

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/AuthenticationExtensionsSupported.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/AuthenticationExtensionsSupported.java
@@ -27,9 +27,10 @@ import java.util.Objects;
 
 /**
  * List of supported extensions as an array of extension identifier strings.
- *
+ * @deprecated
  * @see <a href="https://www.w3.org/TR/webauthn-1/#ref-for-typedefdef-authenticationextensionssupported">§10.5. Supported Extensions Extension (exts) - Client extension output</a>
  */
+@Deprecated
 public class AuthenticationExtensionsSupported extends AbstractList<String> implements Serializable {
 
     private final int size;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/Coordinates.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/Coordinates.java
@@ -23,8 +23,10 @@ import java.util.Objects;
  * Location information in the authenticator extension output as a Coordinates value,
  * as defined by [Geolocation-API].
  *
+ * @deprecated
  * @see <a href="https://www.w3.org/TR/webauthn-1/#dictdef-authenticationextensionsclientoutputs">§10.7. Location Extension (loc) - Client extension output</a>
  */
+@Deprecated
 public class Coordinates implements Serializable {
 
     private Double latitude;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/GenericTransactionAuthorizationExtensionAuthenticatorOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/GenericTransactionAuthorizationExtensionAuthenticatorOutput.java
@@ -19,6 +19,10 @@ package com.webauthn4j.data.extension.authenticator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.webauthn4j.data.extension.AbstractExtensionOutput;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class GenericTransactionAuthorizationExtensionAuthenticatorOutput
         extends AbstractExtensionOutput<byte[]>
         implements AuthenticationExtensionAuthenticatorOutput<byte[]> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/LocationExtensionAuthenticatorOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/LocationExtensionAuthenticatorOutput.java
@@ -20,6 +20,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.webauthn4j.data.extension.AbstractExtensionOutput;
 import com.webauthn4j.data.extension.Coordinates;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class LocationExtensionAuthenticatorOutput
         extends AbstractExtensionOutput<Coordinates>
         implements RegistrationExtensionAuthenticatorOutput<Coordinates>, AuthenticationExtensionAuthenticatorOutput<Coordinates> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/SimpleTransactionAuthorizationExtensionAuthenticatorOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/SimpleTransactionAuthorizationExtensionAuthenticatorOutput.java
@@ -19,6 +19,10 @@ package com.webauthn4j.data.extension.authenticator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.webauthn4j.data.extension.AbstractExtensionOutput;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class SimpleTransactionAuthorizationExtensionAuthenticatorOutput
         extends AbstractExtensionOutput<String>
         implements AuthenticationExtensionAuthenticatorOutput<String> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/SupportedExtensionsExtensionAuthenticatorInput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/SupportedExtensionsExtensionAuthenticatorInput.java
@@ -19,6 +19,10 @@ package com.webauthn4j.data.extension.authenticator;
 import com.webauthn4j.data.extension.AbstractExtensionInput;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionClientInput;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class SupportedExtensionsExtensionAuthenticatorInput extends AbstractExtensionInput<Boolean> implements AuthenticationExtensionClientInput<Boolean> {
 
     public static final String ID = "exts";

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/SupportedExtensionsExtensionAuthenticatorOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/SupportedExtensionsExtensionAuthenticatorOutput.java
@@ -22,6 +22,10 @@ import com.webauthn4j.data.extension.AuthenticationExtensionsSupported;
 
 import java.util.List;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class SupportedExtensionsExtensionAuthenticatorOutput
         extends AbstractExtensionOutput<AuthenticationExtensionsSupported>
         implements RegistrationExtensionAuthenticatorOutput<AuthenticationExtensionsSupported> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/UserVerificationIndexExtensionAuthenticatorOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/UserVerificationIndexExtensionAuthenticatorOutput.java
@@ -19,6 +19,10 @@ package com.webauthn4j.data.extension.authenticator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.webauthn4j.data.extension.AbstractExtensionOutput;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class UserVerificationIndexExtensionAuthenticatorOutput
         extends AbstractExtensionOutput<byte[]>
         implements RegistrationExtensionAuthenticatorOutput<byte[]>, AuthenticationExtensionAuthenticatorOutput<byte[]> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticatorSelectionExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticatorSelectionExtensionClientOutput.java
@@ -19,6 +19,10 @@ package com.webauthn4j.data.extension.client;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.webauthn4j.data.extension.AbstractExtensionOutput;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class AuthenticatorSelectionExtensionClientOutput
         extends AbstractExtensionOutput<Boolean>
         implements RegistrationExtensionClientOutput<Boolean> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/BiometricAuthenticatorPerformanceBoundsExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/BiometricAuthenticatorPerformanceBoundsExtensionClientOutput.java
@@ -19,6 +19,10 @@ package com.webauthn4j.data.extension.client;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.webauthn4j.data.extension.AbstractExtensionOutput;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class BiometricAuthenticatorPerformanceBoundsExtensionClientOutput
         extends AbstractExtensionOutput<Boolean>
         implements RegistrationExtensionClientOutput<Boolean> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/GenericTransactionAuthorizationExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/GenericTransactionAuthorizationExtensionClientOutput.java
@@ -23,6 +23,10 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class GenericTransactionAuthorizationExtensionClientOutput
         extends AbstractExtensionOutput<GenericTransactionAuthorizationExtensionClientOutput.TxAuthnGenericArg>
         implements AuthenticationExtensionClientOutput<GenericTransactionAuthorizationExtensionClientOutput.TxAuthnGenericArg> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/LocationExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/LocationExtensionClientOutput.java
@@ -20,6 +20,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.webauthn4j.data.extension.AbstractExtensionOutput;
 import com.webauthn4j.data.extension.Coordinates;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class LocationExtensionClientOutput
         extends AbstractExtensionOutput<Coordinates>
         implements RegistrationExtensionClientOutput<Coordinates>, AuthenticationExtensionClientOutput<Coordinates> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/SimpleTransactionAuthorizationExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/SimpleTransactionAuthorizationExtensionClientOutput.java
@@ -19,6 +19,10 @@ package com.webauthn4j.data.extension.client;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.webauthn4j.data.extension.AbstractExtensionOutput;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class SimpleTransactionAuthorizationExtensionClientOutput
         extends AbstractExtensionOutput<String>
         implements AuthenticationExtensionClientOutput<String> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/SupportedExtensionsExtensionClientInput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/SupportedExtensionsExtensionClientInput.java
@@ -18,6 +18,10 @@ package com.webauthn4j.data.extension.client;
 
 import com.webauthn4j.data.extension.AbstractExtensionInput;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class SupportedExtensionsExtensionClientInput extends AbstractExtensionInput<Boolean> implements RegistrationExtensionClientInput<Boolean> {
 
     public static final String ID = "exts";

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/SupportedExtensionsExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/SupportedExtensionsExtensionClientOutput.java
@@ -22,6 +22,10 @@ import com.webauthn4j.data.extension.AuthenticationExtensionsSupported;
 
 import java.util.List;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class SupportedExtensionsExtensionClientOutput
         extends AbstractExtensionOutput<AuthenticationExtensionsSupported>
         implements RegistrationExtensionClientOutput<AuthenticationExtensionsSupported> {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/UserVerificationIndexExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/UserVerificationIndexExtensionClientOutput.java
@@ -21,6 +21,10 @@ import com.webauthn4j.data.extension.AbstractExtensionOutput;
 
 import java.util.Arrays;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class UserVerificationIndexExtensionClientOutput
         extends AbstractExtensionOutput<byte[]>
         implements RegistrationExtensionClientOutput<byte[]>, AuthenticationExtensionClientOutput<byte[]> {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorDataConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorDataConverterTest.java
@@ -22,6 +22,8 @@ import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
 import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
 import com.webauthn4j.data.extension.authenticator.SupportedExtensionsExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.client.CredentialPropertiesExtensionClientOutput;
+import com.webauthn4j.data.extension.client.FIDOAppIDExtensionClientOutput;
 import com.webauthn4j.util.Base64UrlUtil;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Extensions unimplemented by client platforms(browsers) are removed from WebAuthn Level2 spec.
This commit reflect the change.

Deprecated extensions will be removed in 0.13.0.RELEASE.