### PR TITLE
Make converters to throw DataConversionException when null check failed

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AttestationObjectConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AttestationObjectConverter.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.converter;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.jackson.JacksonUtil;
 import com.webauthn4j.converter.util.CborConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
@@ -55,9 +56,14 @@ public class AttestationObjectConverter {
      * @return the converted object
      */
     public @Nullable AttestationObject convert(@NonNull String source) {
-        AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
-        byte[] value = Base64UrlUtil.decode(source);
-        return convert(value);
+        try{
+            AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
+            byte[] value = Base64UrlUtil.decode(source);
+            return convert(value);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
     /**
@@ -67,8 +73,13 @@ public class AttestationObjectConverter {
      * @return the converted object
      */
     public @Nullable AttestationObject convert(@NonNull byte[] source) {
-        AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
-        return cborConverter.readValue(source, AttestationObject.class);
+        try{
+            AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
+            return cborConverter.readValue(source, AttestationObject.class);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
     /**
@@ -78,8 +89,13 @@ public class AttestationObjectConverter {
      * @return the converted byte array
      */
     public @NonNull byte[] convertToBytes(@NonNull AttestationObject source) {
-        AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
-        return cborConverter.writeValueAsBytes(source);
+        try{
+            AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
+            return cborConverter.writeValueAsBytes(source);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
     /**
@@ -89,8 +105,13 @@ public class AttestationObjectConverter {
      * @return the converted byte array
      */
     public @NonNull String convertToBase64urlString(@NonNull AttestationObject source) {
-        byte[] bytes = convertToBytes(source);
-        return Base64UrlUtil.encodeToString(bytes);
+        try{
+            byte[] bytes = convertToBytes(source);
+            return Base64UrlUtil.encodeToString(bytes);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
     /**

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverter.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.converter;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientInputs;
@@ -46,15 +47,25 @@ public class AuthenticationExtensionsClientInputsConverter {
     // ================================================================================================
 
     public <T extends ExtensionClientInput> @Nullable AuthenticationExtensionsClientInputs<T> convert(@NonNull String value) {
-        AssertUtil.notNull(value, "value must not be null");
-        return jsonConverter.readValue(value, new TypeReference<AuthenticationExtensionsClientInputs<T>>() {
-        });
+        try{
+            AssertUtil.notNull(value, "value must not be null");
+            return jsonConverter.readValue(value, new TypeReference<AuthenticationExtensionsClientInputs<T>>() {
+            });
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
 
     public <T extends ExtensionClientInput> @NonNull String convertToString(@NonNull AuthenticationExtensionsClientInputs<T> value) {
-        AssertUtil.notNull(value, "value must not be null");
-        return jsonConverter.writeValueAsString(value);
+        try{
+            AssertUtil.notNull(value, "value must not be null");
+            return jsonConverter.writeValueAsString(value);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverter.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.converter;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
@@ -46,14 +47,24 @@ public class AuthenticationExtensionsClientOutputsConverter {
     // ================================================================================================
 
     public <T extends ExtensionClientOutput> @Nullable AuthenticationExtensionsClientOutputs<T> convert(@NonNull String value) {
-        AssertUtil.notNull(value, "value must not be null");
-        return jsonConverter.readValue(value, new TypeReference<AuthenticationExtensionsClientOutputs<T>>() {
-        });
+        try{
+            AssertUtil.notNull(value, "value must not be null");
+            return jsonConverter.readValue(value, new TypeReference<AuthenticationExtensionsClientOutputs<T>>() {
+            });
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
     public <T extends ExtensionClientOutput> @NonNull String convertToString(@NonNull AuthenticationExtensionsClientOutputs<T> value) {
-        AssertUtil.notNull(value, "value must not be null");
-        return jsonConverter.writeValueAsString(value);
+        try{
+            AssertUtil.notNull(value, "value must not be null");
+            return jsonConverter.writeValueAsString(value);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticatorTransportConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AuthenticatorTransportConverter.java
@@ -27,8 +27,8 @@ import java.util.stream.Collectors;
 public class AuthenticatorTransportConverter {
 
     public @NonNull AuthenticatorTransport convert(@NonNull String value) {
-        AssertUtil.notNull(value, "value must not be null");
         try {
+            AssertUtil.notNull(value, "value must not be null");
             return AuthenticatorTransport.create(value);
         } catch (IllegalArgumentException e) {
             throw new DataConversionException(e);
@@ -37,19 +37,31 @@ public class AuthenticatorTransportConverter {
 
     @SuppressWarnings("squid:S1168")
     public @NonNull Set<AuthenticatorTransport> convertSet(@NonNull Set<String> values) {
-        AssertUtil.notNull(values, "values must not be null");
-        return values.stream().map(this::convert).collect(Collectors.toSet());
+        try{
+            AssertUtil.notNull(values, "values must not be null");
+            return values.stream().map(this::convert).collect(Collectors.toSet());
+        } catch (IllegalArgumentException e) {
+            throw new DataConversionException(e);
+        }
     }
 
     public @NonNull String convertToString(@NonNull AuthenticatorTransport value) {
-        AssertUtil.notNull(value, "value must not be null");
-        return value.getValue();
+        try{
+            AssertUtil.notNull(value, "value must not be null");
+            return value.getValue();
+        } catch (IllegalArgumentException e) {
+            throw new DataConversionException(e);
+        }
     }
 
     @SuppressWarnings("squid:S1168")
     public @NonNull Set<String> convertSetToStringSet(@NonNull Set<AuthenticatorTransport> values) {
-        AssertUtil.notNull(values, "values must not be null");
-        return values.stream().map(this::convertToString).collect(Collectors.toSet());
+        try{
+            AssertUtil.notNull(values, "values must not be null");
+            return values.stream().map(this::convertToString).collect(Collectors.toSet());
+        } catch (IllegalArgumentException e) {
+            throw new DataConversionException(e);
+        }
     }
 
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/CollectedClientDataConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/CollectedClientDataConverter.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.converter;
 
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.client.CollectedClientData;
@@ -54,9 +55,14 @@ public class CollectedClientDataConverter {
      * @return the converted object
      */
     public @Nullable CollectedClientData convert(@NonNull String base64UrlString) {
-        AssertUtil.notNull(base64UrlString, "base64UrlString must not be null");
-        byte[] bytes = Base64UrlUtil.decode(base64UrlString);
-        return convert(bytes);
+        try{
+            AssertUtil.notNull(base64UrlString, "base64UrlString must not be null");
+            byte[] bytes = Base64UrlUtil.decode(base64UrlString);
+            return convert(bytes);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
     /**
@@ -66,9 +72,14 @@ public class CollectedClientDataConverter {
      * @return the converted object
      */
     public @Nullable CollectedClientData convert(@NonNull byte[] source) {
-        AssertUtil.notNull(source, "source must not be null");
-        String jsonString = new String(source, StandardCharsets.UTF_8);
-        return jsonConverter.readValue(jsonString, CollectedClientData.class);
+        try{
+            AssertUtil.notNull(source, "source must not be null");
+            String jsonString = new String(source, StandardCharsets.UTF_8);
+            return jsonConverter.readValue(jsonString, CollectedClientData.class);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
     /**
@@ -78,8 +89,13 @@ public class CollectedClientDataConverter {
      * @return the converted byte array
      */
     public @NonNull byte[] convertToBytes(@NonNull CollectedClientData source) {
-        AssertUtil.notNull(source, "source must not be null");
-        return jsonConverter.writeValueAsBytes(source);
+        try{
+            AssertUtil.notNull(source, "source must not be null");
+            return jsonConverter.writeValueAsBytes(source);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
     /**
@@ -89,8 +105,13 @@ public class CollectedClientDataConverter {
      * @return the converted byte array
      */
     public @NonNull String convertToBase64UrlString(@NonNull CollectedClientData source) {
-        byte[] bytes = convertToBytes(source);
-        return Base64UrlUtil.encodeToString(bytes);
+        try{
+            byte[] bytes = convertToBytes(source);
+            return Base64UrlUtil.encodeToString(bytes);
+        }
+        catch (IllegalArgumentException e){
+            throw new DataConversionException(e);
+        }
     }
 
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationObjectConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestationObjectConverterTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.converter;
 
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("ConstantConditions")
 class AttestationObjectConverterTest {
@@ -64,8 +64,8 @@ class AttestationObjectConverterTest {
     @Test
     void convert_null_test() {
         //noinspection ConstantConditions
-        assertThatThrownBy(() -> target.convert((String) null)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> target.convert((byte[]) null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> target.convert((String) null)).isInstanceOf(DataConversionException.class);
+        assertThatThrownBy(() -> target.convert((byte[]) null)).isInstanceOf(DataConversionException.class);
     }
 
     @Test
@@ -80,7 +80,7 @@ class AttestationObjectConverterTest {
     @Test
     void convertToBytes_null_test() {
         //noinspection ConstantConditions
-        assertThatThrownBy(() -> target.convertToBytes(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> target.convertToBytes(null)).isInstanceOf(DataConversionException.class);
     }
 
     @Test
@@ -115,9 +115,7 @@ class AttestationObjectConverterTest {
     @Test
     void convert_test_with_illegal_input() {
         String testData = "illegal input";
-        assertThrows(IllegalArgumentException.class,
-                () -> target.convert(testData)
-        );
+        assertThatThrownBy(() -> target.convert(testData)).isInstanceOf(DataConversionException.class);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestedCredentialDataConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AttestedCredentialDataConverterTest.java
@@ -16,12 +16,16 @@
 
 package com.webauthn4j.converter;
 
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
 import com.webauthn4j.util.Base64UrlUtil;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AttestedCredentialDataConverterTest {
 
@@ -40,6 +44,13 @@ class AttestedCredentialDataConverterTest {
         assertThat(attestedCredentialData.getAaguid().getBytes()).isEqualTo(Base64UrlUtil.decode("VQ5LVKpHQJ-alRq3bBMBMQ"));
         assertThat(attestedCredentialData.getCredentialId()).isEqualTo(Base64UrlUtil.decode("cSLOLIaiEIVRz-EklkZ21K71OGcRvvgro1kLdT4pvCA"));
 
+    }
+
+    @Test
+    void convert_null_test(){
+        assertThatThrownBy(()-> target.convert((AttestedCredentialData) null)).isInstanceOf(DataConversionException.class);
+        assertThatThrownBy(()-> target.convert((ByteBuffer) null)).isInstanceOf(DataConversionException.class);
+        assertThatThrownBy(()-> target.convert((byte[]) null)).isInstanceOf(DataConversionException.class);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientInputsConverterTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.converter;
 
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionClientInput;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientInputs;
@@ -37,7 +38,7 @@ class AuthenticationExtensionsClientInputsConverterTest {
     @SuppressWarnings("ConstantConditions")
     @Test
     void convertRegistrationExtensions_null_test() {
-        assertThatThrownBy(() -> authenticationExtensionsClientInputsConverter.convert(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> authenticationExtensionsClientInputsConverter.convert(null)).isInstanceOf(DataConversionException.class);
     }
 
     @Test
@@ -51,7 +52,7 @@ class AuthenticationExtensionsClientInputsConverterTest {
     @SuppressWarnings("ConstantConditions")
     @Test
     void convertAuthenticationExtensionsToString_null_test() {
-        assertThatThrownBy(() -> authenticationExtensionsClientInputsConverter.convertToString(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> authenticationExtensionsClientInputsConverter.convertToString(null)).isInstanceOf(DataConversionException.class);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticationExtensionsClientOutputsConverterTest.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.converter;
 
 
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 
@@ -31,12 +32,12 @@ class AuthenticationExtensionsClientOutputsConverterTest {
     @Test
     void convert_null_test() {
         //noinspection ConstantConditions
-        assertThatThrownBy(() -> target.convert(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> target.convert(null)).isInstanceOf(DataConversionException.class);
     }
 
     @Test
     void convertToString_null_test() {
         //noinspection ConstantConditions
-        assertThatThrownBy(() -> target.convertToString(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> target.convertToString(null)).isInstanceOf(DataConversionException.class);
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorTransportConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorTransportConverterTest.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.converter;
 
 
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.data.AuthenticatorTransport;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,11 @@ class AuthenticatorTransportConverterTest {
     }
 
     @Test
+    void convert_null_test() {
+        assertThatThrownBy(() -> converter.convert(null)).isInstanceOf(DataConversionException.class);
+    }
+
+    @Test
     void convert_unknown_value_test() {
         assertThat(converter.convert("unknown")).isEqualTo(AuthenticatorTransport.create("unknown"));
     }
@@ -48,12 +54,17 @@ class AuthenticatorTransportConverterTest {
 
     @Test
     void convertSet_null_test() {
-        assertThatThrownBy(() -> converter.convertSet(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> converter.convertSet(null)).isInstanceOf(DataConversionException.class);
     }
 
     @Test
     void convertToString_test() {
         assertThat(converter.convertToString(AuthenticatorTransport.USB)).isEqualTo("usb");
+    }
+
+    @Test
+    void convertToString_null_test() {
+        assertThatThrownBy(() -> converter.convertToString(null)).isInstanceOf(DataConversionException.class);
     }
 
     @Test
@@ -64,7 +75,7 @@ class AuthenticatorTransportConverterTest {
     @Test
     void convertSetToStringSet_null_test() {
         //noinspection ConstantConditions
-        assertThatThrownBy(() -> converter.convertSetToStringSet(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> converter.convertSetToStringSet(null)).isInstanceOf(DataConversionException.class);
     }
 
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/CollectedClientDataConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/CollectedClientDataConverterTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.converter;
 
+import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.client.ClientDataType;
 import com.webauthn4j.data.client.CollectedClientData;
@@ -52,8 +53,10 @@ class CollectedClientDataConverterTest {
 
     @Test
     void convert_null_test() {
-        assertThatThrownBy(() -> target.convert((String) null)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> target.convert((byte[]) null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> target.convert((String) null)).isInstanceOf(DataConversionException.class);
+        assertThatThrownBy(() -> target.convert((byte[]) null)).isInstanceOf(DataConversionException.class);
+        assertThatThrownBy(() -> target.convertToBytes( null)).isInstanceOf(DataConversionException.class);
+        assertThatThrownBy(() -> target.convertToBase64UrlString( null)).isInstanceOf(DataConversionException.class);
     }
 
     @Test


### PR DESCRIPTION
Make converters to throw `DataConversionException` instead of `IllegalArgumentException` when null check failed