### PR TITLE
Relax origin scheme requirement within Origin class

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/server/ServerProperty.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/server/ServerProperty.java
@@ -21,6 +21,8 @@ import com.webauthn4j.data.client.challenge.Challenge;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -31,7 +33,7 @@ public class ServerProperty implements Serializable {
     // ~ Instance fields
     // ================================================================================================
 
-    private final Origin origin;
+    private final List<Origin> origins;
     private final String rpId;
     private final Challenge challenge;
     private final byte[] tokenBindingId;
@@ -40,7 +42,19 @@ public class ServerProperty implements Serializable {
     // ========================================================================================================
 
     public ServerProperty(Origin origin, String rpId, Challenge challenge, byte[] tokenBindingId) {
-        this.origin = origin;
+        if(origin == null){
+            this.origins = null;
+        }
+        else {
+            this.origins = Collections.singletonList(origin);
+        }
+        this.rpId = rpId;
+        this.challenge = challenge;
+        this.tokenBindingId = tokenBindingId;
+    }
+
+    public ServerProperty(List<Origin> origins, String rpId, Challenge challenge, byte[] tokenBindingId) {
+        this.origins = origins;
         this.rpId = rpId;
         this.challenge = challenge;
         this.tokenBindingId = tokenBindingId;
@@ -50,12 +64,28 @@ public class ServerProperty implements Serializable {
     // ========================================================================================================
 
     /**
+     * @deprecated
      * Returns the {@link Origin}
      *
      * @return the {@link Origin}
      */
+    @Deprecated
     public Origin getOrigin() {
-        return origin;
+        if(origins == null || origins.isEmpty()){
+            return null;
+        }
+        else {
+            return origins.get(0);
+        }
+    }
+
+    /**
+     * Returns the {@link Origin} list
+     *
+     * @return the {@link Origin} list
+     */
+    public List<Origin> getOrigins() {
+        return origins;
     }
 
     /**
@@ -90,7 +120,7 @@ public class ServerProperty implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ServerProperty that = (ServerProperty) o;
-        return Objects.equals(origin, that.origin) &&
+        return Objects.equals(origins, that.origins) &&
                 Objects.equals(rpId, that.rpId) &&
                 Objects.equals(challenge, that.challenge) &&
                 Arrays.equals(tokenBindingId, that.tokenBindingId);
@@ -98,8 +128,7 @@ public class ServerProperty implements Serializable {
 
     @Override
     public int hashCode() {
-
-        int result = Objects.hash(origin, rpId, challenge);
+        int result = Objects.hash(origins, rpId, challenge);
         result = 31 * result + Arrays.hashCode(tokenBindingId);
         return result;
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
@@ -214,14 +214,14 @@ class BeanAssertUtil {
         if (serverProperty == null) {
             throw new ConstraintViolationException("serverProperty must not be null");
         }
+        if (serverProperty.getOrigins() == null) {
+            throw new ConstraintViolationException("origin must not be null");
+        }
         if (serverProperty.getRpId() == null) {
             throw new ConstraintViolationException("rpId must not be null");
         }
         if (serverProperty.getChallenge() == null) {
             throw new ConstraintViolationException("challenge must not be null");
-        }
-        if (serverProperty.getOrigin() == null) {
-            throw new ConstraintViolationException("origin must not be null");
         }
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/OriginValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/OriginValidator.java
@@ -40,7 +40,8 @@ class OriginValidator {
         AssertUtil.notNull(collectedClientData, "collectedClientData must not be null");
         AssertUtil.notNull(serverProperty, "serverProperty must not be null");
 
-        if (!Objects.equals(collectedClientData.getOrigin(), serverProperty.getOrigin())) {
+
+        if (serverProperty.getOrigins().stream().noneMatch(origin -> Objects.equals(origin, collectedClientData.getOrigin()))) {
             throw new BadOriginException("The collectedClientData origin doesn't match the preconfigured server origin.");
         }
     }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverterTest.java
@@ -27,7 +27,7 @@ class AuthenticationExtensionsClientOutputsConverterTest {
     private final ObjectConverter objectConverter = new ObjectConverter();
 
     private final AuthenticationExtensionsClientOutputsConverter target = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
-    
+
     @Test
     void convert_null_test() {
         assertThat(target.convert(null)).isNull();

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
@@ -34,27 +34,6 @@ class OriginTest {
     private final JsonConverter jsonConverter = objectConverter.getJsonConverter();
 
     @Test
-    void equals_test() {
-        Origin https_examplecom_default = new Origin("https://example.com");
-        Origin https_examplecom_443 = new Origin("https://example.com:443");
-        Origin http_examplecom_default = new Origin("http://example.com");
-        Origin http_examplecom_80 = new Origin("http://example.com:80");
-        Origin http_examplecom_8080 = new Origin("http://example.com:8080");
-        Origin android_apk_key_hash_abc123_a = new Origin("android:apk-key-hash:abc123");
-        Origin android_apk_key_hash_abc123_b = new Origin("android:apk-key-hash:abc123");
-        Origin android_apk_key_hash_def456 = new Origin("android:apk-key-hash:def");
-
-        assertAll(
-                () -> assertThat(https_examplecom_default).isEqualTo(https_examplecom_443),
-                () -> assertThat(http_examplecom_default).isEqualTo(http_examplecom_80),
-                () -> assertThat(http_examplecom_default).isNotEqualTo(http_examplecom_8080),
-                () -> assertThat(http_examplecom_default).isNotEqualTo(https_examplecom_default),
-                () -> assertThat(android_apk_key_hash_abc123_a).isEqualTo(android_apk_key_hash_abc123_b),
-                () -> assertThat(android_apk_key_hash_abc123_a).isNotEqualTo(android_apk_key_hash_def456)
-        );
-    }
-
-    @Test
     void getter_test() {
         Origin https_examplecom_default = new Origin("https://example.com");
         assertAll(
@@ -144,18 +123,45 @@ class OriginTest {
         assertThatCode(() -> new Origin("example.com")).doesNotThrowAnyException();
     }
 
+
+    @Test
+    void equals_test() {
+        Origin https_examplecom_default = new Origin("https://example.com");
+        Origin https_examplecom_443 = new Origin("https://example.com:443");
+        Origin http_examplecom_default = new Origin("http://example.com");
+        Origin http_examplecom_80 = new Origin("http://example.com:80");
+        Origin http_examplecom_8080 = new Origin("http://example.com:8080");
+        Origin android_apk_key_hash_abc123_a = new Origin("android:apk-key-hash:abc123");
+        Origin android_apk_key_hash_abc123_b = new Origin("android:apk-key-hash:abc123");
+        Origin android_apk_key_hash_def456 = new Origin("android:apk-key-hash:def");
+
+        assertAll(
+                () -> assertThat(https_examplecom_default).isEqualTo(https_examplecom_443),
+                () -> assertThat(http_examplecom_default).isEqualTo(http_examplecom_80),
+                () -> assertThat(http_examplecom_default).isNotEqualTo(http_examplecom_8080),
+                () -> assertThat(http_examplecom_default).isNotEqualTo(https_examplecom_default),
+                () -> assertThat(android_apk_key_hash_abc123_a).isEqualTo(android_apk_key_hash_abc123_b),
+                () -> assertThat(android_apk_key_hash_abc123_a).isNotEqualTo(android_apk_key_hash_def456)
+        );
+    }
+
     @Test
     @SuppressWarnings("deprecation")
     void hasCode_test() {
         Origin originA = new Origin("https://example.com");
         Origin originB = new Origin("https", "example.com", 443);
+        Origin originC = new Origin("http://localhost:8080");
+        Origin originD = new Origin("http", "localhost", 8080);
         Origin android_apk_key_hash_abc123_a = new Origin("android:apk-key-hash:abc123");
         Origin android_apk_key_hash_abc123_b = new Origin("android:apk-key-hash:abc123");
         Origin android_apk_key_hash_def456 = new Origin("android:apk-key-hash:def");
+        Origin invalid_data = new Origin("invalid:data");
 
         assertThat(originA).hasSameHashCodeAs(originB);
+        assertThat(originC).hasSameHashCodeAs(originD);
         assertThat(android_apk_key_hash_abc123_a).hasSameHashCodeAs(android_apk_key_hash_abc123_b);
         assertThat(android_apk_key_hash_abc123_a.hashCode()).isNotEqualTo(android_apk_key_hash_def456.hashCode());
+        assertThat(android_apk_key_hash_abc123_a.hashCode()).isNotEqualTo(invalid_data.hashCode());
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
@@ -16,12 +16,12 @@
 
 package com.webauthn4j.data.client;
 
-import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -40,12 +40,17 @@ class OriginTest {
         Origin http_examplecom_default = new Origin("http://example.com");
         Origin http_examplecom_80 = new Origin("http://example.com:80");
         Origin http_examplecom_8080 = new Origin("http://example.com:8080");
+        Origin android_apk_key_hash_abc123_a = new Origin("android:apk-key-hash:abc123");
+        Origin android_apk_key_hash_abc123_b = new Origin("android:apk-key-hash:abc123");
+        Origin android_apk_key_hash_def456 = new Origin("android:apk-key-hash:def");
 
         assertAll(
                 () -> assertThat(https_examplecom_default).isEqualTo(https_examplecom_443),
                 () -> assertThat(http_examplecom_default).isEqualTo(http_examplecom_80),
                 () -> assertThat(http_examplecom_default).isNotEqualTo(http_examplecom_8080),
-                () -> assertThat(http_examplecom_default).isNotEqualTo(https_examplecom_default)
+                () -> assertThat(http_examplecom_default).isNotEqualTo(https_examplecom_default),
+                () -> assertThat(android_apk_key_hash_abc123_a).isEqualTo(android_apk_key_hash_abc123_b),
+                () -> assertThat(android_apk_key_hash_abc123_a).isNotEqualTo(android_apk_key_hash_def456)
         );
     }
 
@@ -55,11 +60,41 @@ class OriginTest {
         assertAll(
                 () -> assertThat(https_examplecom_default.getScheme()).isEqualTo("https"),
                 () -> assertThat(https_examplecom_default.getHost()).isEqualTo("example.com"),
-                () -> assertThat(https_examplecom_default.getPort()).isEqualTo(443)
+                () -> assertThat(https_examplecom_default.getPort()).isEqualTo(443),
+                () -> assertThat(https_examplecom_default.getSchemeSpecificPart()).isNull()
+        );
+        Origin https_examplecom_443 = new Origin("https://example.com:443");
+        assertAll(
+                () -> assertThat(https_examplecom_443.getScheme()).isEqualTo("https"),
+                () -> assertThat(https_examplecom_443.getHost()).isEqualTo("example.com"),
+                () -> assertThat(https_examplecom_443.getPort()).isEqualTo(443),
+                () -> assertThat(https_examplecom_443.getSchemeSpecificPart()).isNull()
+        );
+        Origin android_apk_key_hash_abc123 = new Origin("android:apk-key-hash:abc123");
+        assertAll(
+                () -> assertThat(android_apk_key_hash_abc123.getScheme()).isEqualTo("android"),
+                () -> assertThat(android_apk_key_hash_abc123.getHost()).isNull(),
+                () -> assertThat(android_apk_key_hash_abc123.getPort()).isNull(),
+                () -> assertThat(android_apk_key_hash_abc123.getSchemeSpecificPart()).isEqualTo("apk-key-hash:abc123")
         );
     }
 
     @Test
+    void toString_test(){
+        assertAll(
+                ()-> assertThat(new Origin("example.com")).hasToString("example.com"),
+                ()-> assertThat(new Origin("https://example.com")).hasToString("https://example.com"),
+                ()-> assertThat(new Origin("https://example.com:443")).hasToString("https://example.com:443"),
+                ()-> assertThat(new Origin("https://example.com:8443")).hasToString("https://example.com:8443"),
+                ()-> assertThat(new Origin("http://example.com")).hasToString("http://example.com"),
+                ()-> assertThat(new Origin("http://example.com:80")).hasToString("http://example.com:80"),
+                ()-> assertThat(new Origin("http://example.com:8080")).hasToString("http://example.com:8080"),
+                ()-> assertThat(new Origin("android:apk-key-hash:abc123")).hasToString("android:apk-key-hash:abc123")
+        );
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     void constructor_test() {
         Origin originA = new Origin("https://example.com");
         Origin originB = new Origin("https", "example.com", 443);
@@ -68,6 +103,7 @@ class OriginTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void constructor_test_with_illegal_input() {
         assertThrows(IllegalArgumentException.class,
                 () -> new Origin("ftp", "example.com", 80)
@@ -75,6 +111,7 @@ class OriginTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void constructor_test_with_null_input() {
         assertThrows(IllegalArgumentException.class,
                 () -> new Origin(null, "example.com", 80)
@@ -82,25 +119,43 @@ class OriginTest {
     }
 
     @Test
-    void single_string_constructor_test_with_illegal_input() {
+    void create_with_null_test(){
         assertThrows(IllegalArgumentException.class,
-                () -> new Origin("ftp://example.com")
+                () -> Origin.create(null)
         );
+    }
+
+    @Test
+    void explicit_port_notation_and_non_explicit_port_notation_comparison_test(){
+        assertThat(new Origin("https://example.com:443")).isEqualTo(new Origin("https://example.com"));
+        assertThat(new Origin("https://example.com:443")).hasToString("https://example.com:443");
+    }
+
+
+    @Test
+    void single_string_constructor_test_with_illegal_input() {
+        // invalid scheme is to be handled by validator
+        assertThatCode(() -> new Origin("ftp://example.com")).doesNotThrowAnyException();
     }
 
     @Test
     void single_string_constructor_test_without_scheme_input() {
-        assertThrows(IllegalArgumentException.class,
-                () -> new Origin("example.com")
-        );
+        // invalid scheme is to be handled by validator
+        assertThatCode(() -> new Origin("example.com")).doesNotThrowAnyException();
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void hasCode_test() {
         Origin originA = new Origin("https://example.com");
         Origin originB = new Origin("https", "example.com", 443);
+        Origin android_apk_key_hash_abc123_a = new Origin("android:apk-key-hash:abc123");
+        Origin android_apk_key_hash_abc123_b = new Origin("android:apk-key-hash:abc123");
+        Origin android_apk_key_hash_def456 = new Origin("android:apk-key-hash:def");
 
-        assertThat(originA.hashCode()).isEqualTo(originB.hashCode());
+        assertThat(originA).hasSameHashCodeAs(originB);
+        assertThat(android_apk_key_hash_abc123_a).hasSameHashCodeAs(android_apk_key_hash_abc123_b);
+        assertThat(android_apk_key_hash_abc123_a.hashCode()).isNotEqualTo(android_apk_key_hash_def456.hashCode());
     }
 
     @Test
@@ -111,9 +166,8 @@ class OriginTest {
 
     @Test
     void fromString_test_with_invalid_value() {
-        assertThrows(DataConversionException.class,
-                () -> jsonConverter.readValue("{\"origin\":\"file://example.com\"}", TestDTO.class)
-        );
+        // invalid scheme is to be handled by validator
+        assertThatCode(() -> jsonConverter.readValue("{\"origin\":\"file://example.com\"}", TestDTO.class)).doesNotThrowAnyException();
     }
 
     static class TestDTO {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/server/ServerPropertyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/server/ServerPropertyTest.java
@@ -16,15 +16,27 @@
 
 package com.webauthn4j.server;
 
+import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.test.TestDataUtil;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ServerPropertyTest {
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void getOrigin_test(){
+        Origin origin = new Origin("https://example.com");
+        assertThat(new ServerProperty(origin, "example.com", new DefaultChallenge(), null).getOrigin()).isEqualTo(origin);
+        assertThat(new ServerProperty(Collections.emptyList(), "example.com", new DefaultChallenge(), null).getOrigin()).isNull();;
+        assertThat(new ServerProperty((Origin) null, "example.com", new DefaultChallenge(), null).getOrigin()).isNull();;
+    }
 
     @Test
     void equals_hashCode_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
@@ -24,6 +24,7 @@ import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.client.*;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.test.TestAttestationStatementUtil;
 import com.webauthn4j.test.TestDataUtil;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -530,4 +532,37 @@ class BeanAssertUtilTest {
                 () -> BeanAssertUtil.validate(attestationObject)
         );
     }
+
+    @Test
+    void validate_serverProperty_with_null_test(){
+        assertThrows(ConstraintViolationException.class,
+                () -> BeanAssertUtil.validate((ServerProperty) null)
+        );
+    }
+
+    @Test
+    void validate_serverProperty_with_origins_null_test(){
+        ServerProperty serverProperty = new ServerProperty((List<Origin>) null, "example.com", new DefaultChallenge(), null);
+        assertThrows(ConstraintViolationException.class,
+                () -> BeanAssertUtil.validate(serverProperty)
+        );
+    }
+
+    @Test
+    void validate_serverProperty_with_rpId_null_test(){
+        ServerProperty serverProperty = new ServerProperty(new Origin("https://example.com"), null, new DefaultChallenge(), null);
+                assertThrows(ConstraintViolationException.class,
+                () -> BeanAssertUtil.validate(serverProperty)
+        );
+    }
+
+    @Test
+    void validate_serverProperty_with_challenge_null_test(){
+        ServerProperty serverProperty = new ServerProperty(new Origin("https://example.com"), "example.com", null, null);
+        assertThrows(ConstraintViolationException.class,
+                () -> BeanAssertUtil.validate(serverProperty)
+        );
+    }
+
+
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/ChallengeValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/ChallengeValidatorTest.java
@@ -18,6 +18,7 @@ package com.webauthn4j.validator;
 
 import com.webauthn4j.data.client.ClientDataType;
 import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.server.ServerProperty;
@@ -42,7 +43,7 @@ class ChallengeValidatorTest {
         Challenge challengeB = new DefaultChallenge(new byte[]{0x00});
 
         CollectedClientData collectedClientData = new CollectedClientData(ClientDataType.CREATE, challengeA, null, null);
-        ServerProperty serverProperty = new ServerProperty(null, null, challengeB, null);
+        ServerProperty serverProperty = new ServerProperty((Origin) null, null, challengeB, null);
 
         //When
         target.validate(collectedClientData, serverProperty);
@@ -55,7 +56,7 @@ class ChallengeValidatorTest {
         Challenge challengeB = new DefaultChallenge(new byte[]{0x01});
 
         CollectedClientData collectedClientData = new CollectedClientData(ClientDataType.CREATE, challengeA, null, null);
-        ServerProperty serverProperty = new ServerProperty(null, null, challengeB, null);
+        ServerProperty serverProperty = new ServerProperty((Origin) null, null, challengeB, null);
 
         //When
         assertThrows(BadChallengeException.class,
@@ -70,7 +71,7 @@ class ChallengeValidatorTest {
         Challenge challengeB = null;
 
         CollectedClientData collectedClientData = new CollectedClientData(ClientDataType.CREATE, challengeA, null, null);
-        ServerProperty serverProperty = new ServerProperty(null, null, challengeB, null);
+        ServerProperty serverProperty = new ServerProperty((Origin) null, null, challengeB, null);
 
         //When
         assertThrows(MissingChallengeException.class,

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/RpIdHashValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/RpIdHashValidatorTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.validator;
 
+import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.MessageDigestUtil;
 import com.webauthn4j.validator.exception.BadRpIdException;
@@ -40,7 +41,7 @@ class RpIdHashValidatorTest {
         byte[] rpIdBytesA = rpIdA.getBytes(StandardCharsets.UTF_8);
         byte[] rpIdHashA = MessageDigestUtil.createSHA256().digest(rpIdBytesA);
 
-        ServerProperty serverProperty = new ServerProperty(null, rpIdB, null, null);
+        ServerProperty serverProperty = new ServerProperty((Origin) null, rpIdB, null, null);
 
         //When
         target.validate(rpIdHashA, serverProperty);
@@ -54,7 +55,7 @@ class RpIdHashValidatorTest {
         byte[] rpIdBytesA = rpIdA.getBytes(StandardCharsets.UTF_8);
         byte[] rpIdHashA = MessageDigestUtil.createSHA256().digest(rpIdBytesA);
 
-        ServerProperty serverProperty = new ServerProperty(null, rpIdB, null, null);
+        ServerProperty serverProperty = new ServerProperty((Origin) null, rpIdB, null, null);
 
         //When
         assertThrows(BadRpIdException.class,
@@ -84,7 +85,7 @@ class RpIdHashValidatorTest {
         byte[] rpIdBytesA = rpIdA.getBytes(StandardCharsets.UTF_8);
         byte[] rpIdHashA = MessageDigestUtil.createSHA256().digest(rpIdBytesA);
 
-        ServerProperty serverProperty = new ServerProperty(null, null, null, null);
+        ServerProperty serverProperty = new ServerProperty((Origin) null, null, null, null);
 
         //When
         assertThrows(IllegalArgumentException.class,


### PR DESCRIPTION
Relax origin scheme requirement within Origin class to accept "android" scheme from Android FIDO2 API.
Even if illegal scheme is provided, `OriginValidator` will reject the request by comparing with valid data.

`Origin#getPort` now returns `Integer` instread of `int` because non `https` or `http` schemes may not have `port`.