### PR TITLE
Expose OriginValidator to public

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
@@ -41,7 +41,6 @@ import java.util.Objects;
 public class AuthenticationDataValidator {
 
     private final ChallengeValidator challengeValidator = new ChallengeValidator();
-    private final OriginValidator originValidator = new OriginValidator();
     private final TokenBindingValidator tokenBindingValidator = new TokenBindingValidator();
     private final RpIdHashValidator rpIdHashValidator = new RpIdHashValidator();
     private final AssertionSignatureValidator assertionSignatureValidator = new AssertionSignatureValidator();
@@ -50,6 +49,7 @@ public class AuthenticationDataValidator {
 
     private final List<CustomAuthenticationValidator> customAuthenticationValidators;
 
+    private OriginValidator originValidator = new OriginValidatorImpl();
     private CoreMaliciousCounterValueHandler maliciousCounterValueHandler = new DefaultCoreMaliciousCounterValueHandler();
 
     public AuthenticationDataValidator(@NonNull List<CustomAuthenticationValidator> customAuthenticationValidators) {
@@ -132,7 +132,7 @@ public class AuthenticationDataValidator {
 
         //spec| Step9
         //spec| Verify that the value of C.origin matches the Relying Party's origin.
-        originValidator.validate(collectedClientData, serverProperty);
+        originValidator.validate(authenticationObject);
 
         //spec| Step10
         //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
@@ -215,6 +215,14 @@ public class AuthenticationDataValidator {
     public void setMaliciousCounterValueHandler(@NonNull CoreMaliciousCounterValueHandler maliciousCounterValueHandler) {
         AssertUtil.notNull(maliciousCounterValueHandler, "maliciousCounterValueHandler must not be null");
         this.maliciousCounterValueHandler = maliciousCounterValueHandler;
+    }
+
+    public OriginValidator getOriginValidator() {
+        return originValidator;
+    }
+
+    public void setOriginValidator(OriginValidator originValidator) {
+        this.originValidator = originValidator;
     }
 
     public @NonNull List<CustomAuthenticationValidator> getCustomAuthenticationValidators() {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/OriginValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/OriginValidator.java
@@ -16,32 +16,14 @@
 
 package com.webauthn4j.validator;
 
-import com.webauthn4j.data.client.CollectedClientData;
 import com.webauthn4j.data.client.Origin;
-import com.webauthn4j.server.ServerProperty;
-import com.webauthn4j.util.AssertUtil;
-import com.webauthn4j.validator.exception.BadOriginException;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Validates the specified {@link Origin} instance
  */
-class OriginValidator {
+public interface OriginValidator {
 
-    //~ Instance fields
-    // ================================================================================================
-
-
-    // ~ Methods
-    // ========================================================================================================
-
-    public void validate(@NonNull CollectedClientData collectedClientData, @NonNull ServerProperty serverProperty) {
-        AssertUtil.notNull(collectedClientData, "collectedClientData must not be null");
-        AssertUtil.notNull(serverProperty, "serverProperty must not be null");
-
-        final Origin clientOrigin = collectedClientData.getOrigin();
-        if (!serverProperty.getOrigins().contains(clientOrigin)) {
-            throw new BadOriginException("The collectedClientData '" + clientOrigin + "' origin doesn't match any of the preconfigured server origin.");
-        }
-    }
+    void validate(@NonNull RegistrationObject registrationObject);
+    void validate(@NonNull AuthenticationObject authenticationObject);
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/OriginValidatorImpl.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/OriginValidatorImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.validator;
+
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.client.Origin;
+import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.util.AssertUtil;
+import com.webauthn4j.validator.exception.BadOriginException;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class OriginValidatorImpl implements OriginValidator{
+
+    //~ Instance fields
+    // ================================================================================================
+
+
+    // ~ Methods
+    // ========================================================================================================
+
+    @Override
+    public void validate(@NonNull RegistrationObject registrationObject) {
+        AssertUtil.notNull(registrationObject, "registrationObject must not be null");
+        CollectedClientData collectedClientData = registrationObject.getCollectedClientData();
+        ServerProperty serverProperty = registrationObject.getServerProperty();
+        validate(collectedClientData, serverProperty);
+    }
+
+    @Override
+    public void validate(@NonNull AuthenticationObject authenticationObject) {
+        AssertUtil.notNull(authenticationObject, "authenticationObject must not be null");
+        CollectedClientData collectedClientData = authenticationObject.getCollectedClientData();
+        ServerProperty serverProperty = authenticationObject.getServerProperty();
+        validate(collectedClientData, serverProperty);
+    }
+
+    protected void validate(@NonNull CollectedClientData collectedClientData, @NonNull ServerProperty serverProperty) {
+        AssertUtil.notNull(collectedClientData, "collectedClientData must not be null");
+        AssertUtil.notNull(serverProperty, "serverProperty must not be null");
+
+        final Origin clientOrigin = collectedClientData.getOrigin();
+        if (!serverProperty.getOrigins().contains(clientOrigin)) {
+            throw new BadOriginException("The collectedClientData '" + clientOrigin + "' origin doesn't match any of the preconfigured server origin.");
+        }
+    }
+
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
@@ -48,9 +48,7 @@ public class RegistrationDataValidator {
 
     // ~ Instance fields
     // ================================================================================================
-
     private final ChallengeValidator challengeValidator = new ChallengeValidator();
-    private final OriginValidator originValidator = new OriginValidator();
     private final TokenBindingValidator tokenBindingValidator = new TokenBindingValidator();
     private final RpIdHashValidator rpIdHashValidator = new RpIdHashValidator();
     private final ClientExtensionValidator clientExtensionValidator = new ClientExtensionValidator();
@@ -59,6 +57,8 @@ public class RegistrationDataValidator {
     private final List<CustomRegistrationValidator> customRegistrationValidators = new ArrayList<>();
 
     private final AttestationValidator attestationValidator;
+
+    private OriginValidator originValidator = new OriginValidatorImpl();
 
     public RegistrationDataValidator(
             @NonNull List<AttestationStatementValidator> attestationStatementValidators,
@@ -120,7 +120,7 @@ public class RegistrationDataValidator {
 
         //spec| Step5
         //spec| Verify that the value of C.origin matches the Relying Party's origin.
-        originValidator.validate(collectedClientData, serverProperty);
+        originValidator.validate(registrationObject);
 
         //spec| Step6
         //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
@@ -197,6 +197,14 @@ public class RegistrationDataValidator {
         if (isUserPresenceRequired && !authenticatorData.isFlagUP()) {
             throw new UserNotPresentException("Validator is configured to check user present, but UP flag in authenticatorData is not set.");
         }
+    }
+
+    public OriginValidator getOriginValidator() {
+        return originValidator;
+    }
+
+    public void setOriginValidator(OriginValidator originValidator) {
+        this.originValidator = originValidator;
     }
 
     public List<CustomRegistrationValidator> getCustomRegistrationValidators() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationDataValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationDataValidatorTest.java
@@ -48,4 +48,14 @@ class AuthenticationDataValidatorTest {
         target.getCustomAuthenticationValidators().add(customAuthenticationValidator);
         assertThat(target.getCustomAuthenticationValidators()).contains(customAuthenticationValidator);
     }
+
+    @Test
+    void getter_setter_test(){
+        target.setOriginValidator(new TestOriginValidator());
+        assertThat(target.getOriginValidator()).isInstanceOf(TestOriginValidator.class);
+    }
+
+    private static class TestOriginValidator extends OriginValidatorImpl {
+    }
+
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/OriginValidatorImplTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/OriginValidatorImplTest.java
@@ -34,9 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Test for OriginValidator
  */
-class OriginValidatorTest {
+class OriginValidatorImplTest {
 
-    private final OriginValidator target = new OriginValidator();
+    private final OriginValidatorImpl target = new OriginValidatorImpl();
 
     @ParameterizedTest
     @ValueSource(strings = {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationDataValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationDataValidatorTest.java
@@ -102,4 +102,13 @@ class RegistrationDataValidatorTest {
         target.getCustomRegistrationValidators().add(customRegistrationValidator);
         assertThat(target.getCustomRegistrationValidators()).contains(customRegistrationValidator);
     }
+
+    @Test
+    void getter_setter_test(){
+        target.setOriginValidator(new TestOriginValidator());
+        assertThat(target.getOriginValidator()).isInstanceOf(TestOriginValidator.class);
+    }
+
+    private static class TestOriginValidator extends OriginValidatorImpl {
+    }
 }

--- a/webauthn4j-core/src/test/java/integration/component/CustomOriginValidatorTest.java
+++ b/webauthn4j-core/src/test/java/integration/component/CustomOriginValidatorTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.component;
+
+import com.webauthn4j.WebAuthnManager;
+import com.webauthn4j.converter.AuthenticationExtensionsClientOutputsConverter;
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.*;
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
+import com.webauthn4j.data.client.Origin;
+import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.data.client.challenge.DefaultChallenge;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientInputs;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientInput;
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.test.EmulatorUtil;
+import com.webauthn4j.test.authenticator.webauthn.WebAuthnAuthenticatorAdaptor;
+import com.webauthn4j.test.client.ClientPlatform;
+import com.webauthn4j.validator.AuthenticationObject;
+import com.webauthn4j.validator.OriginValidator;
+import com.webauthn4j.validator.RegistrationObject;
+import com.webauthn4j.validator.exception.BadOriginException;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("ConstantConditions")
+class CustomOriginValidatorTest {
+
+    private final ObjectConverter objectConverter = new ObjectConverter();
+
+    private final Origin origin = new Origin("http://localhost");
+    private final WebAuthnAuthenticatorAdaptor webAuthnAuthenticatorAdaptor = new WebAuthnAuthenticatorAdaptor(EmulatorUtil.PACKED_AUTHENTICATOR);
+    private final ClientPlatform clientPlatform = new ClientPlatform(origin, webAuthnAuthenticatorAdaptor);
+    private final WebAuthnManager target = WebAuthnManager.createNonStrictWebAuthnManager();
+
+    private final AuthenticationExtensionsClientOutputsConverter authenticationExtensionsClientOutputsConverter
+            = new AuthenticationExtensionsClientOutputsConverter(objectConverter);
+
+    @BeforeEach
+    void setup(){
+        target.getRegistrationDataValidator().setOriginValidator(new CustomOriginValidator());
+    }
+
+    @Test
+    void registration_test() {
+        String rpId = "example.com";
+        Challenge challenge = new DefaultChallenge();
+        AuthenticatorSelectionCriteria authenticatorSelectionCriteria =
+                new AuthenticatorSelectionCriteria(
+                        AuthenticatorAttachment.CROSS_PLATFORM,
+                        true,
+                        UserVerificationRequirement.REQUIRED);
+
+        PublicKeyCredentialParameters publicKeyCredentialParameters = new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256);
+
+        PublicKeyCredentialUserEntity publicKeyCredentialUserEntity = new PublicKeyCredentialUserEntity(new byte[32], "username", "displayName");
+
+        AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput> extensions = new AuthenticationExtensionsClientInputs<>();
+        PublicKeyCredentialCreationOptions credentialCreationOptions
+                = new PublicKeyCredentialCreationOptions(
+                new PublicKeyCredentialRpEntity(rpId, "example.com"),
+                publicKeyCredentialUserEntity,
+                challenge,
+                Collections.singletonList(publicKeyCredentialParameters),
+                null,
+                Collections.emptyList(),
+                authenticatorSelectionCriteria,
+                AttestationConveyancePreference.NONE,
+                extensions
+        );
+        PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput> credential = clientPlatform.create(credentialCreationOptions);
+        AuthenticatorAttestationResponse registrationRequest = credential.getAuthenticatorResponse();
+        AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensionResults = credential.getClientExtensionResults();
+        Set<String> transports = Collections.emptySet();
+        String clientExtensionJSON = authenticationExtensionsClientOutputsConverter.convertToString(clientExtensionResults);
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
+        RegistrationRequest webAuthnRegistrationRequest
+                = new RegistrationRequest(
+                registrationRequest.getAttestationObject(),
+                registrationRequest.getClientDataJSON(),
+                clientExtensionJSON,
+                transports
+        );
+        RegistrationParameters registrationParameters = new RegistrationParameters(
+                serverProperty,
+                false
+        );
+
+
+        RegistrationData registrationData = target.parse(webAuthnRegistrationRequest);
+        assertThatThrownBy(()->{
+                target.validate(registrationData, registrationParameters);
+        }).isInstanceOf(BadOriginException.class);
+
+    }
+
+    private static class CustomOriginValidator implements OriginValidator {
+        @Override
+        public void validate(@NonNull RegistrationObject registrationObject) {
+            if(!Objects.equals(registrationObject.getCollectedClientData().getOrigin(), new Origin("http://example.com"))){
+                throw new BadOriginException("origin must be http://example.com");
+            }
+        }
+
+        @Override
+        public void validate(@NonNull AuthenticationObject authenticationObject) {
+            if(!Objects.equals(authenticationObject.getCollectedClientData().getOrigin(), new Origin("http://localhost"))){
+                throw new BadOriginException("origin must be http://example.com");
+            }
+        }
+    }
+}


### PR DESCRIPTION
In some cases, users want to customize OriginValidator logic.
This commit make OriginValidator to interface and expose it to public.
Now users can set their own OriginValidator implementation to
RegistrationDataValidator or AuthenticationDataValidator through their
setter.