### PR TITLE
Revert "Bump build-info-extractor-gradle from 4.17.2 to 4.18.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
     def sonarqubeVersion = "3.0"
     def asciidoctorGradleVersion = "3.3.0"
-    def artifactoryVersion = "4.18.0"
+    def artifactoryVersion="4.17.2"
     def bintrayVersion = "1.8.5"
     def owaspDependencyCheckVersion = "6.0.3"
     def httpBuilderVersion = "0.7.2"


### PR DESCRIPTION
This reverts commit d074dd727708e6ae344d748057c405a5b211be86 as it
breaks build