### PR TITLE
Move Parameters classes non-null check into these classes

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreAuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreAuthenticationParameters.java
@@ -18,6 +18,7 @@ package com.webauthn4j.data;
 
 import com.webauthn4j.authenticator.CoreAuthenticator;
 import com.webauthn4j.server.CoreServerProperty;
+import com.webauthn4j.util.AssertUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -38,6 +39,8 @@ public class CoreAuthenticationParameters implements Serializable {
             @NonNull CoreAuthenticator authenticator,
             boolean userVerificationRequired,
             boolean userPresenceRequired) {
+        AssertUtil.notNull(serverProperty, "serverProperty must not be null");
+        AssertUtil.notNull(serverProperty, "authenticator must not be null");
         this.serverProperty = serverProperty;
         this.authenticator = authenticator;
         this.userVerificationRequired = userVerificationRequired;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreRegistrationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreRegistrationParameters.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.data;
 
 import com.webauthn4j.server.CoreServerProperty;
+import com.webauthn4j.util.AssertUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -33,6 +34,7 @@ public class CoreRegistrationParameters implements Serializable {
     private final boolean userPresenceRequired;
 
     public CoreRegistrationParameters(@NonNull CoreServerProperty serverProperty, boolean userVerificationRequired, boolean userPresenceRequired) {
+        AssertUtil.notNull(serverProperty, "serverProperty must not be null");
         this.serverProperty = serverProperty;
         this.userVerificationRequired = userVerificationRequired;
         this.userPresenceRequired = userPresenceRequired;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
@@ -63,7 +63,7 @@ public class AuthenticationDataValidator {
     public void validate(@NonNull AuthenticationData authenticationData, @NonNull AuthenticationParameters authenticationParameters) {
 
         BeanAssertUtil.validate(authenticationData);
-        BeanAssertUtil.validate(authenticationParameters);
+        AssertUtil.notNull(authenticationParameters, "authenticationParameters must not be null");
 
         //spec| Step1
         //spec| If the allowCredentials option was given when this authentication ceremony was initiated,
@@ -106,7 +106,6 @@ public class AuthenticationDataValidator {
 
         BeanAssertUtil.validate(collectedClientData);
         BeanAssertUtil.validate(authenticatorData);
-        BeanAssertUtil.validate(serverProperty);
 
         validateAuthenticatorData(authenticatorData);
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/BeanAssertUtil.java
@@ -16,7 +16,10 @@
 
 package com.webauthn4j.validator;
 
-import com.webauthn4j.data.*;
+import com.webauthn4j.data.AuthenticationData;
+import com.webauthn4j.data.CoreAuthenticationData;
+import com.webauthn4j.data.CoreRegistrationData;
+import com.webauthn4j.data.RegistrationData;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
@@ -24,19 +27,14 @@ import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.attestation.authenticator.COSEKey;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import com.webauthn4j.data.client.CollectedClientData;
-import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.TokenBinding;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
 import com.webauthn4j.data.extension.authenticator.ExtensionAuthenticatorOutput;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
 import com.webauthn4j.data.extension.client.ExtensionClientOutput;
-import com.webauthn4j.server.CoreServerProperty;
-import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.UnsignedNumberUtil;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.util.Collection;
 
 /**
  * Per field checker utility class
@@ -74,18 +72,6 @@ class BeanAssertUtil {
         }
     }
 
-    public static void validate(@Nullable RegistrationParameters registrationParameters) {
-        validate((CoreRegistrationParameters) registrationParameters);
-        validate(registrationParameters.getServerProperty());
-    }
-
-    public static void validate(@Nullable CoreRegistrationParameters registrationParameters) {
-        if (registrationParameters == null) {
-            throw new ConstraintViolationException("registrationParameters must not be null");
-        }
-        validate(registrationParameters.getServerProperty());
-    }
-
     public static void validate(@Nullable AuthenticationData authenticationData) {
         validate((CoreAuthenticationData) authenticationData);
         if (authenticationData.getCollectedClientData() == null) {
@@ -113,21 +99,6 @@ class BeanAssertUtil {
         if (authenticationData.getAuthenticatorDataBytes() == null) {
             throw new ConstraintViolationException("authenticatorDataBytes must not be null");
         }
-    }
-
-    public static void validate(@Nullable AuthenticationParameters authenticationParameters) {
-        validate((CoreAuthenticationParameters) authenticationParameters);
-        validate(authenticationParameters.getServerProperty());
-    }
-
-    public static void validate(@Nullable CoreAuthenticationParameters authenticationParameters) {
-        if (authenticationParameters == null) {
-            throw new ConstraintViolationException("authenticationParameters must not be null");
-        }
-        if (authenticationParameters.getAuthenticator() == null) {
-            throw new ConstraintViolationException("authenticator must not be null");
-        }
-        validate(authenticationParameters.getServerProperty());
     }
 
     public static void validate(@Nullable CollectedClientData collectedClientData) {
@@ -230,25 +201,6 @@ class BeanAssertUtil {
         }
     }
 
-    public static void validate(@Nullable ServerProperty serverProperty) {
-        validate((CoreServerProperty) serverProperty);
-        final Collection<Origin> origins = serverProperty.getOrigins();
-        if (origins == null || origins.isEmpty()) {
-            throw new ConstraintViolationException("origins must not be null or empty");
-        }
-    }
-
-    public static void validate(@Nullable CoreServerProperty serverProperty) {
-        if (serverProperty == null) {
-            throw new ConstraintViolationException("serverProperty must not be null");
-        }
-        if (serverProperty.getRpId() == null) {
-            throw new ConstraintViolationException("rpId must not be null");
-        }
-        if (serverProperty.getChallenge() == null) {
-            throw new ConstraintViolationException(CHALLENGE_MUST_NOT_BE_NULL);
-        }
-    }
 
     public static void validate(@Nullable AttestationStatement attestationStatement) {
         if (attestationStatement == null) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/ChallengeValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/ChallengeValidator.java
@@ -37,7 +37,7 @@ class ChallengeValidator {
 
     // ~ Methods
     // ========================================================================================================
-
+    @SuppressWarnings("S2259")
     public void validate(@Nullable CollectedClientData collectedClientData, @Nullable ServerProperty serverProperty) {
         AssertUtil.notNull(collectedClientData, "collectedClientData must not be null");
         AssertUtil.notNull(serverProperty, "serverProperty must not be null");
@@ -54,6 +54,7 @@ class ChallengeValidator {
 
     }
 
+    @SuppressWarnings("S2259")
     public void validate(@Nullable Challenge expected, @Nullable Challenge actual) {
         AssertUtil.notNull(expected, "expected must not be null");
         AssertUtil.notNull(actual, "actual must not be null");

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreAuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreAuthenticationDataValidator.java
@@ -62,7 +62,8 @@ public class CoreAuthenticationDataValidator {
     public void validate(@NonNull CoreAuthenticationData authenticationData, @NonNull CoreAuthenticationParameters authenticationParameters) {
 
         BeanAssertUtil.validate(authenticationData);
-        BeanAssertUtil.validate(authenticationParameters);
+
+        AssertUtil.notNull(authenticationParameters, "authenticationParameters must not be null");
 
         //spec| Step1
         //spec| If the allowCredentials option was given when this authentication ceremony was initiated,
@@ -99,8 +100,6 @@ public class CoreAuthenticationDataValidator {
         CoreServerProperty serverProperty = authenticationParameters.getServerProperty();
 
         BeanAssertUtil.validate(authenticatorData);
-        BeanAssertUtil.validate(serverProperty);
-
         validateAuthenticatorData(authenticatorData);
 
         CoreAuthenticator authenticator = authenticationParameters.getAuthenticator();

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreRegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreRegistrationDataValidator.java
@@ -73,7 +73,7 @@ public class CoreRegistrationDataValidator {
     public void validate(@NonNull CoreRegistrationData registrationData, @NonNull CoreRegistrationParameters registrationParameters) {
 
         BeanAssertUtil.validate(registrationData);
-        BeanAssertUtil.validate(registrationParameters);
+        AssertUtil.notNull(registrationParameters, "registrationParameters must not be null");
 
         AttestationObject attestationObject = registrationData.getAttestationObject();
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
@@ -82,7 +82,7 @@ public class RegistrationDataValidator {
     public void validate(@NonNull RegistrationData registrationData, @NonNull RegistrationParameters registrationParameters) {
 
         BeanAssertUtil.validate(registrationData);
-        BeanAssertUtil.validate(registrationParameters);
+        AssertUtil.notNull(registrationParameters, "registrationParameters must not be null");
 
         byte[] clientDataBytes = registrationData.getCollectedClientDataBytes();
         byte[] attestationObjectBytes = registrationData.getAttestationObjectBytes();

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
@@ -21,9 +21,11 @@ import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.test.TestDataUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AuthenticationParametersTest {
 
@@ -52,6 +54,26 @@ class AuthenticationParametersTest {
         assertThat(authenticationParameters.getAuthenticator()).isEqualTo(authenticator);
         assertThat(authenticationParameters.isUserVerificationRequired()).isEqualTo(userVerificationRequired);
         assertThat(authenticationParameters.isUserPresenceRequired()).isTrue();
+    }
+
+    @Test
+    void constructor_with_serverProperty_null_test() {
+        assertThatThrownBy(()->{new AuthenticationParameters(
+                null,
+                TestDataUtil.createAuthenticator(),
+                true,
+                true
+        );}).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void constructor_with_authenticator_null_test() {
+        new AuthenticationParameters(
+                TestDataUtil.createServerProperty(),
+                null,
+                true,
+                true
+        );
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/RegistrationDataTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/RegistrationDataTest.java
@@ -20,15 +20,39 @@ import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.client.CollectedClientData;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.test.TestDataUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 class RegistrationDataTest {
+
+    @Test
+    void constructor_RegistrationParameters_test() {
+        RegistrationParameters registrationParameters = new RegistrationParameters(
+                TestDataUtil.createServerProperty(),
+                true
+        );
+        assertThat(registrationParameters.getServerProperty()).isInstanceOf(ServerProperty.class);
+        assertThat(registrationParameters.isUserPresenceRequired()).isTrue();
+        assertThat(registrationParameters.isUserVerificationRequired()).isTrue();
+    }
+
+    @Test
+    void constructor_with_serverProperty_null_test() {
+        assertThatThrownBy(()->{
+            new RegistrationParameters(
+                    null,
+                    true
+            );
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
 
     @Test
     void equals_hashCode_test() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/BeanAssertUtilTest.java
@@ -17,9 +17,7 @@
 package com.webauthn4j.validator;
 
 import com.webauthn4j.data.AuthenticationData;
-import com.webauthn4j.data.AuthenticationParameters;
 import com.webauthn4j.data.RegistrationData;
-import com.webauthn4j.data.RegistrationParameters;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.client.*;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
@@ -143,35 +141,6 @@ class BeanAssertUtilTest {
         );
         assertDoesNotThrow(
                 () -> BeanAssertUtil.validate(registrationData)
-        );
-    }
-
-
-
-    @Test
-    void validate_RegistrationParameters_test() {
-        RegistrationParameters registrationParameters = new RegistrationParameters(
-                TestDataUtil.createServerProperty(),
-                true
-        );
-        BeanAssertUtil.validate(registrationParameters);
-    }
-
-    @Test
-    void validate_RegistrationParameters_with_null_test() {
-        assertThrows(ConstraintViolationException.class,
-                () -> BeanAssertUtil.validate((RegistrationParameters) null)
-        );
-    }
-
-    @Test
-    void validate_RegistrationParameters_with_serverProperty_null_test() {
-        RegistrationParameters registrationParameters = new RegistrationParameters(
-                null,
-                true
-        );
-        assertThrows(ConstraintViolationException.class,
-                () -> BeanAssertUtil.validate(registrationParameters)
         );
     }
 
@@ -333,50 +302,6 @@ class BeanAssertUtilTest {
         );
         assertThrows(ConstraintViolationException.class,
                 () -> BeanAssertUtil.validate(authenticationData)
-        );
-    }
-
-    @Test
-    void validate_AuthenticationParameters_test() {
-        AuthenticationParameters authenticationParameters = new AuthenticationParameters(
-                TestDataUtil.createServerProperty(),
-                TestDataUtil.createAuthenticator(),
-                true,
-                true
-        );
-        BeanAssertUtil.validate(authenticationParameters);
-    }
-
-    @Test
-    void validate_AuthenticationParameters_with_null_test() {
-        assertThrows(ConstraintViolationException.class,
-                () -> BeanAssertUtil.validate((AuthenticationParameters) null)
-        );
-    }
-
-    @Test
-    void validate_AuthenticationParameters_with_serverProperty_null_test() {
-        AuthenticationParameters authenticationParameters = new AuthenticationParameters(
-                null,
-                TestDataUtil.createAuthenticator(),
-                true,
-                true
-        );
-        assertThrows(ConstraintViolationException.class,
-                () -> BeanAssertUtil.validate(authenticationParameters)
-        );
-    }
-
-    @Test
-    void validate_AuthenticationParameters_with_authenticator_null_test() {
-        AuthenticationParameters authenticationParameters = new AuthenticationParameters(
-                TestDataUtil.createServerProperty(),
-                null,
-                true,
-                true
-        );
-        assertThrows(ConstraintViolationException.class,
-                () -> BeanAssertUtil.validate(authenticationParameters)
         );
     }
 


### PR DESCRIPTION
As RegistrationParameters and AuthenticationParameters class members are marked as non-null, move non-null check logic from BeanAssertUtil to these class constructors