### PR TITLE
Split WebAuthnManager

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnAuthenticationManager.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnAuthenticationManager.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j;
+
+import com.webauthn4j.converter.*;
+import com.webauthn4j.converter.exception.DataConversionException;
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.AuthenticationData;
+import com.webauthn4j.data.AuthenticationParameters;
+import com.webauthn4j.data.AuthenticationRequest;
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.util.AssertUtil;
+import com.webauthn4j.validator.AuthenticationDataValidator;
+import com.webauthn4j.validator.CustomAuthenticationValidator;
+import com.webauthn4j.validator.exception.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+
+public class WebAuthnAuthenticationManager {
+
+    // ~ Instance fields
+    // ================================================================================================
+
+    private final CollectedClientDataConverter collectedClientDataConverter;
+    private final AuthenticatorDataConverter authenticatorDataConverter;
+    private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter;
+
+    private final AuthenticationDataValidator authenticationDataValidator;
+
+    public WebAuthnAuthenticationManager(List<CustomAuthenticationValidator> customAuthenticationValidators, ObjectConverter objectConverter) {
+        AssertUtil.notNull(customAuthenticationValidators, "customAuthenticationValidators must not be null");
+        AssertUtil.notNull(objectConverter, "objectConverter must not be null");
+
+        authenticationDataValidator = new AuthenticationDataValidator(customAuthenticationValidators);
+
+        collectedClientDataConverter = new CollectedClientDataConverter(objectConverter);
+        authenticatorDataConverter = new AuthenticatorDataConverter(objectConverter);
+        authenticationExtensionsClientOutputsConverter = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
+    }
+
+    public WebAuthnAuthenticationManager(List<CustomAuthenticationValidator> customAuthenticationValidators) {
+        this(customAuthenticationValidators, new ObjectConverter());
+    }
+
+    public WebAuthnAuthenticationManager() {
+        this(Collections.emptyList(), new ObjectConverter());
+    }
+
+    @SuppressWarnings("squid:S1130")
+    public AuthenticationData parse(AuthenticationRequest authenticationRequest) throws DataConversionException {
+
+        byte[] credentialId = authenticationRequest.getCredentialId();
+        byte[] signature = authenticationRequest.getSignature();
+        byte[] userHandle = authenticationRequest.getUserHandle();
+        byte[] clientDataBytes = authenticationRequest.getClientDataJSON();
+        CollectedClientData collectedClientData = collectedClientDataConverter.convert(clientDataBytes);
+        byte[] authenticatorDataBytes = authenticationRequest.getAuthenticatorData();
+        AuthenticatorData<AuthenticationExtensionAuthenticatorOutput<?>> authenticatorData = authenticatorDataConverter.convert(authenticatorDataBytes);
+
+        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput<?>> clientExtensions =
+                authenticationExtensionsClientOutputsConverter.convert(authenticationRequest.getClientExtensionsJSON());
+
+        return new AuthenticationData(
+                credentialId,
+                userHandle,
+                authenticatorData,
+                authenticatorDataBytes,
+                collectedClientData,
+                clientDataBytes,
+                clientExtensions,
+                signature
+        );
+
+    }
+
+    @SuppressWarnings("squid:S1130")
+    public AuthenticationData validate(AuthenticationRequest authenticationRequest, AuthenticationParameters authenticationParameters) throws DataConversionException, ValidationException {
+        AuthenticationData authenticationData = parse(authenticationRequest);
+        validate(authenticationData, authenticationParameters);
+        return authenticationData;
+    }
+
+    @SuppressWarnings("squid:S1130")
+    public AuthenticationData validate(AuthenticationData authenticationData, AuthenticationParameters authenticationParameters) throws ValidationException {
+        authenticationDataValidator.validate(authenticationData, authenticationParameters);
+        return authenticationData;
+    }
+
+    public AuthenticationDataValidator getAuthenticationDataValidator() {
+        return authenticationDataValidator;
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationManagerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationManagerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.validator.CustomAuthenticationValidator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class WebAuthnAuthenticationManagerTest {
+
+    @Test
+    void constructor_test() {
+        ObjectConverter objectConverter = new ObjectConverter();
+        List<CustomAuthenticationValidator> customAuthenticationValidators = Collections.emptyList();
+        assertThatCode(WebAuthnAuthenticationManager::new).doesNotThrowAnyException();
+        assertThatCode(()-> new WebAuthnAuthenticationManager(customAuthenticationValidators)).doesNotThrowAnyException();
+        assertThatCode(()-> new WebAuthnAuthenticationManager(customAuthenticationValidators, objectConverter)).doesNotThrowAnyException();
+    }
+
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnRegistrationManagerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnRegistrationManagerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j;
+
+import com.webauthn4j.anchor.TrustAnchorsResolver;
+import com.webauthn4j.test.TestAttestationUtil;
+import com.webauthn4j.validator.attestation.statement.androidkey.AndroidKeyAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.none.NoneAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.packed.PackedAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.u2f.FIDOU2FAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.certpath.TrustAnchorCertPathTrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.DefaultECDAATrustworthinessValidator;
+import com.webauthn4j.validator.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessValidator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+class WebAuthnRegistrationManagerTest {
+
+    @Test
+    void constructor_test() {
+        NoneAttestationStatementValidator noneAttestationStatementValidator = new NoneAttestationStatementValidator();
+        PackedAttestationStatementValidator packedAttestationStatementValidator = new PackedAttestationStatementValidator();
+        FIDOU2FAttestationStatementValidator fidoU2FAttestationStatementValidator = new FIDOU2FAttestationStatementValidator();
+        AndroidKeyAttestationStatementValidator androidKeyAttestationStatementValidator = new AndroidKeyAttestationStatementValidator();
+        TrustAnchorsResolver trustAnchorsResolver = TestAttestationUtil.createTrustAnchorProviderWith3tierTestRootCACertificate();
+        WebAuthnRegistrationManager webAuthnRegistrationManager = new WebAuthnRegistrationManager(
+                Arrays.asList(
+                        noneAttestationStatementValidator,
+                        packedAttestationStatementValidator,
+                        fidoU2FAttestationStatementValidator,
+                        androidKeyAttestationStatementValidator),
+                new TrustAnchorCertPathTrustworthinessValidator(trustAnchorsResolver),
+                new DefaultECDAATrustworthinessValidator(),
+                new DefaultSelfAttestationTrustworthinessValidator()
+        );
+        assertThat(webAuthnRegistrationManager).isNotNull();
+    }
+
+    @Test
+    void createNonStrictWebAuthnRegistrationManager_test() {
+        assertThat(WebAuthnRegistrationManager.createNonStrictWebAuthnRegistrationManager()).isNotNull();
+    }
+
+
+}


### PR DESCRIPTION
`WebAuthnManager` is intended that its instance is shared between registration phase and authentication phase to keep configuration consistency easily. 
But in some use-cases, sharing its instance between two phases are not straight-forward and restricts application design, this pull-request splits `WebAuthnManager` into `WebAuthnRegistrationManager` and `WebAuthnAuthenticationManager` and delegates processing to these classes.
With this change Validator for authentication phase can be initialized
without attestation statement validation configuration.