### PR TITLE
Start 0.16.0 development

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-webAuthn4JVersion=0.15.2-SNAPSHOT
+webAuthn4JVersion=0.16.0-SNAPSHOT
 latestReleasedWebAuthn4JVersion=0.15.1.RELEASE


### PR DESCRIPTION
Change next version from 0.15.2 to 0.16.0 as we will have breaking change (remove deprecated code #484).