### PR TITLE
Make AndroidSafetyNetAttestationStatement Response members nullable

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/AndroidSafetyNetAttestationStatement.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/AndroidSafetyNetAttestationStatement.java
@@ -49,7 +49,11 @@ public class AndroidSafetyNetAttestationStatement implements CertificateBaseAtte
     @JsonIgnore
     @Override
     public @Nullable AttestationCertificatePath getX5c() {
-        return getResponse().getHeader().getX5c();
+        JWS<Response> res = getResponse();
+        if(res == null){
+            throw new IllegalStateException("response is null");
+        }
+        return res.getHeader().getX5c();
     }
 
     @Override

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/Response.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/Response.java
@@ -19,6 +19,7 @@ package com.webauthn4j.data.attestation.statement;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.util.ArrayUtil;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.Serializable;
 
@@ -27,7 +28,7 @@ public class Response implements Serializable {
     @JsonProperty
     private final String nonce;
     @JsonProperty
-    private final long timestampMs; //TODO must not be primitive
+    private final Long timestampMs;
     @JsonProperty
     private final String apkPackageName;
     @JsonProperty
@@ -35,22 +36,22 @@ public class Response implements Serializable {
     @JsonProperty
     private final String apkDigestSha256;
     @JsonProperty
-    private final boolean ctsProfileMatch;
+    private final Boolean ctsProfileMatch;
     @JsonProperty
-    private final boolean basicIntegrity;
+    private final Boolean basicIntegrity;
     @JsonProperty
     private final String advice;
 
     @JsonCreator
     public Response(
-            @JsonProperty("nonce") String nonce,
-            @JsonProperty("timestampMs") long timestampMs,
-            @JsonProperty("apkPackageName") String apkPackageName,
-            @JsonProperty("apkCertificateDigestSha256") String[] apkCertificateDigestSha256,
-            @JsonProperty("apkDigestSha256") String apkDigestSha256,
-            @JsonProperty("ctsProfileMatch") boolean ctsProfileMatch,
-            @JsonProperty("basicIntegrity") boolean basicIntegrity,
-            @JsonProperty("advice") String advice) {
+            @Nullable @JsonProperty("nonce") String nonce,
+            @Nullable @JsonProperty("timestampMs") Long timestampMs,
+            @Nullable @JsonProperty("apkPackageName") String apkPackageName,
+            @Nullable @JsonProperty("apkCertificateDigestSha256") String[] apkCertificateDigestSha256,
+            @Nullable @JsonProperty("apkDigestSha256") String apkDigestSha256,
+            @Nullable @JsonProperty("ctsProfileMatch") Boolean ctsProfileMatch,
+            @Nullable @JsonProperty("basicIntegrity") Boolean basicIntegrity,
+            @Nullable @JsonProperty("advice") String advice) {
         this.nonce = nonce;
         this.timestampMs = timestampMs;
         this.apkPackageName = apkPackageName;
@@ -61,35 +62,35 @@ public class Response implements Serializable {
         this.advice = advice;
     }
 
-    public String getNonce() {
+    public @Nullable String getNonce() {
         return nonce;
     }
 
-    public long getTimestampMs() {
+    public @Nullable Long getTimestampMs() {
         return timestampMs;
     }
 
-    public String getApkPackageName() {
+    public @Nullable String getApkPackageName() {
         return apkPackageName;
     }
 
-    public String[] getApkCertificateDigestSha256() {
+    public @Nullable String[] getApkCertificateDigestSha256() {
         return ArrayUtil.clone(apkCertificateDigestSha256);
     }
 
-    public String getApkDigestSha256() {
+    public @Nullable String getApkDigestSha256() {
         return apkDigestSha256;
     }
 
-    public boolean isCtsProfileMatch() {
+    public @Nullable Boolean isCtsProfileMatch() {
         return ctsProfileMatch;
-    }
+    } //TODO: should be get as it is not primitive now
 
-    public boolean isBasicIntegrity() {
+    public @Nullable Boolean isBasicIntegrity() {
         return basicIntegrity;
-    }
+    } //TODO: should be get as it is not primitive now
 
-    public String getAdvice() {
+    public @Nullable String getAdvice() {
         return advice;
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/Response.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/Response.java
@@ -82,13 +82,13 @@ public class Response implements Serializable {
         return apkDigestSha256;
     }
 
-    public @Nullable Boolean isCtsProfileMatch() {
+    public @Nullable Boolean getCtsProfileMatch() {
         return ctsProfileMatch;
-    } //TODO: should be get as it is not primitive now
+    }
 
-    public @Nullable Boolean isBasicIntegrity() {
+    public @Nullable Boolean getBasicIntegrity() {
         return basicIntegrity;
-    } //TODO: should be get as it is not primitive now
+    }
 
     public @Nullable String getAdvice() {
         return advice;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSException.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSException.java
@@ -17,17 +17,18 @@
 package com.webauthn4j.data.jws;
 
 import com.webauthn4j.util.exception.WebAuthnException;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class JWSException extends WebAuthnException { //TODO: revisit
-    public JWSException(String message, Throwable cause) {
+public class JWSException extends WebAuthnException {
+    public JWSException(@Nullable String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 
-    public JWSException(String message) {
+    public JWSException(@Nullable String message) {
         super(message);
     }
 
-    public JWSException(Throwable cause) {
+    public JWSException(@Nullable Throwable cause) {
         super(cause);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidator.java
@@ -84,7 +84,7 @@ public class AndroidSafetyNetAttestationStatementValidator extends AbstractState
         }
 
         /// Verify that the ctsProfileMatch attribute in the payload of response is true.
-        if (!Objects.equals(response.isCtsProfileMatch(), true)) {
+        if (!Objects.equals(response.getCtsProfileMatch(), true)) {
             throw new BadAttestationStatementException("The profile of the device doesn't match the profile of a device that has passed Android Compatibility Test Suite.");
         }
 
@@ -149,10 +149,10 @@ public class AndroidSafetyNetAttestationStatementValidator extends AbstractState
         if (response.getApkDigestSha256() == null){
             throw new BadAttestationStatementException("apkDigestSha256 must not be null.");
         }
-        if (response.isCtsProfileMatch() == null){
+        if (response.getCtsProfileMatch() == null){
             throw new BadAttestationStatementException("ctsProfileMatch must not be null.");
         }
-        if (response.isBasicIntegrity() == null){
+        if (response.getBasicIntegrity() == null){
             throw new BadAttestationStatementException("basicIntegrity must not be null.");
         }
     }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidatorTest.java
@@ -17,21 +17,32 @@
 package com.webauthn4j.validator.attestation.statement.androidsafetynet;
 
 import com.webauthn4j.data.*;
+import com.webauthn4j.data.attestation.statement.AndroidSafetyNetAttestationStatement;
+import com.webauthn4j.data.attestation.statement.AttestationCertificatePath;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
+import com.webauthn4j.data.attestation.statement.Response;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientInputs;
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientInput;
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import com.webauthn4j.data.jws.JWAIdentifier;
+import com.webauthn4j.data.jws.JWS;
+import com.webauthn4j.data.jws.JWSFactory;
+import com.webauthn4j.data.jws.JWSHeader;
 import com.webauthn4j.test.EmulatorUtil;
 import com.webauthn4j.test.TestDataUtil;
 import com.webauthn4j.test.authenticator.webauthn.AndroidSafetyNetAuthenticator;
 import com.webauthn4j.test.client.ClientPlatform;
 import com.webauthn4j.validator.RegistrationObject;
+import com.webauthn4j.validator.exception.BadAttestationStatementException;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Collections;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AndroidSafetyNetAttestationStatementValidatorTest {
@@ -78,4 +89,155 @@ class AndroidSafetyNetAttestationStatementValidatorTest {
         RegistrationObject registrationObject = TestDataUtil.createRegistrationObject(publicKeyCredential);
         target.validate(registrationObject);
     }
+
+    @Test
+    void validateNull_test(){
+        String ver = "12685023";
+        String nonce = "nonce";
+        long timestampMs = Instant.now().toEpochMilli();
+        String apkPackageName = "com.android.keystore.androidkeystoredemo";
+        String[] apkCertificateDigestSha256 = new String[]{"bsb4/WQdaaOWYCd/j9OJiQpg7b0iwFgAc/zzA1tCfwE="};
+        String apkDigestSha256 = "dM/LUHSI9SkQhZHHpQWRnzJ3MvvB2ANSauqYAAbS2Jg=";
+        boolean ctsProfileMatch = true;
+        boolean basicIntegrity = true;
+        String advice = null;
+        Response response = new Response(nonce, timestampMs, apkPackageName, apkCertificateDigestSha256, apkDigestSha256, ctsProfileMatch, basicIntegrity, advice);
+        JWS<Response> jws = new JWSFactory().create(new JWSHeader(JWAIdentifier.ES256, new AttestationCertificatePath()), response, new byte[32]);
+        AndroidSafetyNetAttestationStatement attestationStatement = new AndroidSafetyNetAttestationStatement(ver, jws);
+        target.validateNull(attestationStatement);
+    }
+
+    @Test
+    void validateNull_with_null_test(){
+        assertThatThrownBy(()->target.validateNull((AndroidSafetyNetAttestationStatement) null)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+    @Test
+    void validateNull_with_ver_null_test(){
+        String nonce = "nonce";
+        long timestampMs = Instant.now().toEpochMilli();
+        String apkPackageName = "com.android.keystore.androidkeystoredemo";
+        String[] apkCertificateDigestSha256 = new String[]{"bsb4/WQdaaOWYCd/j9OJiQpg7b0iwFgAc/zzA1tCfwE="};
+        String apkDigestSha256 = "dM/LUHSI9SkQhZHHpQWRnzJ3MvvB2ANSauqYAAbS2Jg=";
+        boolean ctsProfileMatch = true;
+        boolean basicIntegrity = true;
+        String advice = null;
+        Response response = new Response(nonce, timestampMs, apkPackageName, apkCertificateDigestSha256, apkDigestSha256, ctsProfileMatch, basicIntegrity, advice);
+        JWS<Response> jws = new JWSFactory().create(new JWSHeader(JWAIdentifier.ES256, new AttestationCertificatePath()), response, new byte[32]);
+        AndroidSafetyNetAttestationStatement attestationStatement = new AndroidSafetyNetAttestationStatement(null, jws);
+        assertThatThrownBy(()->target.validateNull(attestationStatement)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+
+    @Test
+    void validateNull_with_response_null_test(){
+        String ver = "12685023";
+        AndroidSafetyNetAttestationStatement attestationStatement = new AndroidSafetyNetAttestationStatement(ver, null);
+        assertThatThrownBy(()->target.validateNull(attestationStatement)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+    @Test
+    void validateNull_with_nonce_null_test(){
+        long timestampMs = Instant.now().toEpochMilli();
+        String apkPackageName = "com.android.keystore.androidkeystoredemo";
+        String[] apkCertificateDigestSha256 = new String[]{"bsb4/WQdaaOWYCd/j9OJiQpg7b0iwFgAc/zzA1tCfwE="};
+        String apkDigestSha256 = "dM/LUHSI9SkQhZHHpQWRnzJ3MvvB2ANSauqYAAbS2Jg=";
+        boolean ctsProfileMatch = true;
+        boolean basicIntegrity = true;
+        String advice = null;
+        Response response = new Response(null, timestampMs, apkPackageName, apkCertificateDigestSha256, apkDigestSha256, ctsProfileMatch, basicIntegrity, advice);
+        assertThatThrownBy(()->target.validateNull(response)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+    @Test
+    void validateNull_with_timestampMs_null_test(){
+        String nonce = "nonce";
+        String apkPackageName = "com.android.keystore.androidkeystoredemo";
+        String[] apkCertificateDigestSha256 = new String[]{"bsb4/WQdaaOWYCd/j9OJiQpg7b0iwFgAc/zzA1tCfwE="};
+        String apkDigestSha256 = "dM/LUHSI9SkQhZHHpQWRnzJ3MvvB2ANSauqYAAbS2Jg=";
+        boolean ctsProfileMatch = true;
+        boolean basicIntegrity = true;
+        String advice = null;
+        Response response = new Response(nonce, null, apkPackageName, apkCertificateDigestSha256, apkDigestSha256, ctsProfileMatch, basicIntegrity, advice);
+        assertThatThrownBy(()->target.validateNull(response)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+    @Test
+    void validateNull_with_apkPackageName_null_test(){
+        String nonce = "nonce";
+        long timestampMs = Instant.now().toEpochMilli();
+        String[] apkCertificateDigestSha256 = new String[]{"bsb4/WQdaaOWYCd/j9OJiQpg7b0iwFgAc/zzA1tCfwE="};
+        String apkDigestSha256 = "dM/LUHSI9SkQhZHHpQWRnzJ3MvvB2ANSauqYAAbS2Jg=";
+        boolean ctsProfileMatch = true;
+        boolean basicIntegrity = true;
+        String advice = null;
+        Response response = new Response(nonce, timestampMs, null, apkCertificateDigestSha256, apkDigestSha256, ctsProfileMatch, basicIntegrity, advice);
+        assertThatThrownBy(()->target.validateNull(response)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+    @Test
+    void validateNull_with_apkCertificateDigestSha256_null_test(){
+        String nonce = "nonce";
+        long timestampMs = Instant.now().toEpochMilli();
+        String apkPackageName = "com.android.keystore.androidkeystoredemo";
+        String apkDigestSha256 = "dM/LUHSI9SkQhZHHpQWRnzJ3MvvB2ANSauqYAAbS2Jg=";
+        boolean ctsProfileMatch = true;
+        boolean basicIntegrity = true;
+        String advice = null;
+        Response response = new Response(nonce, timestampMs, apkPackageName, null, apkDigestSha256, ctsProfileMatch, basicIntegrity, advice);
+        assertThatThrownBy(()->target.validateNull(response)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+    @Test
+    void validateNull_with_apkDigestSha256_null_test(){
+        String nonce = "nonce";
+        long timestampMs = Instant.now().toEpochMilli();
+        String apkPackageName = "com.android.keystore.androidkeystoredemo";
+        String[] apkCertificateDigestSha256 = new String[]{"bsb4/WQdaaOWYCd/j9OJiQpg7b0iwFgAc/zzA1tCfwE="};
+        boolean ctsProfileMatch = true;
+        boolean basicIntegrity = true;
+        String advice = null;
+        Response response = new Response(nonce, timestampMs, apkPackageName, apkCertificateDigestSha256, null, ctsProfileMatch, basicIntegrity, advice);
+        assertThatThrownBy(()->target.validateNull(response)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+    @Test
+    void validateNull_with_ctsProfileMatch_null_test(){
+        String nonce = "nonce";
+        long timestampMs = Instant.now().toEpochMilli();
+        String apkPackageName = "com.android.keystore.androidkeystoredemo";
+        String[] apkCertificateDigestSha256 = new String[]{"bsb4/WQdaaOWYCd/j9OJiQpg7b0iwFgAc/zzA1tCfwE="};
+        String apkDigestSha256 = "dM/LUHSI9SkQhZHHpQWRnzJ3MvvB2ANSauqYAAbS2Jg=";
+        boolean basicIntegrity = true;
+        String advice = null;
+        Response response = new Response(nonce, timestampMs, apkPackageName, apkCertificateDigestSha256, apkDigestSha256, null, basicIntegrity, advice);
+        assertThatThrownBy(()->target.validateNull(response)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+    @Test
+    void validateNull_with_basicIntegrity_null_test(){
+        String nonce = "nonce";
+        long timestampMs = Instant.now().toEpochMilli();
+        String apkPackageName = "com.android.keystore.androidkeystoredemo";
+        String[] apkCertificateDigestSha256 = new String[]{"bsb4/WQdaaOWYCd/j9OJiQpg7b0iwFgAc/zzA1tCfwE="};
+        String apkDigestSha256 = "dM/LUHSI9SkQhZHHpQWRnzJ3MvvB2ANSauqYAAbS2Jg=";
+        boolean ctsProfileMatch = true;
+        String advice = null;
+        Response response = new Response(nonce, timestampMs, apkPackageName, apkCertificateDigestSha256, apkDigestSha256, ctsProfileMatch, null, advice);
+        assertThatThrownBy(()->target.validateNull(response)).isInstanceOf(BadAttestationStatementException.class);
+    }
+
+    @Test
+    void validateNull_with_advice_null_test(){
+        String nonce = "nonce";
+        long timestampMs = Instant.now().toEpochMilli();
+        String apkPackageName = "com.android.keystore.androidkeystoredemo";
+        String[] apkCertificateDigestSha256 = new String[]{"bsb4/WQdaaOWYCd/j9OJiQpg7b0iwFgAc/zzA1tCfwE="};
+        String apkDigestSha256 = "dM/LUHSI9SkQhZHHpQWRnzJ3MvvB2ANSauqYAAbS2Jg=";
+        boolean ctsProfileMatch = true;
+        boolean basicIntegrity = true;
+        Response response = new Response(nonce, timestampMs, apkPackageName, apkCertificateDigestSha256, apkDigestSha256, ctsProfileMatch, basicIntegrity, null);
+        assertThatCode(()->target.validateNull(response)).doesNotThrowAnyException();
+    }
+
 }


### PR DESCRIPTION
to deserialize data precisely

**Breaking Changes**

- `ctsProfileMatch` is changed from boolean to Boolean
- `basicIntegrityis` changed from boolean to Boolean
- `isCtsProfileMatch` is renamed to `getCtsProfileMatch`
- `isBasicIntegrity` is renamed to `getBasicIntegrity`
