### PR TITLE
Revert "Bump spring-boot-dependencies from 2.3.5.RELEASE to 2.4.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ subprojects {
         mavenCentral()
     }
 
-    def springBootVersion = "2.4.0"
+    def springBootVersion = "2.3.5.RELEASE"
     def kerbyVersion = "2.0.1"
     def bouncyCastleVersion = "1.67"
     def checkerframeworkVersion = "3.7.1"


### PR DESCRIPTION
Reverts webauthn4j/webauthn4j#393 as it breaks snapshot release