### PR TITLE
Make DeviceCheckManager.createObjectConverter public

### DIFF
--- a/docs/src/reference/asciidoc/en/deep-dive.adoc
+++ b/docs/src/reference/asciidoc/en/deep-dive.adoc
@@ -103,6 +103,13 @@ This member can be serialized as JSON as it is originally JSON data.
 String serializedClientExtensions = objectConverter.getJsonConverter().writeValueAsString(clientExtensions);
 ----
 
+=== DCAppleDevice serialization and deserialization
+
+When you use `webauthn4j-device-check`, you need to persist `DCAppleDevice` instead of `Authenticator` interface between attestation and assertion.
+In general, you can serialize and deserialize it by the method explained in <<Authenticator serialization and deserialization>>,
+but `ObjectConverter` must be the one with `DeviceCheckCBORModule` registered.
+A `ObjectConverter` with a `DeviceCheckCBORModule` can be obtained with `DeviceCheckManager.createObjectConverter` static method.
+
 === Using FIDO CTAP2 Security key in your own application other than WebAuthn
 
 For FIDO CTAP2 Security key, WebAuthn is just an application. An original application can use a a security key too.

--- a/docs/src/reference/asciidoc/ja/deep-dive.adoc
+++ b/docs/src/reference/asciidoc/ja/deep-dive.adoc
@@ -103,6 +103,14 @@ clientExtensionsは元来JSONデータの為、JSONに変換できます。
 String serializedClientExtensions = objectConverter.getJsonConverter().writeValueAsString(clientExtensions);
 ----
 
+=== DCAppleDeviceのシリアライズ、デシリアライズ
+
+webauthn4j-device-checkでは、`Authenticator` インタフェースの代わりに、`DCAppleDevice` インタフェースを実装したクラスを、構成証明の検証時とアサーションの検証時の間で永続化する必要があります。
+概ね<<Authenticatorのシリアライズ、デシリアライズ>>で解説した方法でシリアライズ、デシリアライズが可能ですが、一点気を付ける必要がある点として、
+webauthn4j-device-check独自のクラス（例えば `AppleAppAttestAttestationStatement` )のシリアライズ、デシリアライズを行う為に、
+`ObjectConverter` は `DeviceCheckCBORModule` が登録されたものを使用する必要があります。
+`DeviceCheckCBORModule` が登録された`ObjectConverter` は `DeviceCheckManager#createObjectConverter` で得ることが出来ます。
+
 === WebAuthn以外のFIDO CTAP2セキュリティキーを用いた独自アプリケーションでの利用
 
 FIDO CTAP2セキュリティキーにとって、WebAuthnは一つの応用例でしかなく、セキュアな認証を必要とする独自アプリケーションで

--- a/webauthn4j-device-check/src/main/java/com/webauthn4j/appattest/DeviceCheckManager.java
+++ b/webauthn4j-device-check/src/main/java/com/webauthn4j/appattest/DeviceCheckManager.java
@@ -114,7 +114,11 @@ public class DeviceCheckManager {
         );
     }
 
-    private static @NonNull ObjectConverter createObjectConverter() {
+    /**
+     * Create {@link ObjectConverter} instance with {@link DeviceCheckCBORModule}
+     * @return {@link ObjectConverter} instance with {@link DeviceCheckCBORModule}
+     */
+    public static @NonNull ObjectConverter createObjectConverter() {
         ObjectMapper jsonMapper = new ObjectMapper();
         ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
         cborMapper.registerModule(new DeviceCheckCBORModule());


### PR DESCRIPTION
This pull-request makes `DeviceCheckManager.createObjectConverter` public.
Users of `webauthn4j-device-check` needs a `ObjectConverter` instance with a `DeviceCheckCBORModule`, and this helper method satisfies these needs.

This fixes #418 