### PR TITLE
Redesign registration timestamp handling

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AttestationValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AttestationValidator.java
@@ -109,7 +109,7 @@ class AttestationValidator {
                     CertificateBaseAttestationStatement certificateBaseAttestationStatement =
                             (CertificateBaseAttestationStatement) attestationStatement;
                     AAGUID aaguid = attestationObject.getAuthenticatorData().getAttestedCredentialData().getAaguid();
-                    certPathTrustworthinessValidator.validate(aaguid, certificateBaseAttestationStatement);
+                    certPathTrustworthinessValidator.validate(aaguid, certificateBaseAttestationStatement, registrationObject.getTimestamp());
                 } else {
                     throw new IllegalStateException();
                 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreRegistrationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreRegistrationObject.java
@@ -23,8 +23,7 @@ import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.util.ArrayUtil;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -36,14 +35,14 @@ public class CoreRegistrationObject {
     private final byte[] attestationObjectBytes;
     private final byte[] clientDataHash;
     private final CoreServerProperty serverProperty;
-    private final LocalDateTime timestamp;
+    private final Instant timestamp;
 
     public CoreRegistrationObject(
             AttestationObject attestationObject,
             byte[] attestationObjectBytes,
             byte[] clientDataHash,
             CoreServerProperty serverProperty,
-            LocalDateTime timestamp) {
+            Instant timestamp) {
         this.attestationObject = attestationObject;
         this.attestationObjectBytes = attestationObjectBytes;
         this.clientDataHash = clientDataHash;
@@ -57,7 +56,7 @@ public class CoreRegistrationObject {
             byte[] clientDataHash,
             CoreServerProperty serverProperty) {
 
-        this(attestationObject, attestationObjectBytes, clientDataHash, serverProperty, LocalDateTime.now(Clock.systemUTC()));
+        this(attestationObject, attestationObjectBytes, clientDataHash, serverProperty, Instant.now());
     }
 
     public AttestationObject getAttestationObject() {
@@ -81,7 +80,7 @@ public class CoreRegistrationObject {
         return serverProperty;
     }
 
-    public LocalDateTime getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationObject.java
@@ -26,8 +26,7 @@ import com.webauthn4j.util.ArrayUtil;
 import com.webauthn4j.util.CollectionUtil;
 import com.webauthn4j.util.MessageDigestUtil;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
@@ -56,7 +55,7 @@ public class RegistrationObject extends CoreRegistrationObject {
             AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions,
             Set<AuthenticatorTransport> transports,
             ServerProperty serverProperty,
-            LocalDateTime timestamp) {
+            Instant timestamp) {
 
         super(attestationObject, attestationObjectBytes, MessageDigestUtil.createSHA256().digest(collectedClientDataBytes), serverProperty, timestamp);
         this.collectedClientData = collectedClientData;
@@ -74,7 +73,7 @@ public class RegistrationObject extends CoreRegistrationObject {
             Set<AuthenticatorTransport> transports,
             ServerProperty serverProperty) {
 
-        this(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, clientExtensions, transports, serverProperty, LocalDateTime.now(Clock.systemUTC()));
+        this(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, clientExtensions, transports, serverProperty, Instant.now());
     }
 
     // ~ Methods

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidator.java
@@ -29,7 +29,6 @@ import com.webauthn4j.validator.exception.BadAttestationStatementException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -83,12 +82,12 @@ public class AndroidSafetyNetAttestationStatementValidator extends AbstractState
         }
 
         // Verify the timestampMs doesn't violate backwardThreshold
-        if (Instant.ofEpochMilli(response.getTimestampMs()).isBefore(registrationObject.getTimestamp().toInstant(ZoneOffset.UTC).minus(Duration.ofSeconds(backwardThreshold)))) {
+        if (Instant.ofEpochMilli(response.getTimestampMs()).isBefore(registrationObject.getTimestamp().minus(Duration.ofSeconds(backwardThreshold)))) {
             throw new BadAttestationStatementException("timestampMs violates backwardThreshold.");
         }
 
         // Verify the timestampMs doesn't violate forwardThreshold
-        if (Instant.ofEpochMilli(response.getTimestampMs()).isAfter(registrationObject.getTimestamp().toInstant(ZoneOffset.UTC).plus(Duration.ofSeconds(forwardThreshold)))) {
+        if (Instant.ofEpochMilli(response.getTimestampMs()).isAfter(registrationObject.getTimestamp().plus(Duration.ofSeconds(forwardThreshold)))) {
             throw new BadAttestationStatementException("timestampMs violates forwardThreshold.");
         }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/trustworthiness/certpath/CertPathTrustworthinessValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/trustworthiness/certpath/CertPathTrustworthinessValidator.java
@@ -20,10 +20,16 @@ import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import com.webauthn4j.data.attestation.statement.CertificateBaseAttestationStatement;
 
+import java.time.Instant;
+
 /**
  * Validates the specified {@link AttestationStatement} x5c trustworthiness
  */
 public interface CertPathTrustworthinessValidator {
 
-    void validate(AAGUID aaguid, CertificateBaseAttestationStatement attestationStatement);
+    void validate(AAGUID aaguid, CertificateBaseAttestationStatement attestationStatement, Instant timestamp);
+
+    default void validate(AAGUID aaguid, CertificateBaseAttestationStatement attestationStatement){
+        validate(aaguid, attestationStatement, Instant.now());
+    }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/trustworthiness/certpath/CertPathTrustworthinessValidatorBase.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/trustworthiness/certpath/CertPathTrustworthinessValidatorBase.java
@@ -24,13 +24,15 @@ import com.webauthn4j.validator.exception.TrustAnchorNotFoundException;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.cert.*;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Set;
 
 public abstract class CertPathTrustworthinessValidatorBase implements CertPathTrustworthinessValidator {
 
     private boolean fullChainProhibited = false;
 
-    public void validate(AAGUID aaguid, CertificateBaseAttestationStatement attestationStatement) {
+    public void validate(AAGUID aaguid, CertificateBaseAttestationStatement attestationStatement, Instant timestamp) {
         CertPath certPath = attestationStatement.getX5c().createCertPath();
 
         Set<TrustAnchor> trustAnchors = resolveTrustAnchors(aaguid);
@@ -44,6 +46,7 @@ public abstract class CertPathTrustworthinessValidatorBase implements CertPathTr
         certPathParameters.setPolicyQualifiersRejected(false); // As policy qualifiers are checked manually in attestation statement validator, it is turned off
 
         certPathParameters.setRevocationEnabled(false);
+        certPathParameters.setDate(Date.from(timestamp));
 
         PKIXCertPathValidatorResult result;
         try {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/trustworthiness/certpath/NullCertPathTrustworthinessValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/trustworthiness/certpath/NullCertPathTrustworthinessValidator.java
@@ -19,12 +19,14 @@ package com.webauthn4j.validator.attestation.trustworthiness.certpath;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.statement.CertificateBaseAttestationStatement;
 
+import java.time.Instant;
+
 /**
  * Null validator that bypass x5c trustworthiness check
  */
 public class NullCertPathTrustworthinessValidator implements CertPathTrustworthinessValidator {
     @Override
-    public void validate(AAGUID aaguid, CertificateBaseAttestationStatement attestationStatement) {
+    public void validate(AAGUID aaguid, CertificateBaseAttestationStatement attestationStatement, Instant timestamp) {
         // nop
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationObjectTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationObjectTest.java
@@ -32,7 +32,7 @@ import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.test.TestDataUtil;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Set;
 
@@ -55,7 +55,7 @@ class RegistrationObjectTest {
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
-        LocalDateTime timestamp = LocalDateTime.now();
+        Instant timestamp = Instant.now();
         RegistrationObject registrationObject = new RegistrationObject(
                 attestationObject,
                 attestationObjectBytes,
@@ -89,7 +89,7 @@ class RegistrationObjectTest {
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
-        LocalDateTime timestamp = LocalDateTime.now();
+        Instant timestamp = Instant.now();
         RegistrationObject instanceA = new RegistrationObject(
                 attestationObject,
                 attestationObjectBytes,

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
@@ -55,7 +55,7 @@ import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.ECPoint;
 import java.security.spec.EllipticCurve;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
@@ -110,7 +110,7 @@ public class TestDataUtil {
         AttestationObject attestationObject = attestationObjectConverter.convert(attestationObjectBytes);
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();
-        LocalDateTime timestamp = LocalDateTime.parse("2019-02-02T07:01:00");
+        Instant timestamp = Instant.parse("2019-02-02T07:01:00.00Z");
         return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, TestDataUtil.createServerProperty(), timestamp);
     }
 


### PR DESCRIPTION
* Use Instant class instread of LocalDateTime class in RegistrationObject.timestamp
* CertPathTrustworthinessValidator.validate takes timestamp as the 3rd argument.

Breaking change:
* `validate(AAGUID aaguid, CertificateBaseAttestationStatement attestationStatement)` method in `CertPathTrustworthinessValidator` interface is changed to `validate(AAGUID aaguid, CertificateBaseAttestationStatement attestationStatement, Instant timestamp)`.
