### PR TITLE
add NullAppleAnonymousAttestationStatementValidator to createNonStric…

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnRegistrationManager.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnRegistrationManager.java
@@ -36,6 +36,7 @@ import com.webauthn4j.validator.RegistrationDataValidator;
 import com.webauthn4j.validator.attestation.statement.AttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.androidkey.NullAndroidKeyAttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.androidsafetynet.NullAndroidSafetyNetAttestationStatementValidator;
+import com.webauthn4j.validator.attestation.statement.apple.NullAppleAnonymousAttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.none.NoneAttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.packed.NullPackedAttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.tpm.NullTPMAttestationStatementValidator;
@@ -155,7 +156,8 @@ public class WebAuthnRegistrationManager {
                         new NullPackedAttestationStatementValidator(),
                         new NullTPMAttestationStatementValidator(),
                         new NullAndroidKeyAttestationStatementValidator(),
-                        new NullAndroidSafetyNetAttestationStatementValidator()
+                        new NullAndroidSafetyNetAttestationStatementValidator(),
+                        new NullAppleAnonymousAttestationStatementValidator()
                 ),
                 new NullCertPathTrustworthinessValidator(),
                 new NullSelfAttestationTrustworthinessValidator(),


### PR DESCRIPTION
…tWebAuthnRegistrationManager()

Apple Anonymous Attestation with NonStrictWebAuthnRegistrationManager couses this error.

com.webauthn4j.converter.exception.DataConversionException: Input data does not match expected form
        at com.webauthn4j.converter.util.CborConverter.readValue(CborConverter.java:54)
        at com.webauthn4j.converter.AttestationObjectConverter.convert(AttestationObjectConverter.java:70)
        at com.webauthn4j.WebAuthnRegistrationManager.parse(WebAuthnRegistrationManager.java:251)

Caused by: com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'apple' as a subtype of `com.webauthn4j.data.attestation.statement.AttestationStatement`: known type ids = [android-key, android-safetynet, fido-u2f, none, packed, tpm] (for POJO property 'attStmt')
