### PR TITLE
Refine ServerProperty nullability and remove getOrigin method

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/server/CoreServerProperty.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/server/CoreServerProperty.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.server;
 
 import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.util.AssertUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -28,7 +29,8 @@ public class CoreServerProperty implements Serializable {
     private final String rpId;
     private final Challenge challenge;
 
-    public CoreServerProperty(@NonNull String rpId, @NonNull Challenge challenge) {
+    public CoreServerProperty(@NonNull String rpId, @Nullable Challenge challenge) {
+        AssertUtil.notNull(rpId, "rpId must not be null");
         this.rpId = rpId;
         this.challenge = challenge;
     }
@@ -47,7 +49,7 @@ public class CoreServerProperty implements Serializable {
      *
      * @return the {@link Challenge}
      */
-    public @NonNull Challenge getChallenge() {
+    public @Nullable Challenge getChallenge() {
         return challenge;
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/server/ServerProperty.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/server/ServerProperty.java
@@ -18,6 +18,7 @@ package com.webauthn4j.server;
 
 import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.util.AssertUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -42,39 +43,22 @@ public class ServerProperty extends CoreServerProperty {
     // ~ Constructor
     // ========================================================================================================
 
-    public ServerProperty(@NonNull Origin origin, @NonNull String rpId, @NonNull Challenge challenge, @Nullable byte[] tokenBindingId) {
-        this(origin != null ? Collections.singleton(origin) : Collections.emptySet(),
-                rpId,
-                challenge, tokenBindingId);
+    public ServerProperty(@NonNull Origin origin, @NonNull String rpId, @Nullable Challenge challenge, @Nullable byte[] tokenBindingId) {
+        super(rpId, challenge);
+        AssertUtil.notNull(origin, "origin must not be null");
+        this.origins = Collections.singleton(origin);
+        this.tokenBindingId = tokenBindingId;
     }
 
-    public ServerProperty(@NonNull Collection<Origin> origins, @NonNull String rpId, @NonNull Challenge challenge, @Nullable byte[] tokenBindingId) {
+    public ServerProperty(@NonNull Collection<Origin> origins, @NonNull String rpId, @Nullable Challenge challenge, @Nullable byte[] tokenBindingId) {
         super(rpId, challenge);
-        this.origins = (origins != null && !origins.isEmpty()) ? Collections.unmodifiableSet(new HashSet<>(origins)) : Collections.emptySet();
+        AssertUtil.notNull(origins, "origins must not be null");
+        this.origins = Collections.unmodifiableSet(new HashSet<>(origins));
         this.tokenBindingId = tokenBindingId;
     }
 
     // ~ Methods
     // ========================================================================================================
-
-    /**
-     * @deprecated
-     * Returns a single {@link Origin}, provided that this ServerProperty is configured with only a single origin
-     *
-     * @return the {@link Origin}
-     */
-    @Deprecated
-    public @Nullable Origin getOrigin() {
-        final int originsSize = origins.size();
-        switch (originsSize){
-            case 0:
-                return null;
-            case 1:
-                return origins.iterator().next();
-            default:
-                throw new IllegalStateException("There are multiple Origins associated with this ServerProperty");
-        }
-    }
 
     public @NonNull Set<Origin> getOrigins(){
         return this.origins;

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
@@ -19,6 +19,7 @@ package com.webauthn4j.data;
 import com.webauthn4j.authenticator.Authenticator;
 import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.server.ServerProperty;
 import org.junit.jupiter.api.Test;
 
@@ -29,9 +30,9 @@ class AuthenticationParametersTest {
     @Test
     void constructor_test() {
         // Server properties
-        Origin origin = null /* set origin */;
-        String rpId = null /* set rpId */;
-        Challenge challenge = null /* set challenge */;
+        Origin origin = Origin.create("https://example.com") /* set origin */;
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
@@ -53,13 +54,12 @@ class AuthenticationParametersTest {
         assertThat(authenticationParameters.isUserPresenceRequired()).isTrue();
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     void equals_hashCode_test() {
         // Server properties
-        Origin origin = null /* set origin */;
-        String rpId = null /* set rpId */;
-        Challenge challenge = null /* set challenge */;
+        Origin origin = Origin.create("https://example.com") /* set origin */;
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/RegistrationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/RegistrationParametersTest.java
@@ -19,6 +19,7 @@ package com.webauthn4j.data;
 
 import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.server.ServerProperty;
 import org.junit.jupiter.api.Test;
 
@@ -29,9 +30,9 @@ class RegistrationParametersTest {
     @Test
     void equals_hashCode_test() {
         // Server properties
-        Origin origin = null /* set origin */;
-        String rpId = null /* set rpId */;
-        Challenge challenge = null /* set challenge */;
+        Origin origin = Origin.create("https://example.com") /* set origin */;
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/server/ServerPropertyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/server/ServerPropertyTest.java
@@ -25,12 +25,11 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ServerPropertyTest {
     private final String rpId = "rp-origin.com";
@@ -38,6 +37,16 @@ class ServerPropertyTest {
     private final Origin webApp2Origin = new Origin("https://app2.rp-origin.com");
     private final Origin apk1Origin = new Origin("android:apk-key-hash:pNiP5iKyQ8JwgGOaKA1zGPUPJIS-0H1xKCQcfIoGLck");
     private final Origin apk2Origin = new Origin("android:apk-key-hash-sha256:xT5ZucZJ9N7oq3j3awG8J/NlKf8trfo6AAJB8deuuNo=");
+
+
+    @Test
+    void constructor_rpId_null() {
+
+        //When
+        assertThrows(IllegalArgumentException.class,
+                () -> new ServerProperty(webApp1Origin, null, null, null)
+        );
+    }
 
     @Test
     void equals_hashCode_test() {
@@ -71,9 +80,8 @@ class ServerPropertyTest {
         final byte[] tokenBindingBytes = "random-token-binding1".getBytes(StandardCharsets.UTF_8);
         final Challenge challenge = new DefaultChallenge();
         final ServerProperty serverProperty =
-                new ServerProperty((Origin)null, rpId, challenge, tokenBindingBytes);
+                new ServerProperty(Collections.emptySet(), rpId, challenge, tokenBindingBytes);
         assertAll(
-                ()->assertThat(serverProperty.getOrigin()).isNull(),
                 ()->assertThat(serverProperty.getOrigins()).isEmpty(),
                 ()->assertThat(serverProperty.getRpId()).isEqualTo(rpId),
                 ()->assertThat(serverProperty.getChallenge()).isEqualTo(challenge),
@@ -87,9 +95,8 @@ class ServerPropertyTest {
         final byte[] tokenBindingBytes = "random-token-binding1".getBytes(StandardCharsets.UTF_8);
         final Challenge challenge = new DefaultChallenge();
         final ServerProperty serverProperty =
-                new ServerProperty((Collection<Origin>)null, rpId, challenge, tokenBindingBytes);
+                new ServerProperty(Collections.emptySet(), rpId, challenge, tokenBindingBytes);
         assertAll(
-                ()->assertThat(serverProperty.getOrigin()).isNull(),
                 ()->assertThat(serverProperty.getOrigins()).isEmpty(),
                 ()->assertThat(serverProperty.getRpId()).isEqualTo(rpId),
                 ()->assertThat(serverProperty.getChallenge()).isEqualTo(challenge),
@@ -105,7 +112,6 @@ class ServerPropertyTest {
         final ServerProperty serverProperty =
                 new ServerProperty(new ArrayList<>(), rpId, challenge, tokenBindingBytes);
         assertAll(
-                ()->assertThat(serverProperty.getOrigin()).isNull(),
                 ()->assertThat(serverProperty.getOrigins()).isEmpty(),
                 ()->assertThat(serverProperty.getRpId()).isEqualTo(rpId),
                 ()->assertThat(serverProperty.getChallenge()).isEqualTo(challenge),
@@ -122,7 +128,6 @@ class ServerPropertyTest {
         final ServerProperty serverProperty =
                 new ServerProperty(webApp1Origin, rpId, challenge, tokenBindingBytes);
         assertAll(
-                ()->assertThat(serverProperty.getOrigin()).isEqualTo(webApp1Origin),
                 ()->assertThat(serverProperty.getOrigins()).isEqualTo(Collections.singleton(webApp1Origin)),
                 ()->assertThat(serverProperty.getRpId()).isEqualTo(rpId),
                 ()->assertThat(serverProperty.getChallenge()).isEqualTo(challenge),
@@ -145,9 +150,6 @@ class ServerPropertyTest {
 
 
         assertAll(
-                () -> assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() ->
-                        serverProperty.getOrigin()
-                ),
                 () -> assertThat(serverProperty.getOrigins()).containsExactlyInAnyOrder(
                         webApp1Origin, apk1Origin, webApp2Origin, apk2Origin),
                 () -> assertThat(serverProperty.getRpId()).isEqualTo(rpId),
@@ -170,7 +172,6 @@ class ServerPropertyTest {
 
 
         assertAll(
-                () -> assertThat(serverProperty.getOrigin()).isEqualTo(webApp1Origin),
                 () -> assertThat(serverProperty.getOrigins()).containsExactlyInAnyOrder(webApp1Origin),
                 () -> assertThat(serverProperty.getRpId()).isEqualTo(rpId),
                 () -> assertThat(serverProperty.getChallenge()).isEqualTo(challenge),
@@ -191,9 +192,6 @@ class ServerPropertyTest {
 
 
         assertAll(
-                () -> assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() ->
-                        serverProperty.getOrigin()
-                ),
                 () -> assertThat(serverProperty.getOrigins()).containsExactlyInAnyOrder(
                         webApp1Origin, apk1Origin),
                 () -> assertThat(serverProperty.getRpId()).isEqualTo(rpId),

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/ChallengeValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/ChallengeValidatorTest.java
@@ -34,31 +34,32 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class ChallengeValidatorTest {
 
-    private final Origin origin = null;
+    private final Origin origin = Origin.create("https://example.com");
+    private final String rpId = "example.com";
 
     private final ChallengeValidator target = new ChallengeValidator();
 
     @Test
-    void verifyChallenge_test1() {
+    void validate_test1() {
 
         Challenge challengeA = new DefaultChallenge(new byte[]{0x00});
         Challenge challengeB = new DefaultChallenge(new byte[]{0x00});
 
         CollectedClientData collectedClientData = new CollectedClientData(ClientDataType.CREATE, challengeA, null, null);
-        ServerProperty serverProperty = new ServerProperty(origin, null, challengeB, null);
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challengeB, null);
 
         //When
         target.validate(collectedClientData, serverProperty);
     }
 
     @Test
-    void verifyChallenge_test_with_different_challenge() {
+    void validate_test_with_different_challenge() {
 
         Challenge challengeA = new DefaultChallenge(new byte[]{0x00});
         Challenge challengeB = new DefaultChallenge(new byte[]{0x01});
 
         CollectedClientData collectedClientData = new CollectedClientData(ClientDataType.CREATE, challengeA, null, null);
-        ServerProperty serverProperty = new ServerProperty(origin, null, challengeB, null);
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challengeB, null);
 
         //When
         assertThrows(BadChallengeException.class,
@@ -67,13 +68,13 @@ class ChallengeValidatorTest {
     }
 
     @Test
-    void verifyChallenge_test_without_saved_challenge() {
+    void validate_test_without_saved_challenge() {
 
         Challenge challengeA = new DefaultChallenge(new byte[]{0x00});
         Challenge challengeB = null;
 
         CollectedClientData collectedClientData = new CollectedClientData(ClientDataType.CREATE, challengeA, null, null);
-        ServerProperty serverProperty = new ServerProperty(origin, null, challengeB, null);
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challengeB, null);
 
         //When
         assertThrows(MissingChallengeException.class,

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/RpIdHashValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/RpIdHashValidatorTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class RpIdHashValidatorTest {
 
-    private final Origin origin = null;
+    private final Origin origin = Origin.create("https://example.com");
 
     private final RpIdHashValidator target = new RpIdHashValidator();
 
@@ -69,7 +69,6 @@ class RpIdHashValidatorTest {
     void verifyRpIdHash_test_with_relyingParty_null() {
 
         String rpIdA = "example.com";
-        String rpIdB = "example.com";
         byte[] rpIdBytesA = rpIdA.getBytes(StandardCharsets.UTF_8);
         byte[] rpIdHashA = MessageDigestUtil.createSHA256().digest(rpIdBytesA);
 
@@ -79,19 +78,4 @@ class RpIdHashValidatorTest {
         );
     }
 
-    @Test
-    void verifyRpIdHash_test_with_relyingParty_rpId_null() {
-
-        String rpIdA = "example.com";
-        String rpIdB = "example.com";
-        byte[] rpIdBytesA = rpIdA.getBytes(StandardCharsets.UTF_8);
-        byte[] rpIdHashA = MessageDigestUtil.createSHA256().digest(rpIdBytesA);
-
-        ServerProperty serverProperty = new ServerProperty(origin, null, null, null);
-
-        //When
-        assertThrows(IllegalArgumentException.class,
-                () -> target.validate(rpIdHashA, serverProperty)
-        );
-    }
 }


### PR DESCRIPTION
* Refine `ServerProperty` nullability as `Challenge` can be null when the challenge is expired or not stored
* Remove `getOrigin` as it is already deprecated in a previous release