### PR TITLE
Bugfix: PublicKeyCredentialUserEntity cannot be deserialized

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/PublicKeyCredentialUserEntity.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/PublicKeyCredentialUserEntity.java
@@ -16,7 +16,10 @@
 
 package com.webauthn4j.data;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.util.ArrayUtil;
+import com.webauthn4j.util.AssertUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Arrays;
@@ -42,11 +45,14 @@ public class PublicKeyCredentialUserEntity extends PublicKeyCredentialEntity {
      * @param name name
      * @param displayName displayName
      */
+    @JsonCreator
     public PublicKeyCredentialUserEntity(
-            @NonNull byte[] id,
-            @NonNull String name,
-            @NonNull String displayName) {
+            @NonNull @JsonProperty("id") byte[] id,
+            @NonNull @JsonProperty("name") String name,
+            @NonNull @JsonProperty("displayName") String displayName) {
         super(name);
+        AssertUtil.notNull(name, "name must not be null");
+        AssertUtil.notNull(displayName, "displayName must not be null");
         this.id = id;
         this.displayName = displayName;
     }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialUserEntityTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialUserEntityTest.java
@@ -16,6 +16,8 @@
 
 package com.webauthn4j.data;
 
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.util.Base64Util;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,5 +44,11 @@ class PublicKeyCredentialUserEntityTest {
                 () -> assertThat(instanceA).isEqualTo(instanceB),
                 () -> assertThat(instanceA).hasSameHashCodeAs(instanceB)
         );
+    }
+
+    @Test
+    void deserialize_test(){
+        PublicKeyCredentialUserEntity user = new ObjectConverter().getJsonConverter().readValue("{\"id\": \"ZHVtbXk=\", \"name\": \"name\", \"displayName\": \"displayName\"}", PublicKeyCredentialUserEntity.class);
+        assertThat(user.getId()).isEqualTo(Base64Util.decode("ZHVtbXk="));
     }
 }


### PR DESCRIPTION
`PublicKeyCredentialUserEntity` cannot be deserialized from JSON/CBOR as it lost Jackson markup from 0.15.0.RELEASE