### PR TITLE
Redesign Converters not to pass through null value

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AttestationObjectConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AttestationObjectConverter.java
@@ -51,9 +51,7 @@ public class AttestationObjectConverter {
      * @return the converted object
      */
     public @NonNull AttestationObject convert(@NonNull String source) {
-        if (source == null) { //TODO: revisit
-            return null;
-        }
+        AssertUtil.notNull(source, "source must not be null");
         byte[] value = Base64UrlUtil.decode(source);
         return convert(value);
     }
@@ -65,9 +63,7 @@ public class AttestationObjectConverter {
      * @return the converted object
      */
     public @NonNull AttestationObject convert(@NonNull byte[] source) {
-        if (source == null) { //TODO: revisit
-            return null;
-        }
+        AssertUtil.notNull(source, "source must not be null");
         return cborConverter.readValue(source, AttestationObject.class);
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverter.java
@@ -44,17 +44,14 @@ public class AuthenticationExtensionsClientInputsConverter {
     // ================================================================================================
 
     public <T extends ExtensionClientInput> @NonNull AuthenticationExtensionsClientInputs<T> convert(@NonNull String value) {
-        if (value == null) { //TODO: revisit
-            return null;
-        }
+        AssertUtil.notNull(value, "value must not be null");
         return jsonConverter.readValue(value, new TypeReference<AuthenticationExtensionsClientInputs<T>>() {});
     }
 
 
     public <T extends ExtensionClientInput> @NonNull String convertToString(@NonNull AuthenticationExtensionsClientInputs<T> value) {
-        if (value == null) { //TODO: revisit
-            return null;
-        }
+        AssertUtil.notNull(value, "value must not be null");
+
         return jsonConverter.writeValueAsString(value);
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverter.java
@@ -45,16 +45,12 @@ public class AuthenticationExtensionsClientOutputsConverter {
     // ================================================================================================
 
     public <T extends ExtensionClientOutput> @NonNull AuthenticationExtensionsClientOutputs<T> convert(@NonNull String value) {
-        if (value == null) { //TODO: revisit
-            return null;
-        }
+        AssertUtil.notNull(value, "value must not be null");
         return jsonConverter.readValue(value, new TypeReference<AuthenticationExtensionsClientOutputs<T>>(){});
     }
 
     public <T extends ExtensionClientOutput> @NonNull String convertToString(@NonNull AuthenticationExtensionsClientOutputs<T> value) {
-        if (value == null) { //TODO: revisit
-            return null;
-        }
+        AssertUtil.notNull(value, "value must not be null");
         return jsonConverter.writeValueAsString(value);
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticatorTransportConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticatorTransportConverter.java
@@ -37,9 +37,7 @@ public class AuthenticatorTransportConverter {
 
     @SuppressWarnings("squid:S1168")
     public @NonNull Set<AuthenticatorTransport> convertSet(@NonNull Set<String> values) {
-        if (values == null) { //TODO: revisit
-            return null;
-        }
+        AssertUtil.notNull(values, "values must not be null");
         return values.stream().map(this::convert).collect(Collectors.toSet());
     }
 
@@ -50,9 +48,7 @@ public class AuthenticatorTransportConverter {
 
     @SuppressWarnings("squid:S1168")
     public @NonNull Set<String> convertSetToStringSet(@NonNull Set<AuthenticatorTransport> values) {
-        if (values == null) { //TODO: revisit
-            return null;
-        }
+        AssertUtil.notNull(values, "values must not be null");
         return values.stream().map(this::convertToString).collect(Collectors.toSet());
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/CollectedClientDataConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/CollectedClientDataConverter.java
@@ -53,9 +53,7 @@ public class CollectedClientDataConverter {
      * @return the converted object
      */
     public @NonNull CollectedClientData convert(@NonNull String base64UrlString) {
-        if (base64UrlString == null) {
-            return null;
-        }
+        AssertUtil.notNull(base64UrlString, "base64UrlString must not be null");
         byte[] bytes = Base64UrlUtil.decode(base64UrlString);
         return convert(bytes);
     }
@@ -67,9 +65,7 @@ public class CollectedClientDataConverter {
      * @return the converted object
      */
     public @NonNull CollectedClientData convert(@NonNull byte[] source) {
-        if (source == null) {
-            return null;
-        }
+        AssertUtil.notNull(source, "source must not be null");
         String jsonString = new String(source, StandardCharsets.UTF_8);
         return jsonConverter.readValue(jsonString, CollectedClientData.class);
     }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationObjectConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationObjectConverterTest.java
@@ -26,6 +26,7 @@ import com.webauthn4j.util.Base64UrlUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -51,11 +52,11 @@ class AttestationObjectConverterTest {
         );
     }
 
-//    @Test
-//    void convert_null_test() {
-//        assertThatThrownBy(() -> target.convert((String) null)).isInstanceOf(IllegalArgumentException.class);
-//        assertThatThrownBy(() -> target.convert((byte[]) null)).isInstanceOf(IllegalArgumentException.class);
-//    }
+    @Test
+    void convert_null_test() {
+        assertThatThrownBy(() -> target.convert((String) null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> target.convert((byte[]) null)).isInstanceOf(IllegalArgumentException.class);
+    }
 
     @Test
     void convert_AttestationObject_with_AndroidKeyAttestation_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverterTest.java
@@ -24,6 +24,7 @@ import com.webauthn4j.data.extension.client.RegistrationExtensionClientInput;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AuthenticationExtensionsClientInputsConverterTest {
 
@@ -32,11 +33,11 @@ class AuthenticationExtensionsClientInputsConverterTest {
     private final AuthenticationExtensionsClientInputsConverter authenticationExtensionsClientInputsConverter = new AuthenticationExtensionsClientInputsConverter(objectConverter);
 
 
-//    @SuppressWarnings("ConstantConditions")
-//    @Test
-//    void convertRegistrationExtensions_null_test() {
-//        assertThatThrownBy(()-> authenticationExtensionsClientInputsConverter.convert(null)).isInstanceOf(IllegalArgumentException.class);
-//    }
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void convertRegistrationExtensions_null_test() {
+        assertThatThrownBy(()-> authenticationExtensionsClientInputsConverter.convert(null)).isInstanceOf(IllegalArgumentException.class);
+    }
 
     @Test
     void convertAuthenticationExtensionsToString_test() {
@@ -46,11 +47,11 @@ class AuthenticationExtensionsClientInputsConverterTest {
         assertThat(authenticationExtensionsClientInputsConverter.convertToString(extensions)).isEqualTo("{\"appid\":\"test\"}");
     }
 
-//    @SuppressWarnings("ConstantConditions")
-//    @Test
-//    void convertAuthenticationExtensionsToString_null_test() {
-//        assertThatThrownBy(()->authenticationExtensionsClientInputsConverter.convertToString(null)).isInstanceOf(IllegalArgumentException.class);
-//    }
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void convertAuthenticationExtensionsToString_null_test() {
+        assertThatThrownBy(()->authenticationExtensionsClientInputsConverter.convertToString(null)).isInstanceOf(IllegalArgumentException.class);
+    }
 
     @Test
     void convert_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverterTest.java
@@ -18,6 +18,9 @@ package com.webauthn4j.converter;
 
 
 import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AuthenticationExtensionsClientOutputsConverterTest {
 
@@ -25,15 +28,15 @@ class AuthenticationExtensionsClientOutputsConverterTest {
 
     private final AuthenticationExtensionsClientOutputsConverter target = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
     
-//    @Test
-//    void convert_null_test() {
-//        //noinspection ConstantConditions
-//        assertThatThrownBy(()->target.convert(null)).isInstanceOf(IllegalArgumentException.class);
-//    }
+    @Test
+    void convert_null_test() {
+        //noinspection ConstantConditions
+        assertThatThrownBy(()->target.convert(null)).isInstanceOf(IllegalArgumentException.class);
+    }
 
-//    @Test
-//    void convertToString_null_test() {
-//        //noinspection ConstantConditions
-//        assertThatThrownBy(()->target.convertToString(null)).isInstanceOf(IllegalArgumentException.class);
-//    }
+    @Test
+    void convertToString_null_test() {
+        //noinspection ConstantConditions
+        assertThatThrownBy(()->target.convertToString(null)).isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorTransportConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorTransportConverterTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AuthenticatorTransportConverterTest {
 
@@ -44,10 +45,10 @@ class AuthenticatorTransportConverterTest {
         assertThat(converter.convertSet(Collections.singleton("usb"))).containsExactly(AuthenticatorTransport.USB);
     }
 
-//    @Test
-//    void convertSet_null_test() {
-//        assertThatThrownBy(()->converter.convertSet(null)).isInstanceOf(IllegalArgumentException.class);
-//    }
+    @Test
+    void convertSet_null_test() {
+        assertThatThrownBy(()->converter.convertSet(null)).isInstanceOf(IllegalArgumentException.class);
+    }
 
     @Test
     void convertToString_test() {
@@ -59,10 +60,10 @@ class AuthenticatorTransportConverterTest {
         assertThat(converter.convertSetToStringSet(Collections.singleton(AuthenticatorTransport.USB))).containsExactly("usb");
     }
 
-//    @Test
-//    void convertSetToStringSet_null_test() {
-//        //noinspection ConstantConditions
-//        assertThatThrownBy(()->converter.convertSetToStringSet(null)).isInstanceOf(IllegalArgumentException.class);
-//    }
+    @Test
+    void convertSetToStringSet_null_test() {
+        //noinspection ConstantConditions
+        assertThatThrownBy(()->converter.convertSetToStringSet(null)).isInstanceOf(IllegalArgumentException.class);
+    }
 
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/CollectedClientDataConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/CollectedClientDataConverterTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class CollectedClientDataConverterTest {
@@ -48,11 +49,11 @@ class CollectedClientDataConverterTest {
         );
     }
 
-//    @Test
-//    void convert_null_test() {
-//        assertThatThrownBy(() -> target.convert((String) null)).isInstanceOf(IllegalArgumentException.class);
-//        assertThatThrownBy(() -> target.convert((byte[]) null)).isInstanceOf(IllegalArgumentException.class);
-//    }
+    @Test
+    void convert_null_test() {
+        assertThatThrownBy(() -> target.convert((String) null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> target.convert((byte[]) null)).isInstanceOf(IllegalArgumentException.class);
+    }
 
     @Test
     void convert_clientDataBase64UrlString_with_new_keys_test() {


### PR DESCRIPTION
to make its behavior consistent and Kotlin friendly.

**Breaking Change**
- If you have passed null value to converter and expected null value is to be returned, you need to rewrite your caller code to do null check and return null value by yourself.
Sorry for inconvenience, but it is for making converter arguments and return values non-nullable and make it consistent.