### PR TITLE
Deprecate expectedExtensionIds member

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
@@ -34,6 +34,10 @@ public class AuthenticationParameters implements Serializable {
     private final boolean userPresenceRequired;
     private final List<String> expectedExtensionIds;
 
+    /**
+     * @deprecated
+     */
+    @Deprecated
     public AuthenticationParameters(
             ServerProperty serverProperty,
             Authenticator authenticator,
@@ -89,6 +93,10 @@ public class AuthenticationParameters implements Serializable {
         return userPresenceRequired;
     }
 
+    /**
+     * @deprecated
+     */
+    @Deprecated
     public List<String> getExpectedExtensionIds() {
         return expectedExtensionIds;
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/RegistrationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/RegistrationParameters.java
@@ -33,6 +33,10 @@ public class RegistrationParameters implements Serializable {
     private final boolean userPresenceRequired;
     private final List<String> expectedExtensionIds;
 
+    /**
+     * @deprecated
+     */
+    @Deprecated
     public RegistrationParameters(ServerProperty serverProperty, boolean userVerificationRequired, boolean userPresenceRequired, List<String> expectedExtensionIds) {
         this.serverProperty = serverProperty;
         this.userVerificationRequired = userVerificationRequired;
@@ -60,6 +64,10 @@ public class RegistrationParameters implements Serializable {
         return userPresenceRequired;
     }
 
+    /**
+     * @deprecated
+     */
+    @Deprecated
     public List<String> getExpectedExtensionIds() {
         return expectedExtensionIds;
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
@@ -58,6 +58,7 @@ public class AuthenticationDataValidator {
         this.customAuthenticationValidators = new ArrayList<>();
     }
 
+    @SuppressWarnings("deprecation")
     public void validate(AuthenticationData authenticationData, AuthenticationParameters authenticationParameters) {
 
         BeanAssertUtil.validate(authenticationData);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
@@ -76,7 +76,7 @@ public class RegistrationDataValidator {
                 selfAttestationTrustworthinessValidator);
     }
 
-
+    @SuppressWarnings("deprecation")
     public void validate(RegistrationData registrationData, RegistrationParameters registrationParameters) {
 
         BeanAssertUtil.validate(registrationData);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthenticationParametersTest {
 
+    @SuppressWarnings("deprecation")
     @Test
     void constructor_test() {
         // Server properties
@@ -57,6 +58,7 @@ class AuthenticationParametersTest {
         assertThat(authenticationParameters.getExpectedExtensionIds()).isNull();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void equals_hashCode_test() {
         // Server properties

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
@@ -335,6 +335,7 @@ class BeanAssertUtilTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_AuthenticationParameters_test() {
         AuthenticationParameters authenticationParameters = new AuthenticationParameters(
@@ -354,6 +355,7 @@ class BeanAssertUtilTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_AuthenticationParameters_with_serverProperty_null_test() {
         AuthenticationParameters authenticationParameters = new AuthenticationParameters(
@@ -368,6 +370,7 @@ class BeanAssertUtilTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_AuthenticationParameters_with_authenticator_null_test() {
         AuthenticationParameters authenticationParameters = new AuthenticationParameters(
@@ -382,6 +385,7 @@ class BeanAssertUtilTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_AuthenticationParameters_with_expectedExtensionIds_null_test() {
         AuthenticationParameters authenticationParameters = new AuthenticationParameters(

--- a/webauthn4j-core/src/test/java/integration/scenario/AndroidKeyAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/AndroidKeyAuthenticatorRegistrationValidationTest.java
@@ -60,6 +60,7 @@ class AndroidKeyAuthenticatorRegistrationValidationTest {
     private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
             = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_RegistrationContext_with_android_key_attestation_statement_test() {
         String rpId = "example.com";

--- a/webauthn4j-core/src/test/java/integration/scenario/AndroidSafetyNetAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/AndroidSafetyNetAuthenticatorRegistrationValidationTest.java
@@ -61,6 +61,7 @@ class AndroidSafetyNetAuthenticatorRegistrationValidationTest {
     private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
             = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_RegistrationContext_with_android_safety_net_attestation_statement_test() {
         String rpId = "example.com";

--- a/webauthn4j-core/src/test/java/integration/scenario/CustomAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/CustomAuthenticationValidationTest.java
@@ -52,6 +52,7 @@ class CustomAuthenticationValidationTest {
     private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
             = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
 
+    @SuppressWarnings("deprecation")
     @Test
     void CustomAuthenticationValidator_test() {
         String rpId = "example.com";

--- a/webauthn4j-core/src/test/java/integration/scenario/CustomRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/CustomRegistrationValidationTest.java
@@ -64,6 +64,7 @@ class CustomRegistrationValidationTest {
     private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
             = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
 
+    @SuppressWarnings("deprecation")
     @Test
     void CustomRegistrationValidator_test() {
         String rpId = "example.com";

--- a/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorAuthenticationValidationTest.java
@@ -57,6 +57,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
     private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
             = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_test() {
         String rpId = "example.com";

--- a/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/FIDOU2FAuthenticatorRegistrationValidationTest.java
@@ -71,6 +71,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
     private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
             = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_test() {
         String rpId = "example.com";
@@ -116,6 +117,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_with_direct_attestation_conveyance_preference_test() {
         String rpId = "example.com";
@@ -172,6 +174,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_with_bad_clientData_type_test() {
         String rpId = "example.com";
@@ -214,6 +217,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_with_bad_challenge_test() {
         String rpId = "example.com";
@@ -252,6 +256,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_with_bad_origin_test() {
         String rpId = "example.com";
@@ -290,6 +295,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_with_bad_rpId_test() {
         String rpId = "example.com";
@@ -325,6 +331,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_with_bad_attestationStatement_test() {
         String rpId = "example.com";
@@ -365,6 +372,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_invalid_format_attestation_signature_test() {
         String rpId = "example.com";
@@ -418,6 +426,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_malicious_client_data_test() {
         Origin phishingSiteOrigin = new Origin("http://phishing.site.example.com");

--- a/webauthn4j-core/src/test/java/integration/scenario/TPMAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/TPMAuthenticatorRegistrationValidationTest.java
@@ -61,6 +61,7 @@ class TPMAuthenticatorRegistrationValidationTest {
     private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
             = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_RegistrationContext_with_tpm_attestation_statement_test() {
         String rpId = "example.com";

--- a/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/UserVerifyingAuthenticatorRegistrationValidationTest.java
@@ -185,6 +185,7 @@ class UserVerifyingAuthenticatorRegistrationValidationTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void validate_RegistrationRequest_with_unexpected_extension_test() {
         String rpId = "example.com";

--- a/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
@@ -46,6 +46,7 @@ public class WebAuthnManagerSample {
         webAuthnManager = WebAuthnManager.createNonStrictWebAuthnManager();
     }
 
+    @SuppressWarnings("deprecation")
     public void registrationValidationSample() {
 
         // Client properties
@@ -93,6 +94,7 @@ public class WebAuthnManagerSample {
     }
 
 
+    @SuppressWarnings("deprecation")
     public void authenticationValidationSample() {
         // Client properties
         byte[] credentialId = null /* set credentialId */;


### PR DESCRIPTION
from Parameters classes

As matching extension id(s) and expected list is no longer required from
WebAuthn Level 2 spec, deprecate the feature.
The feature will be removed by WebAuthn4J 1.0 GA release.