### PR TITLE
Fix bugs using non-resident keys in WebAuthnModelAuthenticator.

### DIFF
--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
@@ -54,8 +54,10 @@ import com.webauthn4j.util.*;
 import com.webauthn4j.validator.CoreRegistrationObject;
 import com.webauthn4j.validator.RegistrationObject;
 
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.*;
+import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.ECPoint;
@@ -318,6 +320,21 @@ public class TestDataUtil {
      * @return {@link EC2COSEKey}
      */
     public static EC2COSEKey createEC2COSEPublicKey(ECPublicKey publicKey) {
+        return createEC2COSEKey(publicKey, null);
+    }
+
+    /**
+     * createEC2COSEPrivateKey from {@code ECPrivateKey}
+     *
+     * @param publicKey publicKey
+     * @param privateKey privateKey
+     * @return {@link EC2COSEKey}
+     */
+    public static EC2COSEKey createEC2COSEPrivateKey(ECPublicKey publicKey, ECPrivateKey privateKey) {
+        return createEC2COSEKey(publicKey, privateKey.getS());
+    }
+
+    private static EC2COSEKey createEC2COSEKey(ECPublicKey publicKey, BigInteger d) {
         ECPoint ecPoint = publicKey.getW();
         EllipticCurve ellipticCurve = publicKey.getParams().getCurve();
         Curve curve;
@@ -348,7 +365,8 @@ public class TestDataUtil {
                 null,
                 curve,
                 x,
-                y
+                y,
+                d == null ? null : d.toByteArray()
         );
     }
 

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/PublicKeyCredentialSource.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/PublicKeyCredentialSource.java
@@ -17,14 +17,13 @@
 package com.webauthn4j.test.authenticator.webauthn;
 
 import com.webauthn4j.data.PublicKeyCredentialType;
-
-import java.security.PrivateKey;
+import com.webauthn4j.data.attestation.authenticator.COSEKey;
 
 public class PublicKeyCredentialSource {
 
     private PublicKeyCredentialType type;
     private byte[] id;
-    private PrivateKey privateKey;
+    private COSEKey privateKey;
     private String rpId;
     private byte[] userHandle;
     private Object otherUI;
@@ -45,11 +44,11 @@ public class PublicKeyCredentialSource {
         this.id = id;
     }
 
-    public PrivateKey getPrivateKey() {
+    public COSEKey getPrivateKey() {
         return privateKey;
     }
 
-    public void setPrivateKey(PrivateKey privateKey) {
+    public void setPrivateKey(COSEKey privateKey) {
         this.privateKey = privateKey;
     }
 

--- a/webauthn4j-test/src/test/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticatorTest.java
+++ b/webauthn4j-test/src/test/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticatorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.test.authenticator.webauthn;
+
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.PublicKeyCredentialCreationOptions;
+import com.webauthn4j.data.PublicKeyCredentialDescriptor;
+import com.webauthn4j.data.PublicKeyCredentialParameters;
+import com.webauthn4j.data.PublicKeyCredentialRpEntity;
+import com.webauthn4j.data.PublicKeyCredentialType;
+import com.webauthn4j.data.PublicKeyCredentialUserEntity;
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
+import com.webauthn4j.data.client.challenge.DefaultChallenge;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class PackedAuthenticatorTest {
+
+    private final ObjectConverter objectConverter = new ObjectConverter();
+    private final PackedAuthenticator target = new PackedAuthenticator();
+
+    @Test
+    void parseOptionsAndMakeCredentials_test() {
+        // Mimic getting a PublicKeyCredentialCreationOptions structure from a remote server
+        String optionsJson = serialize(new PublicKeyCredentialCreationOptions(
+                new PublicKeyCredentialRpEntity("test-rp", "Test RP"),
+                new PublicKeyCredentialUserEntity(new byte[32], "test-user", "Test User"),
+                new DefaultChallenge(new byte[32]),
+                Collections.singletonList(new PublicKeyCredentialParameters(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        COSEAlgorithmIdentifier.ES256
+                ))
+        ));
+
+        PublicKeyCredentialCreationOptions options = deserialize(optionsJson);
+        assertThatCode(() -> target.makeCredential(new MakeCredentialRequest(
+                new byte[32],
+                options.getRp(),
+                options.getUser(),
+                false,
+                true,
+                false,
+                options.getPubKeyCredParams()
+                ))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void makeCredentialsAndGetAssertion_test() {
+        final String rpId = "test-rp";
+        MakeCredentialResponse response = target.makeCredential(new MakeCredentialRequest(
+                new byte[32],
+                new PublicKeyCredentialRpEntity(rpId, "Test RP"),
+                new PublicKeyCredentialUserEntity(new byte[32], "test-user", "Test User"),
+                false,
+                true,
+                false,
+                Collections.singletonList(new PublicKeyCredentialParameters(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        COSEAlgorithmIdentifier.ES256
+                ))
+        ));
+        byte[] credentialId = response.getAttestationObject().getAuthenticatorData().getAttestedCredentialData().getCredentialId();
+
+        assertThatCode(() -> target.getAssertion(new GetAssertionRequest(rpId,
+                new byte[32],
+                Collections.singletonList(new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY,
+                        credentialId, null)),
+                true,
+                false,
+                null))).doesNotThrowAnyException();
+    }
+
+    private String serialize(PublicKeyCredentialCreationOptions options) {
+        return objectConverter.getJsonConverter().writeValueAsString(options);
+    }
+
+    private PublicKeyCredentialCreationOptions deserialize(String json) {
+        return objectConverter.getJsonConverter().readValue(json, PublicKeyCredentialCreationOptions.class);
+    }
+}


### PR DESCRIPTION
I was using the PackedAuthenticator today to do an integration test against a new service and ran into a few of bugs.

- COSEAlgorithmIdentifier is not an enum, so it needs a `.equals()` check instead of `==` (this comes up when it's deserialized JSON, which for me came up since I was deserializing options returned in a REST request from my service under test).
- Jackson wasn't able to serialize the PrivateKey in the `PublicKeyCredentialSource` so I switched this to a COSEKey instead.
- CipherUtil wasn't able to encrypt/decrypt the serialized credential since the attestion key was EC and not RSA, so I switched this to AES.

I added a couple of test cases that cover these things.