### PR TITLE
Define dependency version in a proper way

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,6 @@ allprojects {
 
 subprojects {
 
-    apply plugin: 'java'
     apply plugin: 'java-library'
     apply plugin: 'jacoco'
     apply plugin: 'com.jfrog.bintray'
@@ -67,21 +66,26 @@ subprojects {
 
     sourceCompatibility = 1.8
 
+    test {
+        useJUnitPlatform()
+    }
+
     repositories {
         mavenCentral()
     }
 
     def springBootVersion = "2.3.0.RELEASE"
-    def bouncyCastleVersion = "1.65"
     def kerbyVersion = "2.0.0"
+    def bouncyCastleVersion = "1.65"
 
     dependencies {
-        // Independent libraries
-        implementation ("org.apache.kerby:kerby-asn1:$kerbyVersion")
-        implementation ("org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion")
-        implementation ("org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion")
+        constraints {
+            // Independent libraries
+            implementation ("org.apache.kerby:kerby-asn1:$kerbyVersion")
+            implementation ("org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion")
+            implementation ("org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion")
+        }
 
-        // BOM
         implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
     }
 
@@ -241,7 +245,6 @@ subprojects {
             }
         }
     }
-
 }
 
 check.dependsOn dependencyCheckAggregate

--- a/webauthn4j-core/build.gradle
+++ b/webauthn4j-core/build.gradle
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-group 'com.webauthn4j'
-version "${webAuthn4JVersion}"
-
 description = "WebAuthn4J Core library"
-
-test {
-    useJUnitPlatform()
-}
 
 dependencies {
     api project(':webauthn4j-util')

--- a/webauthn4j-metadata/build.gradle
+++ b/webauthn4j-metadata/build.gradle
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-group 'com.webauthn4j'
-version "${webAuthn4JVersion}"
-
 description = "WebAuthn4J Metadata library"
-
-test {
-    useJUnitPlatform()
-}
 
 dependencies {
     api project(':webauthn4j-core')

--- a/webauthn4j-test/build.gradle
+++ b/webauthn4j-test/build.gradle
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-group 'com.webauthn4j'
-version "${webAuthn4JVersion}"
-
 description = "Package that contains testing classes for WebAuthn4J"
-
-test {
-    useJUnitPlatform()
-}
 
 dependencies {
     implementation project(':webauthn4j-core')

--- a/webauthn4j-util/build.gradle
+++ b/webauthn4j-util/build.gradle
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-group 'com.webauthn4j'
-version "${webAuthn4JVersion}"
-
 description = "Package that contains utility classes for WebAuthn4J"
-
-test {
-    useJUnitPlatform()
-}
 
 dependencies {
 


### PR DESCRIPTION
To define dependency version, constraints block need to be used.
This commit corrects inappropriate definitions.