### PR TITLE
Redesign JWS classes

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
@@ -19,13 +19,16 @@ package com.webauthn4j.converter.jackson;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.webauthn4j.converter.jackson.deserializer.ChallengeDeserializer;
 import com.webauthn4j.converter.jackson.deserializer.JWSDeserializer;
+import com.webauthn4j.converter.jackson.deserializer.JWSHeaderDeserializer;
 import com.webauthn4j.converter.jackson.deserializer.X509CertificateDeserializer;
 import com.webauthn4j.converter.jackson.serializer.ChallengeSerializer;
+import com.webauthn4j.converter.jackson.serializer.JWSHeaderSerializer;
 import com.webauthn4j.converter.jackson.serializer.JWSSerializer;
 import com.webauthn4j.converter.jackson.serializer.X509CertificateSerializer;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.data.jws.JWS;
+import com.webauthn4j.data.jws.JWSHeader;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.security.cert.X509Certificate;
@@ -41,10 +44,12 @@ public class WebAuthnJSONModule extends SimpleModule {
 
         this.addDeserializer(Challenge.class, new ChallengeDeserializer());
         this.addDeserializer(JWS.class, new JWSDeserializer(objectConverter));
+        this.addDeserializer(JWSHeader.class, new JWSHeaderDeserializer());
         this.addDeserializer(X509Certificate.class, new X509CertificateDeserializer());
 
         this.addSerializer(new ChallengeSerializer());
         this.addSerializer(new JWSSerializer());
+        this.addSerializer(new JWSHeaderSerializer());
         this.addSerializer(new X509CertificateSerializer());
 
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/JWSHeaderDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/JWSHeaderDeserializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.webauthn4j.data.jws.JWAIdentifier;
+import com.webauthn4j.data.jws.JWSHeader;
+import com.webauthn4j.util.Base64Util;
+import com.webauthn4j.util.CertificateUtil;
+
+import java.io.IOException;
+import java.security.cert.CertPath;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JWSHeaderDeserializer extends StdDeserializer<JWSHeader> {
+
+
+    public JWSHeaderDeserializer() {
+        super(JWSHeader.class);
+    }
+
+    @Override
+    public JWSHeader deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode jsonNode = p.getCodec().readTree(p);
+        JWAIdentifier alg = p.getCodec().treeToValue(jsonNode.get("alg"), JWAIdentifier.class);
+        JsonNode x5cNode = jsonNode.get("x5c");
+        List<X509Certificate> certificates = new ArrayList<>();
+        for(JsonNode node : x5cNode){
+            certificates.add(CertificateUtil.generateX509Certificate(Base64Util.decode(node.asText())));
+        }
+        CertPath x5c = CertificateUtil.generateCertPath(certificates);
+        return new JWSHeader(alg, x5c);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/JWSHeaderSerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/JWSHeaderSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.webauthn4j.data.jws.JWSHeader;
+import com.webauthn4j.util.Base64Util;
+import com.webauthn4j.util.exception.UnexpectedCheckedException;
+
+import java.io.IOException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+
+public class JWSHeaderSerializer extends StdSerializer<JWSHeader> {
+
+    public JWSHeaderSerializer() {
+        super(JWSHeader.class);
+    }
+
+    @Override
+    public void serialize(JWSHeader value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        try {
+        gen.writeStartObject();
+        gen.writeObjectField("alg", value.getAlg());
+        gen.writeFieldName("x5c");
+        gen.writeStartArray();
+        if(value.getX5c() != null){
+            for(Certificate certificate : value.getX5c().getCertificates()){
+                gen.writeString(Base64Util.encodeToString(certificate.getEncoded())); // x5c must be Base64, not Base64Url
+            }
+        }
+        gen.writeEndArray();
+        } catch (CertificateEncodingException e) {
+            throw new UnexpectedCheckedException(e);
+        }
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/AndroidSafetyNetAttestationStatement.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/AndroidSafetyNetAttestationStatement.java
@@ -22,7 +22,9 @@ import com.webauthn4j.validator.exception.ConstraintViolationException;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.security.cert.X509Certificate;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @JsonTypeName(AndroidSafetyNetAttestationStatement.FORMAT)
 public class AndroidSafetyNetAttestationStatement implements CertificateBaseAttestationStatement {
@@ -53,7 +55,7 @@ public class AndroidSafetyNetAttestationStatement implements CertificateBaseAtte
         if(res == null){
             throw new IllegalStateException("response is null");
         }
-        return res.getHeader().getX5c();
+        return new AttestationCertificatePath(res.getHeader().getX5c().getCertificates().stream().map(item -> (X509Certificate) item).collect(Collectors.toList()));
     }
 
     @Override

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWS.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWS.java
@@ -42,7 +42,7 @@ public class JWS<T extends Serializable> implements Serializable {
     private final String headerString;
     private final String payloadString;
 
-    JWS(@NonNull JWSHeader header, @NonNull String headerString, @NonNull T payload, @NonNull String payloadString, @NonNull byte[] signature) { //TODO revisit
+    JWS(@NonNull JWSHeader header, @NonNull String headerString, @NonNull T payload, @NonNull String payloadString, @NonNull byte[] signature) {
         logger = LoggerFactory.getLogger(JWS.class);
 
         this.header = header;
@@ -72,8 +72,11 @@ public class JWS<T extends Serializable> implements Serializable {
     public boolean isValidSignature() {
         String signedData = headerString + "." + payloadString;
         try {
+            if(header.getAlg() == null || header.getX5c() == null || header.getX5c().getCertificates().isEmpty()){
+                return false;
+            }
             Signature signatureObj = SignatureUtil.createSignature(header.getAlg().getJcaName());
-            PublicKey publicKey = header.getX5c().getEndEntityAttestationCertificate().getCertificate().getPublicKey();
+            PublicKey publicKey = header.getX5c().getCertificates().get(0).getPublicKey();
             signatureObj.initVerify(publicKey);
             signatureObj.update(signedData.getBytes());
             byte[] sig;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSHeader.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSHeader.java
@@ -16,35 +16,30 @@
 
 package com.webauthn4j.data.jws;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.webauthn4j.data.attestation.statement.AttestationCertificatePath;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.Serializable;
+import java.security.cert.CertPath;
 import java.util.Objects;
 
 public class JWSHeader implements Serializable {
 
     private final JWAIdentifier alg;
-    private final AttestationCertificatePath x5c;
+    private final CertPath x5c;
 
-    @JsonCreator
     public JWSHeader(
             @Nullable @JsonProperty("alg") JWAIdentifier alg,
-            @Nullable @JsonProperty("x5c") AttestationCertificatePath x5c) {
+            @Nullable @JsonProperty("x5c") CertPath x5c) {
         this.alg = alg;
         this.x5c = x5c;
     }
 
-    @JsonGetter
     public @Nullable JWAIdentifier getAlg() {
         return alg;
     }
 
-    @JsonGetter
-    public @Nullable AttestationCertificatePath getX5c() {
+    public @Nullable CertPath getX5c() {
         return x5c;
     }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWSFactoryTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWSFactoryTest.java
@@ -16,12 +16,13 @@
 
 package com.webauthn4j.data.jws;
 
-import com.webauthn4j.test.TestAttestationUtil;
+import com.webauthn4j.util.CertificateUtil;
 import com.webauthn4j.util.ECUtil;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.security.KeyPair;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,7 +32,7 @@ class JWSFactoryTest {
 
     @Test
     void create_with_private_key_test() {
-        JWSHeader header = new JWSHeader(JWAIdentifier.ES256, TestAttestationUtil.load3tierTestAttestationCertificatePath());
+        JWSHeader header = new JWSHeader(JWAIdentifier.ES256, CertificateUtil.generateCertPath(Collections.emptyList()));
         Payload payload = new Payload();
         KeyPair keyPair = ECUtil.createKeyPair();
         JWS<Payload> jws = target.create(header, payload, keyPair.getPrivate());
@@ -40,7 +41,7 @@ class JWSFactoryTest {
 
     @Test
     void create_with_signature_test() {
-        JWSHeader header = new JWSHeader(JWAIdentifier.ES256, TestAttestationUtil.load3tierTestAttestationCertificatePath());
+        JWSHeader header = new JWSHeader(JWAIdentifier.ES256, CertificateUtil.generateCertPath(Collections.emptyList()));
         Payload payload = new Payload();
         byte[] signature = new byte[32];
         JWS<Payload> jws = target.create(header, payload, signature);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWSHeaderTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWSHeaderTest.java
@@ -17,8 +17,10 @@
 package com.webauthn4j.data.jws;
 
 
-import com.webauthn4j.test.TestAttestationUtil;
+import com.webauthn4j.util.CertificateUtil;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -27,8 +29,8 @@ class JWSHeaderTest {
 
     @Test
     void equals_hashCode_test() {
-        JWSHeader instanceA = new JWSHeader(JWAIdentifier.ES256, TestAttestationUtil.load2tierTestAttestationCertificatePath());
-        JWSHeader instanceB = new JWSHeader(JWAIdentifier.ES256, TestAttestationUtil.load2tierTestAttestationCertificatePath());
+        JWSHeader instanceA = new JWSHeader(JWAIdentifier.ES256, CertificateUtil.generateCertPath(Collections.emptyList()));
+        JWSHeader instanceB = new JWSHeader(JWAIdentifier.ES256, CertificateUtil.generateCertPath(Collections.emptyList()));
 
         assertAll(
                 () -> assertThat(instanceA).isEqualTo(instanceB),

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidatorTest.java
@@ -18,7 +18,6 @@ package com.webauthn4j.validator.attestation.statement.androidsafetynet;
 
 import com.webauthn4j.data.*;
 import com.webauthn4j.data.attestation.statement.AndroidSafetyNetAttestationStatement;
-import com.webauthn4j.data.attestation.statement.AttestationCertificatePath;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.data.attestation.statement.Response;
 import com.webauthn4j.data.client.challenge.Challenge;
@@ -34,6 +33,7 @@ import com.webauthn4j.test.EmulatorUtil;
 import com.webauthn4j.test.TestDataUtil;
 import com.webauthn4j.test.authenticator.webauthn.AndroidSafetyNetAuthenticator;
 import com.webauthn4j.test.client.ClientPlatform;
+import com.webauthn4j.util.CertificateUtil;
 import com.webauthn4j.validator.RegistrationObject;
 import com.webauthn4j.validator.exception.BadAttestationStatementException;
 import org.junit.jupiter.api.Test;
@@ -102,7 +102,7 @@ class AndroidSafetyNetAttestationStatementValidatorTest {
         boolean basicIntegrity = true;
         String advice = null;
         Response response = new Response(nonce, timestampMs, apkPackageName, apkCertificateDigestSha256, apkDigestSha256, ctsProfileMatch, basicIntegrity, advice);
-        JWS<Response> jws = new JWSFactory().create(new JWSHeader(JWAIdentifier.ES256, new AttestationCertificatePath()), response, new byte[32]);
+        JWS<Response> jws = new JWSFactory().create(new JWSHeader(JWAIdentifier.ES256, CertificateUtil.generateCertPath(Collections.emptyList())), response, new byte[32]);
         AndroidSafetyNetAttestationStatement attestationStatement = new AndroidSafetyNetAttestationStatement(ver, jws);
         target.validateNull(attestationStatement);
     }
@@ -123,7 +123,7 @@ class AndroidSafetyNetAttestationStatementValidatorTest {
         boolean basicIntegrity = true;
         String advice = null;
         Response response = new Response(nonce, timestampMs, apkPackageName, apkCertificateDigestSha256, apkDigestSha256, ctsProfileMatch, basicIntegrity, advice);
-        JWS<Response> jws = new JWSFactory().create(new JWSHeader(JWAIdentifier.ES256, new AttestationCertificatePath()), response, new byte[32]);
+        JWS<Response> jws = new JWSFactory().create(new JWSHeader(JWAIdentifier.ES256, CertificateUtil.generateCertPath(Collections.emptyList())), response, new byte[32]);
         AndroidSafetyNetAttestationStatement attestationStatement = new AndroidSafetyNetAttestationStatement(null, jws);
         assertThatThrownBy(()->target.validateNull(attestationStatement)).isInstanceOf(BadAttestationStatementException.class);
     }

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/FidoMdsMetadataItemsProvider.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/FidoMdsMetadataItemsProvider.java
@@ -218,7 +218,7 @@ public class FidoMdsMetadataItemsProvider implements MetadataItemsProvider {
 
     private void validateCertPath(JWS<MetadataTOCPayload> jws) {
         Set<TrustAnchor> trustAnchors = Collections.singleton(trustAnchor);
-        CertPath certPath = jws.getHeader().getX5c().createCertPath();
+        CertPath certPath = jws.getHeader().getX5c();
 
         CertPathValidator certPathValidator = CertificateUtil.createCertPathValidator();
         PKIXParameters certPathParameters = CertificateUtil.createPKIXParameters(trustAnchors);


### PR DESCRIPTION
**Breaking change**
* JWSHeader.x5c type is changed from `AttestationCertificatePath` to `CertPath` because it is not always attestation certificates