### PR TITLE
A relaxed origin validator

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnAuthenticationManager.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnAuthenticationManager.java
@@ -32,6 +32,7 @@ import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutput
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.validator.AuthenticationDataValidator;
 import com.webauthn4j.validator.CustomAuthenticationValidator;
+import com.webauthn4j.validator.OriginValidator;
 import com.webauthn4j.validator.exception.ValidationException;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -51,11 +52,14 @@ public class WebAuthnAuthenticationManager {
 
     public WebAuthnAuthenticationManager(
             @NonNull List<CustomAuthenticationValidator> customAuthenticationValidators,
+            @NonNull OriginValidator originValidator,
             @NonNull ObjectConverter objectConverter) {
         AssertUtil.notNull(customAuthenticationValidators, "customAuthenticationValidators must not be null");
+        AssertUtil.notNull(originValidator, "originValidator must not be null");
         AssertUtil.notNull(objectConverter, "objectConverter must not be null");
 
         authenticationDataValidator = new AuthenticationDataValidator(customAuthenticationValidators);
+        authenticationDataValidator.setOriginValidator(originValidator);
 
         collectedClientDataConverter = new CollectedClientDataConverter(objectConverter);
         authenticatorDataConverter = new AuthenticatorDataConverter(objectConverter);
@@ -64,11 +68,11 @@ public class WebAuthnAuthenticationManager {
 
     public WebAuthnAuthenticationManager(
             @NonNull List<CustomAuthenticationValidator> customAuthenticationValidators) {
-        this(customAuthenticationValidators, new ObjectConverter());
+        this(customAuthenticationValidators, new OriginValidator(), new ObjectConverter());
     }
 
     public WebAuthnAuthenticationManager() {
-        this(Collections.emptyList(), new ObjectConverter());
+        this(Collections.emptyList(), new OriginValidator(), new ObjectConverter());
     }
 
     @SuppressWarnings("squid:S1130")

--- a/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnManager.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnManager.java
@@ -19,10 +19,7 @@ package com.webauthn4j;
 import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.*;
-import com.webauthn4j.validator.AuthenticationDataValidator;
-import com.webauthn4j.validator.CustomAuthenticationValidator;
-import com.webauthn4j.validator.CustomRegistrationValidator;
-import com.webauthn4j.validator.RegistrationDataValidator;
+import com.webauthn4j.validator.*;
 import com.webauthn4j.validator.attestation.statement.AttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.androidkey.NullAndroidKeyAttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.androidsafetynet.NullAndroidSafetyNetAttestationStatementValidator;
@@ -55,6 +52,7 @@ public class WebAuthnManager {
                            @NonNull SelfAttestationTrustworthinessValidator selfAttestationTrustworthinessValidator,
                            @NonNull List<CustomRegistrationValidator> customRegistrationValidators,
                            @NonNull List<CustomAuthenticationValidator> customAuthenticationValidators,
+                           @NonNull OriginValidator originValidator,
                            @NonNull ObjectConverter objectConverter) {
 
         this.webAuthnRegistrationManager = new WebAuthnRegistrationManager(
@@ -62,9 +60,11 @@ public class WebAuthnManager {
                 certPathTrustworthinessValidator,
                 selfAttestationTrustworthinessValidator,
                 customRegistrationValidators,
+                originValidator,
                 objectConverter);
         this.webAuthnAuthenticationManager = new WebAuthnAuthenticationManager(
                 customAuthenticationValidators,
+                originValidator,
                 objectConverter);
     }
 
@@ -79,6 +79,7 @@ public class WebAuthnManager {
                 selfAttestationTrustworthinessValidator,
                 customRegistrationValidators,
                 customAuthenticationValidators,
+                new OriginValidator(),
                 new ObjectConverter()
         );
     }
@@ -93,6 +94,7 @@ public class WebAuthnManager {
                 selfAttestationTrustworthinessValidator,
                 new ArrayList<>(),
                 new ArrayList<>(),
+                new OriginValidator(),
                 objectConverter
         );
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnRegistrationManager.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnRegistrationManager.java
@@ -32,6 +32,7 @@ import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutput
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.validator.CustomRegistrationValidator;
+import com.webauthn4j.validator.OriginValidator;
 import com.webauthn4j.validator.RegistrationDataValidator;
 import com.webauthn4j.validator.attestation.statement.AttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.androidkey.NullAndroidKeyAttestationStatementValidator;
@@ -69,11 +70,13 @@ public class WebAuthnRegistrationManager {
             @NonNull CertPathTrustworthinessValidator certPathTrustworthinessValidator,
             @NonNull SelfAttestationTrustworthinessValidator selfAttestationTrustworthinessValidator,
             @NonNull List<CustomRegistrationValidator> customRegistrationValidators,
+            @NonNull OriginValidator originValidator,
             @NonNull ObjectConverter objectConverter) {
         AssertUtil.notNull(attestationStatementValidators, "attestationStatementValidators must not be null");
         AssertUtil.notNull(certPathTrustworthinessValidator, "certPathTrustworthinessValidator must not be null");
         AssertUtil.notNull(selfAttestationTrustworthinessValidator, "selfAttestationTrustworthinessValidator must not be null");
         AssertUtil.notNull(customRegistrationValidators, "customRegistrationValidators must not be null");
+        AssertUtil.notNull(originValidator, "originValidator must not be null");
         AssertUtil.notNull(objectConverter, "objectConverter must not be null");
 
         registrationDataValidator = new RegistrationDataValidator(
@@ -82,7 +85,7 @@ public class WebAuthnRegistrationManager {
                 selfAttestationTrustworthinessValidator,
                 customRegistrationValidators,
                 objectConverter);
-
+        registrationDataValidator.setOriginValidator(originValidator);
 
         collectedClientDataConverter = new CollectedClientDataConverter(objectConverter);
         attestationObjectConverter = new AttestationObjectConverter(objectConverter);
@@ -99,6 +102,7 @@ public class WebAuthnRegistrationManager {
                 certPathTrustworthinessValidator,
                 selfAttestationTrustworthinessValidator,
                 customRegistrationValidators,
+                new OriginValidator(),
                 new ObjectConverter()
         );
     }
@@ -112,6 +116,7 @@ public class WebAuthnRegistrationManager {
                 certPathTrustworthinessValidator,
                 selfAttestationTrustworthinessValidator,
                 Collections.emptyList(),
+                new OriginValidator(),
                 objectConverter
         );
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/client/Origin.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/client/Origin.java
@@ -141,6 +141,14 @@ public class Origin implements Serializable {
         return schemeSpecificPart;
     }
 
+    public boolean matchesRelaxed(Origin other) {
+        if (SCHEME_HTTPS.equals(scheme) || SCHEME_HTTP.equals(scheme)) {
+            return host.endsWith(other.host);
+        } else {
+            return this.equals(other);
+        }
+    }
+
     @JsonValue
     @Override
     public @NonNull String toString() {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/client/Origin.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/client/Origin.java
@@ -142,7 +142,8 @@ public class Origin implements Serializable {
     }
 
     public boolean matchesRelaxed(Origin other) {
-        if (SCHEME_HTTPS.equals(scheme) || SCHEME_HTTP.equals(scheme)) {
+        if (SCHEME_HTTPS.equals(scheme) && SCHEME_HTTPS.equals(other.scheme) ||
+                SCHEME_HTTP.equals(scheme) && SCHEME_HTTP.equals(other.scheme)) {
             return host.endsWith(other.host);
         } else {
             return this.equals(other);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
@@ -41,7 +41,6 @@ import java.util.Objects;
 public class AuthenticationDataValidator {
 
     private final ChallengeValidator challengeValidator = new ChallengeValidator();
-    private final OriginValidator originValidator = new OriginValidator();
     private final TokenBindingValidator tokenBindingValidator = new TokenBindingValidator();
     private final RpIdHashValidator rpIdHashValidator = new RpIdHashValidator();
     private final AssertionSignatureValidator assertionSignatureValidator = new AssertionSignatureValidator();
@@ -51,6 +50,7 @@ public class AuthenticationDataValidator {
     private final List<CustomAuthenticationValidator> customAuthenticationValidators;
 
     private CoreMaliciousCounterValueHandler maliciousCounterValueHandler = new DefaultCoreMaliciousCounterValueHandler();
+    private OriginValidator originValidator = new OriginValidator();
 
     public AuthenticationDataValidator(@NonNull List<CustomAuthenticationValidator> customAuthenticationValidators) {
         AssertUtil.notNull(customAuthenticationValidators, "customAuthenticationValidators must not be null");
@@ -219,5 +219,10 @@ public class AuthenticationDataValidator {
 
     public @NonNull List<CustomAuthenticationValidator> getCustomAuthenticationValidators() {
         return customAuthenticationValidators;
+    }
+
+    public void setOriginValidator(@NonNull OriginValidator originValidator) {
+        AssertUtil.notNull(originValidator, "originValidator must not be null");
+        this.originValidator = originValidator;
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
@@ -50,7 +50,6 @@ public class RegistrationDataValidator {
     // ================================================================================================
 
     private final ChallengeValidator challengeValidator = new ChallengeValidator();
-    private final OriginValidator originValidator = new OriginValidator();
     private final TokenBindingValidator tokenBindingValidator = new TokenBindingValidator();
     private final RpIdHashValidator rpIdHashValidator = new RpIdHashValidator();
     private final ClientExtensionValidator clientExtensionValidator = new ClientExtensionValidator();
@@ -59,6 +58,8 @@ public class RegistrationDataValidator {
     private final List<CustomRegistrationValidator> customRegistrationValidators = new ArrayList<>();
 
     private final AttestationValidator attestationValidator;
+    
+    private OriginValidator originValidator = new OriginValidator();
 
     public RegistrationDataValidator(
             @NonNull List<AttestationStatementValidator> attestationStatementValidators,
@@ -203,4 +204,8 @@ public class RegistrationDataValidator {
         return customRegistrationValidators;
     }
 
+    public void setOriginValidator(@NonNull OriginValidator originValidator) {
+        AssertUtil.notNull(originValidator, "originValidator must not be null");
+        this.originValidator = originValidator;
+    }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/RelaxedOriginValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/RelaxedOriginValidator.java
@@ -23,14 +23,17 @@ import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.validator.exception.BadOriginException;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.util.Set;
+
 /**
  * Validates the specified {@link Origin} instance
  */
-public class OriginValidator {
+public class RelaxedOriginValidator extends OriginValidator {
+    
+    public RelaxedOriginValidator() { }
 
     //~ Instance fields
     // ================================================================================================
-
 
     // ~ Methods
     // ========================================================================================================
@@ -40,8 +43,14 @@ public class OriginValidator {
         AssertUtil.notNull(serverProperty, "serverProperty must not be null");
 
         final Origin clientOrigin = collectedClientData.getOrigin();
-        if (!serverProperty.getOrigins().contains(clientOrigin)) {
-            throw new BadOriginException("The collectedClientData '" + clientOrigin + "' origin doesn't match any of the preconfigured server origin.");
+        final Set<Origin> serverOrigins = serverProperty.getOrigins();
+
+        for (Origin serverOrigin : serverOrigins) {
+            if (clientOrigin != null && clientOrigin.matchesRelaxed(serverOrigin)) {
+                return;
+            }
         }
+
+        throw new BadOriginException("The collectedClientData '" + clientOrigin + "' origin doesn't match any of the preconfigured server origin.");
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/RelaxedOriginValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/RelaxedOriginValidator.java
@@ -29,9 +29,6 @@ import java.util.Set;
  * Validates the specified {@link Origin} instance
  */
 public class RelaxedOriginValidator extends OriginValidator {
-    
-    public RelaxedOriginValidator() { }
-
     //~ Instance fields
     // ================================================================================================
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationManagerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/WebAuthnAuthenticationManagerTest.java
@@ -18,6 +18,7 @@ package com.webauthn4j;
 
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.validator.CustomAuthenticationValidator;
+import com.webauthn4j.validator.OriginValidator;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -33,7 +34,7 @@ class WebAuthnAuthenticationManagerTest {
         List<CustomAuthenticationValidator> customAuthenticationValidators = Collections.emptyList();
         assertThatCode(WebAuthnAuthenticationManager::new).doesNotThrowAnyException();
         assertThatCode(() -> new WebAuthnAuthenticationManager(customAuthenticationValidators)).doesNotThrowAnyException();
-        assertThatCode(() -> new WebAuthnAuthenticationManager(customAuthenticationValidators, objectConverter)).doesNotThrowAnyException();
+        assertThatCode(() -> new WebAuthnAuthenticationManager(customAuthenticationValidators, new OriginValidator(), objectConverter)).doesNotThrowAnyException();
     }
 
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/RelaxedOriginValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/RelaxedOriginValidatorTest.java
@@ -1,0 +1,53 @@
+package com.webauthn4j.validator;
+
+import com.webauthn4j.data.client.Origin;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RelaxedOriginValidatorTest {
+    
+    @Test
+    void validateSameHttpsOrigin_test() {
+        Origin origin1 = new Origin("https://my.fido2/");
+        Origin origin2 = new Origin("https://my.fido2/");
+        assertTrue(origin1.matchesRelaxed(origin2));
+    }
+
+    @Test
+    void validateDifferentHttpsOrigin_test() {
+        Origin origin1 = new Origin("https://my.fido2/");
+        Origin origin2 = new Origin("https://other.fido/");
+        assertFalse(origin1.matchesRelaxed(origin2));
+    }
+
+    @Test
+    void validateDifferentScheme_test() {
+        Origin origin1 = new Origin("https://my.fido2/");
+        Origin origin2 = new Origin("http://my.fido2/");
+        Origin origin3 = new Origin("android://my.fido2/");
+        assertFalse(origin1.matchesRelaxed(origin2));
+        assertFalse(origin1.matchesRelaxed(origin3));
+    }
+
+    @Test
+    void validateDifferentPort_test() {
+        Origin origin1 = new Origin("https://my.fido2/");
+        Origin origin2 = new Origin("https://my.fido2:8443/");
+        assertTrue(origin1.matchesRelaxed(origin2));
+
+        origin1 = new Origin("http://my.fido2:20/");
+        origin2 = new Origin("http://my.fido2:30/");
+        assertTrue(origin1.matchesRelaxed(origin2));
+    }
+
+    @Test
+    void validateSubdomain_test() {
+        Origin origin1 = new Origin("https://my.fido2.com/");
+        Origin origin2 = new Origin("https://myother.fido2.com/");
+        Origin origin3 = new Origin("https://fido2.com/");
+        assertTrue(origin1.matchesRelaxed(origin3));
+        assertTrue(origin2.matchesRelaxed(origin3));
+    }
+    
+}


### PR DESCRIPTION
The spec mandates a relaxed same origin restriction, as opposed to an equality test - see https://www.w3.org/TR/webauthn/#determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised.

This change includes:
- A `RelaxedOriginValidator`.
- A respective relaxed matcher method in the `Origin` class.
- Allows to set an origin validator on `Manager` and `DataValidator` classes. Default is still the usual `OriginValidator`.

The default `OriginValidator` is unchanged, except for being exposed to referring classes.