### PR TITLE
Fix missing credenital id from assertion of non-resident credential.

### DIFF
--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
@@ -125,7 +125,9 @@ public abstract class WebAuthnModelAuthenticator implements WebAuthnAuthenticato
 
         try {
             byte[] cbor = CipherUtil.decrypt(credentialId, credentialEncryptionKey);
-            return cborConverter.readValue(cbor, PublicKeyCredentialSource.class);
+            PublicKeyCredentialSource src = cborConverter.readValue(cbor, PublicKeyCredentialSource.class);
+            src.setId(credentialId);
+            return src;
         } catch (RuntimeException e) {
             // Do nothing; it wasn't an encrypted credential
         }

--- a/webauthn4j-test/src/test/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticatorTest.java
+++ b/webauthn4j-test/src/test/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticatorTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 class PackedAuthenticatorTest {
@@ -79,13 +80,14 @@ class PackedAuthenticatorTest {
         ));
         byte[] credentialId = response.getAttestationObject().getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
-        assertThatCode(() -> target.getAssertion(new GetAssertionRequest(rpId,
+        GetAssertionResponse assertion = target.getAssertion(new GetAssertionRequest(rpId,
                 new byte[32],
                 Collections.singletonList(new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY,
                         credentialId, null)),
                 true,
                 false,
-                null))).doesNotThrowAnyException();
+                null));
+        assertThat(assertion.getCredentialId()).isEqualTo(credentialId);
     }
 
     private String serialize(PublicKeyCredentialCreationOptions options) {


### PR DESCRIPTION
Fixing one more follow-up bug I found related to my previous PR (#510). When looking up a key the credential ID should get set on the result (since it's not part of what got serialized when it was created). Otherwise the credential ID ends up being missing on the GetAssertionResponse.