### PR TITLE
Add verifications introduced from WebAuthn L2

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If your would like to validate Apple App Attest, please see the reference.
 // Client properties
 byte[] attestationObject = null /* set attestationObject */;
 byte[] clientDataJSON = null /* set clientDataJSON */;
-String clientExtensionJSON = null;  /* set clientExtensionJSON */;
+String clientExtensionJSON = null;  /* set clientExtensionJSON */
 Set<String> transports = null /* set transports */;
 
 // Server properties
@@ -111,22 +111,19 @@ ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, toke
 // expectations
 boolean userVerificationRequired = false;
 boolean userPresenceRequired = true;
-List<String> expectedExtensionIds = Collections.emptyList();
 
 RegistrationRequest registrationRequest = new RegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
-RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
+RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired);
 RegistrationData registrationData;
-try{
+try {
     registrationData = webAuthnManager.parse(registrationRequest);
-}
-catch (DataConversionException e){
+} catch (DataConversionException e) {
     // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
     throw e;
 }
-try{
+try {
     webAuthnManager.validate(registrationData, registrationParameters);
-}
-catch (ValidationException e){
+} catch (ValidationException e) {
     // If you would like to handle WebAuthn data validation error, please catch ValidationException
     throw e;
 }
@@ -159,6 +156,7 @@ byte[] tokenBindingId = null /* set tokenBindingId */;
 ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
 // expectations
+List<byte[]> allowCredentials = null;
 boolean userVerificationRequired = true;
 boolean userPresenceRequired = true;
 List<String> expectedExtensionIds = Collections.emptyList();
@@ -178,23 +176,21 @@ AuthenticationParameters authenticationParameters =
         new AuthenticationParameters(
                 serverProperty,
                 authenticator,
+                allowCredentials,
                 userVerificationRequired,
-                userPresenceRequired,
-                expectedExtensionIds
+                userPresenceRequired
         );
 
 AuthenticationData authenticationData;
-try{
+try {
     authenticationData = webAuthnManager.parse(authenticationRequest);
-}
-catch (DataConversionException e){
+} catch (DataConversionException e) {
     // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
     throw e;
 }
-try{
+try {
     webAuthnManager.validate(authenticationData, authenticationParameters);
-}
-catch (ValidationException e){
+} catch (ValidationException e) {
     // If you would like to handle WebAuthn data validation error, please catch ValidationException
     throw e;
 }
@@ -203,7 +199,6 @@ updateCounter(
         authenticationData.getCredentialId(),
         authenticationData.getAuthenticatorData().getSignCount()
 );
-
 ```
 
 ## Sample application

--- a/docs/src/reference/asciidoc/en/quick-start.adoc
+++ b/docs/src/reference/asciidoc/en/quick-start.adoc
@@ -44,7 +44,7 @@ For more details about `Authenticator` serialization, please refer <<./deep-dive
 // Client properties
 byte[] attestationObject = null /* set attestationObject */;
 byte[] clientDataJSON = null /* set clientDataJSON */;
-String clientExtensionJSON = null;  /* set clientExtensionJSON */;
+String clientExtensionJSON = null;  /* set clientExtensionJSON */
 Set<String> transports = null /* set transports */;
 
 // Server properties
@@ -57,22 +57,19 @@ ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, toke
 // expectations
 boolean userVerificationRequired = false;
 boolean userPresenceRequired = true;
-List<String> expectedExtensionIds = Collections.emptyList();
 
 RegistrationRequest registrationRequest = new RegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
-RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
+RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired);
 RegistrationData registrationData;
-try{
+try {
     registrationData = webAuthnManager.parse(registrationRequest);
-}
-catch (DataConversionException e){
+} catch (DataConversionException e) {
     // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
     throw e;
 }
-try{
+try {
     webAuthnManager.validate(registrationData, registrationParameters);
-}
-catch (ValidationException e){
+} catch (ValidationException e) {
     // If you would like to handle WebAuthn data validation error, please catch ValidationException
     throw e;
 }
@@ -117,6 +114,7 @@ byte[] tokenBindingId = null /* set tokenBindingId */;
 ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
 // expectations
+List<byte[]> allowCredentials = null;
 boolean userVerificationRequired = true;
 boolean userPresenceRequired = true;
 List<String> expectedExtensionIds = Collections.emptyList();
@@ -136,23 +134,21 @@ AuthenticationParameters authenticationParameters =
         new AuthenticationParameters(
                 serverProperty,
                 authenticator,
+                allowCredentials,
                 userVerificationRequired,
-                userPresenceRequired,
-                expectedExtensionIds
+                userPresenceRequired
         );
 
 AuthenticationData authenticationData;
-try{
+try {
     authenticationData = webAuthnManager.parse(authenticationRequest);
-}
-catch (DataConversionException e){
+} catch (DataConversionException e) {
     // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
     throw e;
 }
-try{
+try {
     webAuthnManager.validate(authenticationData, authenticationParameters);
-}
-catch (ValidationException e){
+} catch (ValidationException e) {
     // If you would like to handle WebAuthn data validation error, please catch ValidationException
     throw e;
 }
@@ -161,7 +157,6 @@ updateCounter(
         authenticationData.getCredentialId(),
         authenticationData.getAuthenticatorData().getSignCount()
 );
-
 ----
 
 === Apple App Attest verification

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
@@ -19,9 +19,38 @@ package com.webauthn4j.data;
 import com.webauthn4j.authenticator.Authenticator;
 import com.webauthn4j.server.ServerProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
 
 public class AuthenticationParameters extends CoreAuthenticationParameters {
 
+    /**
+     * {@link AuthenticationParameters} constructor
+     * @param serverProperty server property
+     * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     * @param userPresenceRequired true if user presence is required. Otherwise, false
+     */
+    public AuthenticationParameters(@NonNull ServerProperty serverProperty, @NonNull Authenticator authenticator, @Nullable List<byte[]> allowCredentials, boolean userVerificationRequired, boolean userPresenceRequired) {
+        super(serverProperty, authenticator, allowCredentials, userVerificationRequired, userPresenceRequired);
+    }
+
+    /**
+     * {@link AuthenticationParameters} constructor
+     * @param serverProperty server property
+     * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     */
+    public AuthenticationParameters(@NonNull ServerProperty serverProperty, @NonNull Authenticator authenticator, @Nullable List<byte[]> allowCredentials, boolean userVerificationRequired) {
+        super(serverProperty, authenticator, allowCredentials, userVerificationRequired);
+    }
+
+    /**
+     * @deprecated Deprecated as pubKeyCredParams verification was introduced from WebAuthn Level2.
+     */
+    @SuppressWarnings("squid:S1133")
+    @Deprecated
     public AuthenticationParameters(
             @NonNull ServerProperty serverProperty,
             @NonNull Authenticator authenticator,
@@ -30,6 +59,11 @@ public class AuthenticationParameters extends CoreAuthenticationParameters {
         super(serverProperty, authenticator, userVerificationRequired, userPresenceRequired);
     }
 
+    /**
+     * @deprecated Deprecated as pubKeyCredParams verification was introduced from WebAuthn Level2.
+     */
+    @SuppressWarnings("squid:S1133")
+    @Deprecated
     public AuthenticationParameters(
             @NonNull ServerProperty serverProperty,
             @NonNull Authenticator authenticator,

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreAuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreAuthenticationParameters.java
@@ -19,10 +19,12 @@ package com.webauthn4j.data;
 import com.webauthn4j.authenticator.CoreAuthenticator;
 import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.util.AssertUtil;
+import com.webauthn4j.util.CollectionUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 public class CoreAuthenticationParameters implements Serializable {
@@ -31,22 +33,76 @@ public class CoreAuthenticationParameters implements Serializable {
     private final CoreAuthenticator authenticator;
 
     // verification condition
+    private final List<byte[]> allowCredentials;
     private final boolean userVerificationRequired;
     private final boolean userPresenceRequired;
 
+    /**
+     * {@link CoreAuthenticationParameters} constructor
+     * @param serverProperty server property
+     * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     * @param userPresenceRequired true if user presence is required. Otherwise, false
+     */
     public CoreAuthenticationParameters(
             @NonNull CoreServerProperty serverProperty,
             @NonNull CoreAuthenticator authenticator,
+            @Nullable List<byte[]> allowCredentials,
             boolean userVerificationRequired,
             boolean userPresenceRequired) {
         AssertUtil.notNull(serverProperty, "serverProperty must not be null");
         AssertUtil.notNull(authenticator, "authenticator must not be null");
         this.serverProperty = serverProperty;
         this.authenticator = authenticator;
+        this.allowCredentials = CollectionUtil.unmodifiableList(allowCredentials);
         this.userVerificationRequired = userVerificationRequired;
         this.userPresenceRequired = userPresenceRequired;
     }
 
+    /**
+     * {@link CoreAuthenticationParameters} constructor
+     * @param serverProperty server property
+     * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     */
+    public CoreAuthenticationParameters(
+            @NonNull CoreServerProperty serverProperty,
+            @NonNull CoreAuthenticator authenticator,
+            @Nullable List<byte[]> allowCredentials,
+            boolean userVerificationRequired) {
+        this(
+                serverProperty,
+                authenticator,
+                allowCredentials,
+                userVerificationRequired,
+                true
+        );
+    }
+
+    /**
+     * @deprecated Deprecated as pubKeyCredParams verification was introduced from WebAuthn Level2.
+     */
+    @SuppressWarnings("squid:S1133")
+    @Deprecated
+    public CoreAuthenticationParameters(
+            @NonNull CoreServerProperty serverProperty,
+            @NonNull CoreAuthenticator authenticator,
+            boolean userVerificationRequired,
+            boolean userPresenceRequired) {
+        this(
+                serverProperty,
+                authenticator,
+                null,
+                userVerificationRequired,
+                userPresenceRequired
+        );
+    }
+
+    /**
+     * @deprecated Deprecated as pubKeyCredParams verification was introduced from WebAuthn Level2.
+     */
+    @SuppressWarnings("squid:S1133")
+    @Deprecated
     public CoreAuthenticationParameters(
             @NonNull CoreServerProperty serverProperty,
             @NonNull CoreAuthenticator authenticator,
@@ -54,6 +110,7 @@ public class CoreAuthenticationParameters implements Serializable {
         this(
                 serverProperty,
                 authenticator,
+                null,
                 userVerificationRequired,
                 true
         );
@@ -67,6 +124,10 @@ public class CoreAuthenticationParameters implements Serializable {
         return authenticator;
     }
 
+    public @Nullable List<byte[]> getAllowCredentials() {
+        return allowCredentials;
+    }
+
     public boolean isUserVerificationRequired() {
         return userVerificationRequired;
     }
@@ -75,20 +136,20 @@ public class CoreAuthenticationParameters implements Serializable {
         return userPresenceRequired;
     }
 
-
     @Override
-    public boolean equals(@Nullable Object o) {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CoreAuthenticationParameters that = (CoreAuthenticationParameters) o;
         return userVerificationRequired == that.userVerificationRequired &&
                 userPresenceRequired == that.userPresenceRequired &&
                 Objects.equals(serverProperty, that.serverProperty) &&
-                Objects.equals(authenticator, that.authenticator);
+                Objects.equals(authenticator, that.authenticator) &&
+                Objects.equals(allowCredentials, that.allowCredentials);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(serverProperty, authenticator, userVerificationRequired, userPresenceRequired);
+        return Objects.hash(serverProperty, authenticator, allowCredentials, userVerificationRequired, userPresenceRequired);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreRegistrationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreRegistrationParameters.java
@@ -16,36 +16,81 @@
 
 package com.webauthn4j.data;
 
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.util.AssertUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 public class CoreRegistrationParameters implements Serializable {
 
     // server property
     private final CoreServerProperty serverProperty;
+    private final List<PublicKeyCredentialParameters> pubKeyCredParams;
 
     // verification condition
     private final boolean userVerificationRequired;
     private final boolean userPresenceRequired;
 
-    public CoreRegistrationParameters(@NonNull CoreServerProperty serverProperty, boolean userVerificationRequired, boolean userPresenceRequired) {
+    /**
+     * {@link CoreRegistrationParameters} constructor
+     * @param serverProperty server property
+     * @param pubKeyCredParams allowed {@link PublicKeyCredentialParameters}. If all {@link COSEAlgorithmIdentifier} are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     * @param userPresenceRequired true if user presence is required. Otherwise, false
+     */
+    public CoreRegistrationParameters(@NonNull CoreServerProperty serverProperty,
+                                      @Nullable List<PublicKeyCredentialParameters> pubKeyCredParams,
+                                      boolean userVerificationRequired, boolean userPresenceRequired) {
         AssertUtil.notNull(serverProperty, "serverProperty must not be null");
         this.serverProperty = serverProperty;
+        this.pubKeyCredParams = pubKeyCredParams;
         this.userVerificationRequired = userVerificationRequired;
         this.userPresenceRequired = userPresenceRequired;
     }
 
-    public CoreRegistrationParameters(@NonNull CoreServerProperty serverProperty, boolean userVerificationRequired) {
-        this(serverProperty, userVerificationRequired, true);
+    /**
+     * {@link CoreRegistrationParameters} constructor
+     * @param serverProperty server property
+     * @param pubKeyCredParams allowed {@link PublicKeyCredentialParameters}. If all {@link COSEAlgorithmIdentifier} are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     */
+    public CoreRegistrationParameters(@NonNull CoreServerProperty serverProperty,
+                                      @Nullable List<PublicKeyCredentialParameters> pubKeyCredParams,
+                                      boolean userVerificationRequired) {
+        this(serverProperty, pubKeyCredParams, userVerificationRequired, true);
+    }
+
+    /**
+     * @deprecated Deprecated as pubKeyCredParams verification was introduced from WebAuthn Level2.
+     */
+    @SuppressWarnings("squid:S1133")
+    @Deprecated
+    public CoreRegistrationParameters(@NonNull CoreServerProperty serverProperty,
+                                      boolean userVerificationRequired, boolean userPresenceRequired) {
+        this(serverProperty, null ,userVerificationRequired, userPresenceRequired);
+    }
+
+    /**
+     * @deprecated Deprecated as pubKeyCredParams verification was introduced from WebAuthn Level2.
+     */
+    @SuppressWarnings("squid:S1133")
+    @Deprecated
+    public CoreRegistrationParameters(@NonNull CoreServerProperty serverProperty,
+                                      boolean userVerificationRequired) {
+        this(serverProperty, null, userVerificationRequired, true);
     }
 
     public @NonNull CoreServerProperty getServerProperty() {
         return serverProperty;
+    }
+
+    public @Nullable List<PublicKeyCredentialParameters> getPubKeyCredParams() {
+        return pubKeyCredParams;
     }
 
     public boolean isUserVerificationRequired() {
@@ -57,17 +102,18 @@ public class CoreRegistrationParameters implements Serializable {
     }
 
     @Override
-    public boolean equals(@Nullable Object o) {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CoreRegistrationParameters that = (CoreRegistrationParameters) o;
         return userVerificationRequired == that.userVerificationRequired &&
                 userPresenceRequired == that.userPresenceRequired &&
-                Objects.equals(serverProperty, that.serverProperty);
+                Objects.equals(serverProperty, that.serverProperty) &&
+                Objects.equals(pubKeyCredParams, that.pubKeyCredParams);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(serverProperty, userVerificationRequired, userPresenceRequired);
+        return Objects.hash(serverProperty, pubKeyCredParams, userVerificationRequired, userPresenceRequired);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/RegistrationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/RegistrationParameters.java
@@ -16,11 +16,41 @@
 
 package com.webauthn4j.data;
 
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.server.ServerProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
 
 public class RegistrationParameters extends CoreRegistrationParameters {
 
+    /**
+     * {@link RegistrationParameters} constructor
+     * @param serverProperty server property
+     * @param pubKeyCredParams allowed {@link PublicKeyCredentialParameters}. If all {@link COSEAlgorithmIdentifier} are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     * @param userPresenceRequired true if user presence is required. Otherwise, false
+     */
+    public RegistrationParameters(@NonNull ServerProperty serverProperty, @Nullable List<PublicKeyCredentialParameters> pubKeyCredParams, boolean userVerificationRequired, boolean userPresenceRequired) {
+        super(serverProperty, pubKeyCredParams, userVerificationRequired, userPresenceRequired);
+    }
+
+    /**
+     * {@link RegistrationParameters} constructor
+     * @param serverProperty server property
+     * @param pubKeyCredParams allowed {@link PublicKeyCredentialParameters}. If all {@link COSEAlgorithmIdentifier} are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     */
+    public RegistrationParameters(@NonNull ServerProperty serverProperty, @Nullable List<PublicKeyCredentialParameters> pubKeyCredParams, boolean userVerificationRequired) {
+        super(serverProperty, pubKeyCredParams, userVerificationRequired);
+    }
+
+    /**
+     * @deprecated Deprecated as pubKeyCredParams verification was introduced from WebAuthn Level2.
+     */
+    @SuppressWarnings("squid:S1133")
+    @Deprecated
     public RegistrationParameters(
             @NonNull ServerProperty serverProperty,
             boolean userVerificationRequired,
@@ -28,6 +58,11 @@ public class RegistrationParameters extends CoreRegistrationParameters {
         super(serverProperty, userVerificationRequired, userPresenceRequired);
     }
 
+    /**
+     * @deprecated Deprecated as pubKeyCredParams verification was introduced from WebAuthn Level2.
+     */
+    @SuppressWarnings("squid:S1133")
+    @Deprecated
     public RegistrationParameters(
             @NonNull ServerProperty serverProperty,
             boolean userVerificationRequired) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AttestationValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AttestationValidator.java
@@ -71,32 +71,32 @@ class AttestationValidator {
 
         AttestationObject attestationObject = registrationObject.getAttestationObject();
 
-        //spec| Determine the attestation statement format by performing a USASCII case-sensitive match on fmt against the set
-        //spec| of supported WebAuthn Attestation Statement Format Identifier values. The up-to-date list of registered
-        //spec| WebAuthn Attestation Statement Format Identifier values is maintained in the in the IANA registry of the same
-        //spec| name [WebAuthn-Registries].
+        //spec| Step18
+        //spec| Determine the attestation statement format by performing a USASCII case-sensitive match on fmt against
+        //spec| the set of supported WebAuthn Attestation Statement Format Identifier values.
+        //spec| An up-to-date list of registered WebAuthn Attestation Statement Format Identifier values is maintained in
+        //spec| the IANA "WebAuthn Attestation Statement Format Identifiers" registry [IANA-WebAuthn-Registries] established by [RFC8809].
+        //spec| Step19
+        //spec| Verify that attStmt is a correct attestation statement, conveying a valid attestation signature,
+        //spec| by using the attestation statement format fmt’s verification procedure given attStmt, authData and hash.
 
-        //spec| Verify that attStmt is a correct attestation statement, conveying a valid attestation signature, by using the
-        //spec| attestation statement format fmt’s verification procedure given attStmt, authData and the hash of the
-        //spec| serialized client data computed in step 7.
-
-        //spec| Note: Each attestation statement format specifies its own verification procedure. See §8 Defined Attestation
-        //spec| Statement Formats for the initially-defined formats, and  [WebAuthn-Registries] for the up-to-date list.
         AttestationType attestationType = validateAttestationStatement(registrationObject);
 
         validateAAGUID(attestationObject);
 
-        //spec| If validation is successful, obtain a list of acceptable trust anchors (attestation root certificates or
-        //spec| ECDAA-Issuer public keys) for that attestation type and attestation statement format fmt,
-        //spec| from a trusted source or from policy.
+        //spec| Step20
+        //spec| If validation is successful, obtain a list of acceptable trust anchors (i.e. attestation root certificates)
+        //spec| for that attestation type and attestation statement format fmt, from a trusted source or from policy.
         //spec| For example, the FIDO Metadata Service [FIDOMetadataService] provides one way to obtain such information,
         //spec| using the aaguid in the attestedCredentialData in authData.
-
-        //spec| Assess the attestation trustworthiness using the outputs of the verification procedure in step 14, as follows:
+        //spec| Step21
+        //spec| Assess the attestation trustworthiness using the outputs of the verification procedure in step 19, as follows:
+        //spec| If no attestation was provided, verify that None attestation is acceptable under Relying Party policy.
+        //      (This is already done in validateAttestationStatement method)
 
         AttestationStatement attestationStatement = attestationObject.getAttestationStatement();
         switch (attestationType) {
-            // If self attestation was used, check if self attestation is acceptable under Relying Party policy.
+            //spec| If self attestation was used, check if self attestation is acceptable under Relying Party policy.
             case SELF:
                 if (attestationStatement instanceof CertificateBaseAttestationStatement) {
                     CertificateBaseAttestationStatement certificateBaseAttestationStatement =
@@ -108,8 +108,9 @@ class AttestationValidator {
                 }
                 break;
 
-            // Otherwise, use the X.509 certificates returned by the verification procedure to verify that
-            // the attestation public key correctly chains up to an acceptable root certificate.
+            //spec| Otherwise, use the X.509 certificates returned as the attestation trust path from the verification procedure
+            //spec| to verify that the attestation public key either correctly chains up to an acceptable root certificate,
+            //spec| or is itself an acceptable certificate (i.e., it and the root certificate obtained in Step 20 may be the same).
             case BASIC:
             case ATT_CA:
                 if (attestationStatement instanceof CertificateBaseAttestationStatement) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
@@ -30,8 +30,10 @@ import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.validator.exception.*;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -67,42 +69,60 @@ public class AuthenticationDataValidator {
         AssertUtil.notNull(authenticationParameters, "authenticationParameters must not be null");
 
         //spec| Step1
-        //spec| If the allowCredentials option was given when this authentication ceremony was initiated,
-        //spec| verify that credential.id identifies one of the public key credentials that were listed in allowCredentials.
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+        //spec| Let options be a new PublicKeyCredentialRequestOptions structure configured to the Relying Party's needs for the ceremony.
+        //      (This step is done on client slide and out of WebAuthn4J responsibility.)
 
         //spec| Step2
-        //spec| Identify the user being authenticated and verify that this user is the owner of the public key credential source credentialSource identified by credential.id:
-
-        //spec| If the user was identified before the authentication ceremony was initiated,
-        //spec| verify that the identified user is the owner of credentialSource.
-        //spec| If credential.response.userHandle is present,
-        //spec| verify that this value identifies the same user as was previously identified.
-        //spec| If the user was not identified before the authentication ceremony was initiated,
-        //spec| verify that credential.response.userHandle is present, and that the user identified by this value is the owner of credentialSource.
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+        //spec| Call navigator.credentials.get() and pass options as the publicKey option. Let credential be the result of the successfully resolved promise.
+        //spec| If the promise is rejected, abort the ceremony with a user-visible error, or otherwise guide the user experience as might be determinable
+        //spec| from the context available in the rejected promise. For information on different error contexts and the circumstances leading to them,
+        //spec| see § 6.3.3 The authenticatorGetAssertion Operation.
+        //      (This step is done on client slide and out of WebAuthn4J responsibility.)
 
         //spec| Step3
-        //spec| Using credential’s id attribute (or the corresponding rawId, if base64url encoding is inappropriate for your use case),
-        //spec| look up the corresponding credential public key.
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+        //spec| Let response be credential.response. If response is not an instance of AuthenticatorAssertionResponse, abort the ceremony with a user-visible error.
+        //      (This step is done on client slide and out of WebAuthn4J responsibility.)
 
         //spec| Step4
+        //spec| Let clientExtensionResults be the result of calling credential.getClientExtensionResults().
+        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = authenticationData.getClientExtensions();
+
+        //spec| Step5
+        //spec| If options.allowCredentials is not empty, verify that credential.id identifies one of the public key credentials listed in options.allowCredentials.
+        byte[] credentialId = authenticationData.getCredentialId();
+        List<byte[]> allowCredentials = authenticationParameters.getAllowCredentials();
+        validateCredentialId(credentialId, allowCredentials);
+
+        //spec| Step6
+        //spec| Identify the user being authenticated and verify that this user is the owner of the public key credential source credentialSource identified by credential.id:
+        //spec| - If the user was identified before the authentication ceremony was initiated,
+        //spec|   verify that the identified user is the owner of credentialSource. If credential.response.userHandle is present,
+        //spec|   let userHandle be its value. Verify that userHandle also maps to the same user.
+        //spec| - If the user was not identified before the authentication ceremony was initiated,
+        //spec|   verify that response.userHandle is present, and that the user identified by this value is the owner of credentialSource.
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+
+        //spec| Step7
+        //spec| Using credential’s id attribute (or the corresponding rawId, if base64url encoding is inappropriate for your use case),
+        //spec| look up the corresponding credential public key and let credentialPublicKey be that credential public key.
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+
+        //spec| Step8
         //spec| Let cData, aData and sig denote the value of credential’s response's clientDataJSON, authenticatorData,
         //spec| and signature respectively.
         byte[] cData = authenticationData.getCollectedClientDataBytes();
         byte[] aData = authenticationData.getAuthenticatorDataBytes();
 
-        //spec| Step5
+        //spec| Step9
         //spec| Let JSONtext be the result of running UTF-8 decode on the value of cData.
-        //spec| Step6
-        //spec| Let C, the client data claimed as used for the signature, be the result of running an implementation-specific JSON parser on JSONtext.
+        //      (This step is done on caller.)
 
+        //spec| Step10
+        //spec| Let C, the client data claimed as used for the signature, be the result of running an implementation-specific JSON parser on JSONtext.
         //      (In the spec, claimed as "C", but use "collectedClientData" here)
         CollectedClientData collectedClientData = authenticationData.getCollectedClientData();
 
         AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData = authenticationData.getAuthenticatorData();
-        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = authenticationData.getClientExtensions();
         ServerProperty serverProperty = authenticationParameters.getServerProperty();
 
         BeanAssertUtil.validate(collectedClientData);
@@ -110,7 +130,6 @@ public class AuthenticationDataValidator {
 
         validateAuthenticatorData(authenticatorData);
 
-        byte[] credentialId = authenticationData.getCredentialId();
         Authenticator authenticator = authenticationParameters.getAuthenticator();
 
         AuthenticationObject authenticationObject = new AuthenticationObject(
@@ -118,47 +137,47 @@ public class AuthenticationDataValidator {
                 serverProperty, authenticator
         );
 
-        //spec| Step7
+        //spec| Step11
         //spec| Verify that the value of C.type is the string webauthn.get.
         if (!Objects.equals(collectedClientData.getType(), ClientDataType.GET)) {
             throw new InconsistentClientDataTypeException("ClientData.type must be 'get' on authentication, but it isn't.");
         }
 
-        //spec| Step8
+        //spec| Step12
         //spec| Verify that the value of C.challenge matches the challenge that was sent to the authenticator in
         //spec| the PublicKeyCredentialRequestOptions passed to the get() call.
         challengeValidator.validate(collectedClientData, serverProperty);
 
-        //spec| Step9
+        //spec| Step13
         //spec| Verify that the value of C.origin matches the Relying Party's origin.
         originValidator.validate(authenticationObject);
 
-        // not defined in spec
+        // Verify cross origin, which is not defined in the spec
         validateClientDataCrossOrigin(collectedClientData);
 
-        //spec| Step10
+        //spec| Step14
         //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
         //spec| which the attestation was obtained. If Token Binding was used on that TLS connection,
         //spec| also verify that C.tokenBinding.id matches the base64url encoding of the Token Binding ID for the connection.
         tokenBindingValidator.validate(collectedClientData.getTokenBinding(), serverProperty.getTokenBindingId());
 
-        //spec| Step11
-        //spec| Verify that the rpIdHash in aData is the SHA-256 hash of the RP ID expected by the Relying Party.
+        //spec| Step15
+        //spec| Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID expected by the Relying Party.
         rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
 
-        //spec| Step12
+        //spec| Step16
         //spec| Verify that the User Present bit of the flags in authData is set.
         if (authenticationParameters.isUserPresenceRequired() && !authenticatorData.isFlagUP()) {
             throw new UserNotPresentException("Validator is configured to check user present, but UP flag in authenticatorData is not set.");
         }
 
-        //spec| Step13
-        //spec| If user verification is required for this assertion, verify that the User Verified bit of the flags in aData is set.
+        //spec| Step17
+        //spec| If user verification is required for this assertion, verify that the User Verified bit of the flags in authData is set.
         if (authenticationParameters.isUserVerificationRequired() && !authenticatorData.isFlagUV()) {
             throw new UserNotVerifiedException("Validator is configured to check user verified, but UV flag in authenticatorData is not set.");
         }
 
-        //spec| Step14
+        //spec| Step18
         //spec| Verify that the values of the client extension outputs in clientExtensionResults and the authenticator
         //spec| extension outputs in the extensions in authData are as expected, considering the client extension input
         //spec| values that were given as the extensions option in the get() call. In particular, any extension identifier
@@ -169,26 +188,31 @@ public class AuthenticationDataValidator {
         clientExtensionValidator.validate(clientExtensions);
         authenticatorExtensionValidator.validate(authenticationExtensionsAuthenticatorOutputs);
 
+        //spec| Step19
+        //spec| Let hash be the result of computing a hash over the cData using SHA-256.
+        //spec| Step20
         //spec| Using the credential public key, validate that sig is a valid signature over
         //spec| the binary concatenation of the authenticatorData and the hash of the collectedClientData.
         assertionSignatureValidator.validate(authenticationData, authenticator.getAttestedCredentialData().getCOSEKey());
 
-        //spec| Step17
-        //spec| If the signature counter value adata.signCount is nonzero or the value stored in conjunction with
-        //spec| credential’s id attribute is nonzero, then run the following sub-step:
-        long presentedCounter = authenticatorData.getSignCount();
-        long storedCounter = authenticator.getCounter();
-        if (presentedCounter > 0 || storedCounter > 0) {
-            //spec| If the signature counter value adata.signCount is
-            //spec| greater than the signature counter value stored in conjunction with credential’s id attribute.
-            if (presentedCounter > storedCounter) {
+        //spec| Step21
+        //spec| Let storedSignCount be the stored signature counter value associated with credential.id.
+        //spec| If authData.signCount is nonzero or storedSignCount is nonzero, then run the following sub-step:
+        long presentedSignCount = authenticatorData.getSignCount();
+        long storedSignCount = authenticator.getCounter();
+        if (presentedSignCount > 0 || storedSignCount > 0) {
+            //spec| If authData.signCount is
+            //spec| greater than storedSignCount:
+            if (presentedSignCount > storedSignCount) {
 
-                //spec| Update the stored signature counter value, associated with credential’s id attribute, to be the value of authData.signCount.
-
+                //spec| Update storedSignCount to be the value of authData.signCount.
                 //      (caller need to update the signature counter value based on the value set in the Authenticator instance)
-                authenticator.setCounter(presentedCounter);
+                authenticator.setCounter(presentedSignCount);
             }
-            //spec| less than or equal to the signature counter value stored in conjunction with credential’s id attribute.
+            //spec| less than or equal to storedSignCount:
+            //spec| This is a signal that the authenticator may be cloned, i.e. at least two copies of the credential private key may exist and are being used in parallel.
+            //spec| Relying Parties should incorporate this information into their risk scoring.
+            //spec| Whether the Relying Party updates storedSignCount in this case, or not, or fails the authentication ceremony or not, is Relying Party-specific.
             else {
                 maliciousCounterValueHandler.maliciousCounterValueDetected(authenticationObject);
             }
@@ -202,6 +226,12 @@ public class AuthenticationDataValidator {
         //spec| If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the authentication ceremony.
 
 
+    }
+
+    void validateCredentialId(byte[] credentialId, @Nullable List<byte[]> allowCredentials) {
+        if(allowCredentials != null && allowCredentials.stream().noneMatch(item -> Arrays.equals(item, credentialId))){
+            throw new NotAllowedCredentialIdException("credentialId not listed in allowCredentials is used.");
+        }
     }
 
     void validateClientDataCrossOrigin(CollectedClientData collectedClientData) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreAuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreAuthenticationDataValidator.java
@@ -25,11 +25,14 @@ import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthe
 import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
+import com.webauthn4j.validator.exception.NotAllowedCredentialIdException;
 import com.webauthn4j.validator.exception.UserNotPresentException;
 import com.webauthn4j.validator.exception.UserNotVerifiedException;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class CoreAuthenticationDataValidator {
@@ -70,44 +73,65 @@ public class CoreAuthenticationDataValidator {
     public void validate(@NonNull CoreAuthenticationData authenticationData, @NonNull CoreAuthenticationParameters authenticationParameters) {
 
         BeanAssertUtil.validate(authenticationData);
-
         AssertUtil.notNull(authenticationParameters, "authenticationParameters must not be null");
 
         //spec| Step1
-        //spec| If the allowCredentials option was given when this authentication ceremony was initiated,
-        //spec| verify that credential.id identifies one of the public key credentials that were listed in allowCredentials.
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+        //spec| Let options be a new PublicKeyCredentialRequestOptions structure configured to the Relying Party's needs for the ceremony.
+        //      (This step is done on client slide and out of WebAuthn4J responsibility.)
 
         //spec| Step2
-        //spec| Identify the user being authenticated and verify that this user is the owner of the public key credential source credentialSource identified by credential.id:
-
-        //spec| If the user was identified before the authentication ceremony was initiated,
-        //spec| verify that the identified user is the owner of credentialSource.
-        //spec| If credential.response.userHandle is present,
-        //spec| verify that this value identifies the same user as was previously identified.
-        //spec| If the user was not identified before the authentication ceremony was initiated,
-        //spec| verify that credential.response.userHandle is present, and that the user identified by this value is the owner of credentialSource.
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+        //spec| Call navigator.credentials.get() and pass options as the publicKey option. Let credential be the result of the successfully resolved promise.
+        //spec| If the promise is rejected, abort the ceremony with a user-visible error, or otherwise guide the user experience as might be determinable
+        //spec| from the context available in the rejected promise. For information on different error contexts and the circumstances leading to them,
+        //spec| see § 6.3.3 The authenticatorGetAssertion Operation.
+        //      (This step is done on client slide and out of WebAuthn4J responsibility.)
 
         //spec| Step3
-        //spec| Using credential’s id attribute (or the corresponding rawId, if base64url encoding is inappropriate for your use case),
-        //spec| look up the corresponding credential public key.
-        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+        //spec| Let response be credential.response. If response is not an instance of AuthenticatorAssertionResponse, abort the ceremony with a user-visible error.
+        //      (This step is done on client slide and out of WebAuthn4J responsibility.)
 
         //spec| Step4
-        //spec| Let cData, aData and sig denote the value of credential’s response's clientDataJSON, authenticatorData,
-        //spec| and signature respectively.
-        //      (This step is in createCoreAuthenticationObject method)
+        //spec| Let clientExtensionResults be the result of calling credential.getClientExtensionResults().
+        //      (This step is only applicable to WebAuthn)
 
         //spec| Step5
-        //spec| Let JSONtext be the result of running UTF-8 decode on the value of cData.
+        //spec| If options.allowCredentials is not empty, verify that credential.id identifies one of the public key credentials listed in options.allowCredentials.
+        byte[] credentialId = authenticationData.getCredentialId();
+        List<byte[]> allowCredentials = authenticationParameters.getAllowCredentials();
+        validateCredentialId(credentialId, allowCredentials);
+
         //spec| Step6
+        //spec| Identify the user being authenticated and verify that this user is the owner of the public key credential source credentialSource identified by credential.id:
+        //spec| - If the user was identified before the authentication ceremony was initiated,
+        //spec|   verify that the identified user is the owner of credentialSource. If credential.response.userHandle is present,
+        //spec|   let userHandle be its value. Verify that userHandle also maps to the same user.
+        //spec| - If the user was not identified before the authentication ceremony was initiated,
+        //spec|   verify that response.userHandle is present, and that the user identified by this value is the owner of credentialSource.
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+
+        //spec| Step7
+        //spec| Using credential’s id attribute (or the corresponding rawId, if base64url encoding is inappropriate for your use case),
+        //spec| look up the corresponding credential public key and let credentialPublicKey be that credential public key.
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
+
+        //spec| Step8
+        //spec| Let cData, aData and sig denote the value of credential’s response's clientDataJSON, authenticatorData,
+        //spec| and signature respectively.
+        //      (This step is only applicable to WebAuthn)
+
+        //spec| Step9
+        //spec| Let JSONtext be the result of running UTF-8 decode on the value of cData.
+        //      (This step is done on caller.)
+
+        //spec| Step10
         //spec| Let C, the client data claimed as used for the signature, be the result of running an implementation-specific JSON parser on JSONtext.
+        //      (This step is only applicable to WebAuthn)
 
         AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData = authenticationData.getAuthenticatorData();
         CoreServerProperty serverProperty = authenticationParameters.getServerProperty();
 
         BeanAssertUtil.validate(authenticatorData);
+
         validateAuthenticatorData(authenticatorData);
 
         CoreAuthenticator authenticator = authenticationParameters.getAuthenticator();
@@ -115,22 +139,44 @@ public class CoreAuthenticationDataValidator {
         CoreAuthenticationObject authenticationObject = createCoreAuthenticationObject(authenticationData, authenticationParameters);
 
         //spec| Step11
-        //spec| Verify that the rpIdHash in aData is the SHA-256 hash of the RP ID expected by the Relying Party.
-        rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
+        //spec| Verify that the value of C.type is the string webauthn.get.
+        //      (This step is only applicable to WebAuthn)
 
         //spec| Step12
+        //spec| Verify that the value of C.challenge matches the challenge that was sent to the authenticator in
+        //spec| the PublicKeyCredentialRequestOptions passed to the get() call.
+        //      (This step is only applicable to WebAuthn)
+
+        //spec| Step13
+        //spec| Verify that the value of C.origin matches the Relying Party's origin.
+        //      (This step is only applicable to WebAuthn)
+
+        // Verify cross origin, which is not defined in the spec
+        //      (This step is only applicable to WebAuthn)
+
+        //spec| Step14
+        //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
+        //spec| which the attestation was obtained. If Token Binding was used on that TLS connection,
+        //spec| also verify that C.tokenBinding.id matches the base64url encoding of the Token Binding ID for the connection.
+        //      (This step is only applicable to WebAuthn)
+
+        //spec| Step15
+        //spec| Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID expected by the Relying Party.
+        rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
+
+        //spec| Step16
         //spec| Verify that the User Present bit of the flags in authData is set.
         if (authenticationParameters.isUserPresenceRequired() && !authenticatorData.isFlagUP()) {
             throw new UserNotPresentException("Validator is configured to check user present, but UP flag in authenticatorData is not set.");
         }
 
-        //spec| Step13
-        //spec| If user verification is required for this assertion, verify that the User Verified bit of the flags in aData is set.
+        //spec| Step17
+        //spec| If user verification is required for this assertion, verify that the User Verified bit of the flags in authData is set.
         if (authenticationParameters.isUserVerificationRequired() && !authenticatorData.isFlagUV()) {
             throw new UserNotVerifiedException("Validator is configured to check user verified, but UV flag in authenticatorData is not set.");
         }
 
-        //spec| Step14
+        //spec| Step18
         //spec| Verify that the values of the client extension outputs in clientExtensionResults and the authenticator
         //spec| extension outputs in the extensions in authData are as expected, considering the client extension input
         //spec| values that were given as the extensions option in the get() call. In particular, any extension identifier
@@ -138,28 +184,34 @@ public class CoreAuthenticationDataValidator {
         //spec| identifier values in the extensions member of options, i.e., no extensions are present that were not requested.
         //spec| In the general case, the meaning of "are as expected" is specific to the Relying Party and which extensions are in use.
         AuthenticationExtensionsAuthenticatorOutputs<AuthenticationExtensionAuthenticatorOutput> authenticationExtensionsAuthenticatorOutputs = authenticatorData.getExtensions();
+        //      (This clientExtensionResults verification is only applicable to WebAuthn)
         authenticatorExtensionValidator.validate(authenticationExtensionsAuthenticatorOutputs);
 
+        //spec| Step19
+        //spec| Let hash be the result of computing a hash over the cData using SHA-256.
+        //spec| Step20
         //spec| Using the credential public key, validate that sig is a valid signature over
         //spec| the binary concatenation of the authenticatorData and the hash of the collectedClientData.
         assertionSignatureValidator.validate(authenticationData, authenticator.getAttestedCredentialData().getCOSEKey());
 
-        //spec| Step17
-        //spec| If the signature counter value adata.signCount is nonzero or the value stored in conjunction with
-        //spec| credential’s id attribute is nonzero, then run the following sub-step:
-        long presentedCounter = authenticatorData.getSignCount();
-        long storedCounter = authenticator.getCounter();
-        if (presentedCounter > 0 || storedCounter > 0) {
-            //spec| If the signature counter value adata.signCount is
-            //spec| greater than the signature counter value stored in conjunction with credential’s id attribute.
-            if (presentedCounter > storedCounter) {
+        //spec| Step21
+        //spec| Let storedSignCount be the stored signature counter value associated with credential.id.
+        //spec| If authData.signCount is nonzero or storedSignCount is nonzero, then run the following sub-step:
+        long presentedSignCount = authenticatorData.getSignCount();
+        long storedSignCount = authenticator.getCounter();
+        if (presentedSignCount > 0 || storedSignCount > 0) {
+            //spec| If authData.signCount is
+            //spec| greater than storedSignCount:
+            if (presentedSignCount > storedSignCount) {
 
-                //spec| Update the stored signature counter value, associated with credential’s id attribute, to be the value of authData.signCount.
-
+                //spec| Update storedSignCount to be the value of authData.signCount.
                 //      (caller need to update the signature counter value based on the value set in the Authenticator instance)
-                authenticator.setCounter(presentedCounter);
+                authenticator.setCounter(presentedSignCount);
             }
-            //spec| less than or equal to the signature counter value stored in conjunction with credential’s id attribute.
+            //spec| less than or equal to storedSignCount:
+            //spec| This is a signal that the authenticator may be cloned, i.e. at least two copies of the credential private key may exist and are being used in parallel.
+            //spec| Relying Parties should incorporate this information into their risk scoring.
+            //spec| Whether the Relying Party updates storedSignCount in this case, or not, or fails the authentication ceremony or not, is Relying Party-specific.
             else {
                 coreMaliciousCounterValueHandler.maliciousCounterValueDetected(authenticationObject);
             }
@@ -171,7 +223,6 @@ public class CoreAuthenticationDataValidator {
 
         //spec| Step18
         //spec| If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the authentication ceremony.
-
 
     }
 
@@ -189,6 +240,12 @@ public class CoreAuthenticationDataValidator {
         return new CoreAuthenticationObject(
                 credentialId, authenticatorData, authenticatorDataBytes, clientDataHash, serverProperty, authenticator
         );
+    }
+
+    void validateCredentialId(byte[] credentialId, @Nullable List<byte[]> allowCredentials) {
+        if(allowCredentials != null && allowCredentials.stream().noneMatch(item -> Arrays.equals(item, credentialId))){
+            throw new NotAllowedCredentialIdException("credentialId not listed in allowCredentials is used.");
+        }
     }
 
     void validateAuthenticatorData(@NonNull AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreRegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/CoreRegistrationDataValidator.java
@@ -19,9 +19,11 @@ package com.webauthn4j.validator;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.CoreRegistrationData;
 import com.webauthn4j.data.CoreRegistrationParameters;
+import com.webauthn4j.data.PublicKeyCredentialParameters;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.attestation.authenticator.COSEKey;
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
 import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
 import com.webauthn4j.server.CoreServerProperty;
@@ -30,6 +32,7 @@ import com.webauthn4j.validator.attestation.statement.AttestationStatementValida
 import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.self.SelfAttestationTrustworthinessValidator;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
+import com.webauthn4j.validator.exception.NotAllowedAlgorithmException;
 import com.webauthn4j.validator.exception.UserNotPresentException;
 import com.webauthn4j.validator.exception.UserNotVerifiedException;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -75,10 +78,41 @@ public class CoreRegistrationDataValidator {
     @SuppressWarnings("ConstantConditions") // as null check is done by BeanAssertUtil#validate
     public void validate(@NonNull CoreRegistrationData registrationData, @NonNull CoreRegistrationParameters registrationParameters) {
 
+        //spec| Step1
+        //spec| Let options be a new PublicKeyCredentialCreationOptions structure configured to the Relying Party's needs for the ceremony.
+        //      (This step is done on client slide and out of WebAuthn4J responsibility.)
+
+        //spec| Step2
+        //spec| Call navigator.credentials.create() and pass options as the publicKey option. Let credential be the result of the successfully resolved promise.
+        //spec| If the promise is rejected, abort the ceremony with a user-visible error,
+        //spec| or otherwise guide the user experience as might be determinable from the context available in the rejected promise.
+        //spec| For example if the promise is rejected with an error code equivalent to "InvalidStateError",
+        //spec| the user might be instructed to use a different authenticator.
+        //spec| For information on different error contexts and the circumstances leading to them, see § 6.3.2 The authenticatorMakeCredential Operation.
+        //      (This step is done on client slide and out of WebAuthn4J responsibility.)
+
+        //spec| Step3
+        //spec| Let response be credential.response. If response is not an instance of AuthenticatorAttestationResponse, abort the ceremony with a user-visible error.
+        //      (This step is done on client slide and out of WebAuthn4J responsibility.)
+
+        //spec| Step4
+        //spec| Let clientExtensionResults be the result of calling credential.getClientExtensionResults().
+        //      (This step is only applicable to WebAuthn)
+
+        //spec| Step5
+        //spec| Let JSONtext be the result of running UTF-8 decode on the value of response.clientDataJSON.
+        //      (This step is only applicable to WebAuthn)
+
         BeanAssertUtil.validate(registrationData);
         AssertUtil.notNull(registrationParameters, "registrationParameters must not be null");
 
+        //spec| Step6
+        //spec| Let C, the client data claimed as collected during the credential creation,
+        //spec| be the result of running an implementation-specific JSON parser on JSONtext.
+        //      (This step is only applicable to WebAuthn)
+
         AttestationObject attestationObject = registrationData.getAttestationObject();
+
 
         validateAuthenticatorDataField(attestationObject.getAuthenticatorData());
 
@@ -92,51 +126,93 @@ public class CoreRegistrationDataValidator {
         validateCOSEKey(coseKey);
 
         //spec| Step7
-        //spec| Compute the hash of response.clientDataJSON using SHA-256.
+        //spec| Verify that the value of C.type is webauthn.create.
+        //      (This step is only applicable to WebAuthn)
 
         //spec| Step8
-        //spec| Perform CBOR decoding on the attestationObject field of the AuthenticatorAttestationResponse structure to
-        //spec| obtain the attestation statement format fmt, the authenticator data authData, and the attestation statement attStmt.
+        //spec| Verify that the value of C.challenge equals the base64url encoding of options.challenge.
+        //      (This step is only applicable to WebAuthn)
+
 
         //spec| Step9
-        //spec| Verify that the RP ID hash in authData is indeed the SHA-256 hash of the RP ID expected by the RP.
-        rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
+        //spec| Verify that the value of C.origin matches the Relying Party's origin.
+        //      (This step is only applicable to WebAuthn)
 
+        //spec| Step10
+        //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
+        //spec| which the assertion was obtained. If Token Binding was used on that TLS connection, also verify that
+        //spec| C.tokenBinding.id matches the base64url encoding of the Token Binding ID for the connection.
+        //      (This step is only applicable to WebAuthn)
 
-        //spec| Step10, 11
-        validateUVUPFlags(authenticatorData, registrationParameters.isUserVerificationRequired(), registrationParameters.isUserPresenceRequired());
+        //spec| Step11
+        //spec| Let hash be the result of computing a hash over response.clientDataJSON using SHA-256.
 
         //spec| Step12
-        //spec| Verify that the values of the client extension outputs in clientExtensionResults and the authenticator
-        //spec| extension outputs in the extensions in authData are as expected, considering the client extension input
-        //spec| values that were given as the extensions option in the create() call. In particular, any extension identifier
-        //spec| values in the clientExtensionResults and the extensions in authData MUST be also be present as extension
-        //spec| identifier values in the extensions member of options, i.e., no extensions are present that were not requested.
+        //spec| Perform CBOR decoding on the attestationObject field of the AuthenticatorAttestationResponse structure to
+        //spec| obtain the attestation statement format fmt, the authenticator data authData, and the attestation statement attStmt.
+        //      (This step is done on caller.)
+
+        //spec| Step13
+        //spec| Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID expected by the Relying Party.
+        rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
+
+        //spec| Step14, 15
+        //spec| Verify that the User Present bit of the flags in authData is set.
+        //spec| If user verification is required for this registration, verify that the User Verified bit of the flags in authData is set.
+        validateUVUPFlags(authenticatorData, registrationParameters.isUserVerificationRequired(), registrationParameters.isUserPresenceRequired());
+
+        //spec| Step16
+        //spec| Verify that the "alg" parameter in the credential public key in authData matches the alg attribute of one of the items in options.pubKeyCredParams.
+        COSEAlgorithmIdentifier alg = authenticatorData.getAttestedCredentialData().getCOSEKey().getAlgorithm();
+        List<PublicKeyCredentialParameters> pubKeyCredParams = registrationParameters.getPubKeyCredParams();
+        validateAlg(alg, pubKeyCredParams);
+
+        //spec| Step17
+        //spec| Verify that the values of the client extension outputs in clientExtensionResults and the authenticator extension outputs in the extensions in authData are as expected,
+        //spec| considering the client extension input values that were given in options.extensions and any specific policy of the Relying Party regarding unsolicited extensions,
+        //spec| i.e., those that were not specified as part of options.extensions.
         //spec| In the general case, the meaning of "are as expected" is specific to the Relying Party and which extensions are in use.
         AuthenticationExtensionsAuthenticatorOutputs<RegistrationExtensionAuthenticatorOutput> authenticationExtensionsAuthenticatorOutputs = authenticatorData.getExtensions();
         authenticatorExtensionValidator.validate(authenticationExtensionsAuthenticatorOutputs);
 
-        //spec| Step13-16,19
+        //spec| Step18-21
         attestationValidator.validate(registrationObject);
 
-        //spec| Step17
-        //spec| Check that the credentialId is not yet registered to any other user. If registration is requested for
-        //spec| a credential that is already registered to a different user, the Relying Party SHOULD fail this registration
-        //spec| ceremony, or it MAY decide to accept the registration, e.g. while deleting the older registration.
+        //spec| Step22
+        //spec| Check that the credentialId is not yet registered to any other user.
+        //spec| If registration is requested for a credential that is already registered to a different user,
+        //spec| the Relying Party SHOULD fail this registration ceremony, or it MAY decide to accept the registration,
+        //spec| e.g. while deleting the older registration.
 
         //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
 
-        //spec| Step18
+        //spec| Step23
         //spec| If the attestation statement attStmt verified successfully and is found to be trustworthy,
-        //spec| then register the new credential with the account that was denoted in the options.user passed to create(),
-        //spec| by associating it with the credential ID and credential public key contained in authData’s attestation data,
-        //spec| as appropriate for the Relying Party's systems.
+        //spec| then register the new credential with the account that was denoted in options.user:
+        //spec| - Associate the user’s account with the credentialId and credentialPublicKey
+        //spec|   in authData.attestedCredentialData, as appropriate for the Relying Party's system.
+        //spec| - Associate the credentialId with a new stored signature counter value initialized to the value of authData.signCount.
+        //spec| It is RECOMMENDED to also:
+        //spec| - Associate the credentialId with the transport hints returned by calling credential.response.getTransports().
+        //spec|   This value SHOULD NOT be modified before or after storing it.
+        //spec|   It is RECOMMENDED to use this value to populate the transports of the allowCredentials option in future get() calls
+        //spec|   to help the client know how to find a suitable authenticator.
+        //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
 
+        //spec| Step24
+        //spec| If the attestation statement attStmt successfully verified but is not trustworthy per step 21 above,
+        //spec| the Relying Party SHOULD fail the registration ceremony.
         //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
 
         // validate with custom logic
         for (CustomCoreRegistrationValidator customRegistrationValidator : customRegistrationValidators) {
             customRegistrationValidator.validate(registrationObject);
+        }
+    }
+
+    void validateAlg(COSEAlgorithmIdentifier alg, List<PublicKeyCredentialParameters> pubKeyCredParams) {
+        if(pubKeyCredParams != null && pubKeyCredParams.stream().noneMatch(item -> item.getAlg().equals(alg))){
+            throw new NotAllowedAlgorithmException("alg not listed in options.pubKeyCredParams is used.");
         }
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/exception/NotAllowedAlgorithmException.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/exception/NotAllowedAlgorithmException.java
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-package com.webauthn4j.appattest.data;
+package com.webauthn4j.validator.exception;
 
-import com.webauthn4j.appattest.server.DCServerProperty;
-import com.webauthn4j.data.CoreRegistrationParameters;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class DCAttestationParameters extends CoreRegistrationParameters {
+public class NotAllowedAlgorithmException extends ValidationException {
 
-    public DCAttestationParameters(@NonNull DCServerProperty serverProperty) {
-        super(serverProperty, null, false, false);
+    public NotAllowedAlgorithmException(@Nullable String message, @Nullable Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotAllowedAlgorithmException(@Nullable String message) {
+        super(message);
+    }
+
+    public NotAllowedAlgorithmException(@Nullable Throwable cause) {
+        super(cause);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/exception/NotAllowedCredentialIdException.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/exception/NotAllowedCredentialIdException.java
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-package com.webauthn4j.appattest.data;
+package com.webauthn4j.validator.exception;
 
-import com.webauthn4j.appattest.server.DCServerProperty;
-import com.webauthn4j.data.CoreRegistrationParameters;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class DCAttestationParameters extends CoreRegistrationParameters {
+public class NotAllowedCredentialIdException extends ValidationException {
 
-    public DCAttestationParameters(@NonNull DCServerProperty serverProperty) {
-        super(serverProperty, null, false, false);
+    public NotAllowedCredentialIdException(@Nullable String message, @Nullable Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotAllowedCredentialIdException(@Nullable String message) {
+        super(message);
+    }
+
+    public NotAllowedCredentialIdException(@Nullable Throwable cause) {
+        super(cause);
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
@@ -45,17 +45,73 @@ class AuthenticationParametersTest {
         // expectations
         boolean userVerificationRequired = true;
 
-        AuthenticationParameters authenticationParameters =
+        AuthenticationParameters instance =
+                new AuthenticationParameters(
+                        serverProperty,
+                        authenticator,
+                        null,
+                        userVerificationRequired
+                );
+
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getAuthenticator()).isEqualTo(authenticator);
+        assertThat(instance.isUserVerificationRequired()).isEqualTo(userVerificationRequired);
+        assertThat(instance.isUserPresenceRequired()).isTrue();
+    }
+
+    @Deprecated
+    @Test
+    void constructor_without_allowCredentials_test() {
+        // Server properties
+        Origin origin = Origin.create("https://example.com") /* set origin */;
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        Authenticator authenticator = mock(Authenticator.class);
+
+        AuthenticationParameters instance =
+                new AuthenticationParameters(
+                        serverProperty,
+                        authenticator,
+                        false,
+                        true
+                );
+
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getAuthenticator()).isEqualTo(authenticator);
+        assertThat(instance.getAllowCredentials()).isNull();
+        assertThat(instance.isUserVerificationRequired()).isFalse();
+        assertThat(instance.isUserPresenceRequired()).isTrue();
+    }
+
+    @Deprecated
+    @Test
+    void constructor_without_allowCredentials_userPresenceRequired_test() {
+        // Server properties
+        Origin origin = Origin.create("https://example.com") /* set origin */;
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        Authenticator authenticator = mock(Authenticator.class);
+
+        // expectations
+        boolean userVerificationRequired = true;
+
+        AuthenticationParameters instance =
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
                         userVerificationRequired
                 );
 
-        assertThat(authenticationParameters.getServerProperty()).isEqualTo(serverProperty);
-        assertThat(authenticationParameters.getAuthenticator()).isEqualTo(authenticator);
-        assertThat(authenticationParameters.isUserVerificationRequired()).isEqualTo(userVerificationRequired);
-        assertThat(authenticationParameters.isUserPresenceRequired()).isTrue();
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getAuthenticator()).isEqualTo(authenticator);
+        assertThat(instance.isUserVerificationRequired()).isEqualTo(userVerificationRequired);
+        assertThat(instance.isUserPresenceRequired()).isTrue();
     }
 
     @Test
@@ -64,6 +120,7 @@ class AuthenticationParametersTest {
         assertThatThrownBy(() -> new AuthenticationParameters(
                 null,
                 authenticator,
+                null,
                 true,
                 true
         )).isInstanceOf(IllegalArgumentException.class);
@@ -74,6 +131,7 @@ class AuthenticationParametersTest {
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
         assertThatThrownBy(() -> new AuthenticationParameters(
                 serverProperty,
+                null,
                 null,
                 true,
                 true
@@ -99,6 +157,7 @@ class AuthenticationParametersTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        null,
                         userVerificationRequired,
                         userPresenceRequired
                 );
@@ -106,6 +165,7 @@ class AuthenticationParametersTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        null,
                         userVerificationRequired,
                         userPresenceRequired
                 );

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/CoreAuthenticationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/CoreAuthenticationParametersTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.data.client.challenge.DefaultChallenge;
+import com.webauthn4j.server.CoreServerProperty;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class CoreAuthenticationParametersTest {
+
+    @Deprecated
+    @Test
+    void constructor_without_allowCredentials_test() {
+        // Server properties
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
+        CoreServerProperty serverProperty = new CoreServerProperty(rpId, challenge);
+
+        Authenticator authenticator = mock(Authenticator.class);
+
+        CoreAuthenticationParameters instance =
+                new CoreAuthenticationParameters(
+                        serverProperty,
+                        authenticator,
+                        false,
+                        true
+                );
+
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getAuthenticator()).isEqualTo(authenticator);
+        assertThat(instance.getAllowCredentials()).isNull();
+        assertThat(instance.isUserVerificationRequired()).isFalse();
+        assertThat(instance.isUserPresenceRequired()).isTrue();
+    }
+
+    @Deprecated
+    @Test
+    void constructor_without_allowCredentials_userPresenceRequired_test() {
+        // Server properties
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
+        CoreServerProperty serverProperty = new CoreServerProperty(rpId, challenge);
+
+        Authenticator authenticator = mock(Authenticator.class);
+
+        CoreAuthenticationParameters instance =
+                new CoreAuthenticationParameters(
+                        serverProperty,
+                        authenticator,
+                        false
+                );
+
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getAuthenticator()).isEqualTo(authenticator);
+        assertThat(instance.getAllowCredentials()).isNull();
+        assertThat(instance.isUserVerificationRequired()).isFalse();
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/CoreRegistrationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/CoreRegistrationParametersTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.data.client.challenge.DefaultChallenge;
+import com.webauthn4j.server.CoreServerProperty;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CoreRegistrationParametersTest {
+
+    @Deprecated
+    @Test
+    void constructor_without_pubKeyCredParams_test() {
+        // Server properties
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
+        CoreServerProperty serverProperty = new CoreServerProperty(rpId, challenge);
+
+        CoreRegistrationParameters instance =
+                new CoreRegistrationParameters(
+                        serverProperty,
+                        false,
+                        true
+                );
+
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getPubKeyCredParams()).isNull();
+        assertThat(instance.isUserVerificationRequired()).isFalse();
+        assertThat(instance.isUserPresenceRequired()).isTrue();
+    }
+
+    @Deprecated
+    @Test
+    void constructor_without_pubKeyCredParams_userPresenceRequired_test() {
+        // Server properties
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
+        CoreServerProperty serverProperty = new CoreServerProperty(rpId, challenge);
+
+        CoreRegistrationParameters instance =
+                new CoreRegistrationParameters(
+                        serverProperty,
+                        false
+                );
+
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getPubKeyCredParams()).isNull();
+        assertThat(instance.isUserVerificationRequired()).isFalse();
+    }
+
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/RegistrationDataTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/RegistrationDataTest.java
@@ -38,6 +38,7 @@ class RegistrationDataTest {
     void constructor_RegistrationParameters_test() {
         RegistrationParameters registrationParameters = new RegistrationParameters(
                 TestDataUtil.createServerProperty(),
+                null,
                 true
         );
         assertThat(registrationParameters.getServerProperty()).isInstanceOf(ServerProperty.class);
@@ -48,6 +49,7 @@ class RegistrationDataTest {
     @Test
     void constructor_with_serverProperty_null_test() {
         assertThatThrownBy(() -> new RegistrationParameters(
+                null,
                 null,
                 true
         )).isInstanceOf(IllegalArgumentException.class);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/RegistrationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/RegistrationParametersTest.java
@@ -29,6 +29,75 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RegistrationParametersTest {
 
     @Test
+    void constructor_test() {
+        // Server properties
+        Origin origin = Origin.create("https://example.com") /* set origin */;
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        RegistrationParameters instance =
+                new RegistrationParameters(
+                        serverProperty,
+                        null,
+                        false,
+                        true
+                );
+
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getPubKeyCredParams()).isNull();
+        assertThat(instance.isUserVerificationRequired()).isFalse();
+        assertThat(instance.isUserPresenceRequired()).isTrue();
+    }
+
+    @Deprecated
+    @Test
+    void constructor_without_pubKeyCredParams_test() {
+        // Server properties
+        Origin origin = Origin.create("https://example.com") /* set origin */;
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        RegistrationParameters instance =
+                new RegistrationParameters(
+                        serverProperty,
+                        false,
+                        true
+                );
+
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getPubKeyCredParams()).isNull();
+        assertThat(instance.isUserVerificationRequired()).isFalse();
+        assertThat(instance.isUserPresenceRequired()).isTrue();
+    }
+
+    @Deprecated
+    @Test
+    void constructor_without_pubKeyCredParams_userPresenceRequired_test() {
+        // Server properties
+        Origin origin = Origin.create("https://example.com") /* set origin */;
+        String rpId = "example.com" /* set rpId */;
+        Challenge challenge = new DefaultChallenge() /* set challenge */;
+        byte[] tokenBindingId = null /* set tokenBindingId */;
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+
+        RegistrationParameters instance =
+                new RegistrationParameters(
+                        serverProperty,
+                        false
+                );
+
+        assertThat(instance.getServerProperty()).isEqualTo(serverProperty);
+        assertThat(instance.getPubKeyCredParams()).isNull();
+        assertThat(instance.isUserVerificationRequired()).isFalse();
+        assertThat(instance.isUserPresenceRequired()).isTrue();
+    }
+
+
+    @Test
     void equals_hashCode_test() {
         // Server properties
         Origin origin = Origin.create("https://example.com") /* set origin */;
@@ -43,11 +112,13 @@ class RegistrationParametersTest {
         RegistrationParameters instanceA =
                 new RegistrationParameters(
                         serverProperty,
+                        null,
                         userVerificationRequired
                 );
         RegistrationParameters instanceB =
                 new RegistrationParameters(
                         serverProperty,
+                        null,
                         userVerificationRequired
                 );
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationDataValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationDataValidatorTest.java
@@ -25,10 +25,14 @@ import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthen
 import com.webauthn4j.test.TestDataUtil;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
 import com.webauthn4j.validator.exception.CrossOriginException;
+import com.webauthn4j.validator.exception.NotAllowedCredentialIdException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -40,6 +44,19 @@ import static org.mockito.Mockito.when;
 class AuthenticationDataValidatorTest {
 
     private final AuthenticationDataValidator target = new AuthenticationDataValidator();
+
+    @Test
+    void validateCredentialId_test(){
+        byte[] credentialId = new byte[32];
+        target.validateCredentialId(credentialId, Collections.singletonList(credentialId));
+    }
+
+    @Test
+    void validateCredentialId_not_allowed_credential_test(){
+        byte[] credentialId = new byte[32];
+        List<byte[]> allowCredentials = Collections.emptyList();
+        assertThatThrownBy(() -> target.validateCredentialId(credentialId, allowCredentials)).isInstanceOf(NotAllowedCredentialIdException.class);
+    }
 
     @Test
     void validateAuthenticatorData_with_non_null_AttestedCredentialData(@Mock AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData) {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationDataValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/RegistrationDataValidatorTest.java
@@ -17,7 +17,10 @@
 package com.webauthn4j.validator;
 
 import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.PublicKeyCredentialParameters;
+import com.webauthn4j.data.PublicKeyCredentialType;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
 import com.webauthn4j.validator.attestation.statement.androidkey.NullAndroidKeyAttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.androidsafetynet.NullAndroidSafetyNetAttestationStatementValidator;
@@ -28,12 +31,15 @@ import com.webauthn4j.validator.attestation.statement.u2f.NullFIDOU2FAttestation
 import com.webauthn4j.validator.attestation.trustworthiness.certpath.NullCertPathTrustworthinessValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.self.NullSelfAttestationTrustworthinessValidator;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
+import com.webauthn4j.validator.exception.NotAllowedAlgorithmException;
 import com.webauthn4j.validator.exception.UserNotPresentException;
 import com.webauthn4j.validator.exception.UserNotVerifiedException;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -58,6 +64,20 @@ class RegistrationDataValidatorTest {
                 new NullSelfAttestationTrustworthinessValidator(),
                 new ArrayList<>(),
                 objectConverter);
+    }
+
+    @Test
+    void validateAlg_test(){
+        List<PublicKeyCredentialParameters> pubKeyCredParams = Arrays.asList(new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256), new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.RS256));
+        target.validateAlg(COSEAlgorithmIdentifier.ES256, pubKeyCredParams);
+    }
+
+    @Test
+    void validateAlg_not_allowed_alg_test(){
+        List<PublicKeyCredentialParameters> pubKeyCredParams = Collections.singletonList(new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.RS256));
+        assertThrows(NotAllowedAlgorithmException.class,
+                () -> target.validateAlg(COSEAlgorithmIdentifier.ES256, pubKeyCredParams)
+        );
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/exception/NotAllowedAlgorithmExceptionTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/exception/NotAllowedAlgorithmExceptionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.validator.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotAllowedAlgorithmExceptionTest {
+
+    private final RuntimeException cause = new RuntimeException();
+
+    @Test
+    void test() {
+        NotAllowedAlgorithmException exception1 = new NotAllowedAlgorithmException("dummy", cause);
+        NotAllowedAlgorithmException exception2 = new NotAllowedAlgorithmException("dummy");
+        NotAllowedAlgorithmException exception3 = new NotAllowedAlgorithmException(cause);
+
+        assertAll(
+                () -> assertThat(exception1.getMessage()).isEqualTo("dummy"),
+                () -> assertThat(exception1.getCause()).isEqualTo(cause),
+
+                () -> assertThat(exception2.getMessage()).isEqualTo("dummy"),
+                () -> assertThat(exception2.getCause()).isNull(),
+
+                () -> assertThat(exception3.getMessage()).isEqualTo(cause.toString()),
+                () -> assertThat(exception3.getCause()).isEqualTo(cause)
+        );
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/exception/NotAllowedCredentialIdExceptionTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/exception/NotAllowedCredentialIdExceptionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.validator.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotAllowedCredentialIdExceptionTest {
+
+    private final RuntimeException cause = new RuntimeException();
+
+    @Test
+    void test() {
+        NotAllowedCredentialIdException exception1 = new NotAllowedCredentialIdException("dummy", cause);
+        NotAllowedCredentialIdException exception2 = new NotAllowedCredentialIdException("dummy");
+        NotAllowedCredentialIdException exception3 = new NotAllowedCredentialIdException(cause);
+
+        assertAll(
+                () -> assertThat(exception1.getMessage()).isEqualTo("dummy"),
+                () -> assertThat(exception1.getCause()).isEqualTo(cause),
+
+                () -> assertThat(exception2.getMessage()).isEqualTo("dummy"),
+                () -> assertThat(exception2.getCause()).isNull(),
+
+                () -> assertThat(exception3.getMessage()).isEqualTo(cause.toString()),
+                () -> assertThat(exception3.getCause()).isEqualTo(cause)
+        );
+    }
+
+}

--- a/webauthn4j-core/src/test/java/integration/component/CustomOriginValidatorTest.java
+++ b/webauthn4j-core/src/test/java/integration/component/CustomOriginValidatorTest.java
@@ -106,6 +106,7 @@ class CustomOriginValidatorTest {
         );
         RegistrationParameters registrationParameters = new RegistrationParameters(
                 serverProperty,
+                null,
                 false
         );
 

--- a/webauthn4j-core/src/test/java/integration/component/NullAttestationStatementValidatorTest.java
+++ b/webauthn4j-core/src/test/java/integration/component/NullAttestationStatementValidatorTest.java
@@ -78,7 +78,7 @@ class NullAttestationStatementValidatorTest {
                         registrationRequest.getClientDataJSON(),
                         transports);
         RegistrationParameters registrationParameters =
-                new RegistrationParameters(serverProperty, false);
+                new RegistrationParameters(serverProperty, null,false);
         target.validate(webAuthnRegistrationRequest, registrationParameters);
     }
 
@@ -120,7 +120,7 @@ class NullAttestationStatementValidatorTest {
                         registrationRequest.getClientDataJSON(),
                         transports);
         RegistrationParameters registrationParameters =
-                new RegistrationParameters(serverProperty, false);
+                new RegistrationParameters(serverProperty, null, false);
         target.validate(webAuthnRegistrationRequest, registrationParameters);
 
     }

--- a/webauthn4j-core/src/test/java/integration/scenario/fido/FIDOAuthenticatorCoreAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/fido/FIDOAuthenticatorCoreAuthenticationValidationTest.java
@@ -92,6 +92,7 @@ class FIDOAuthenticatorCoreAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        null,
                         true
                 );
 

--- a/webauthn4j-core/src/test/java/integration/scenario/fido/FIDOAuthenticatorCoreRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/fido/FIDOAuthenticatorCoreRegistrationValidationTest.java
@@ -115,6 +115,7 @@ class FIDOAuthenticatorCoreRegistrationValidationTest {
         );
         CoreRegistrationParameters coreRegistrationParameters = new CoreRegistrationParameters(
                 serverProperty,
+                null,
                 false
         );
 

--- a/webauthn4j-core/src/test/java/integration/scenario/webauthn/AndroidKeyAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/webauthn/AndroidKeyAuthenticatorRegistrationValidationTest.java
@@ -108,6 +108,7 @@ class AndroidKeyAuthenticatorRegistrationValidationTest {
         RegistrationParameters webAuthnRegistrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );

--- a/webauthn4j-core/src/test/java/integration/scenario/webauthn/AndroidSafetyNetAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/webauthn/AndroidSafetyNetAuthenticatorRegistrationValidationTest.java
@@ -109,6 +109,7 @@ class AndroidSafetyNetAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );

--- a/webauthn4j-core/src/test/java/integration/scenario/webauthn/CustomAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/webauthn/CustomAuthenticationValidationTest.java
@@ -97,6 +97,7 @@ class CustomAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        null,
                         false,
                         true
                 );

--- a/webauthn4j-core/src/test/java/integration/scenario/webauthn/CustomRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/webauthn/CustomRegistrationValidationTest.java
@@ -96,6 +96,7 @@ class CustomRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );

--- a/webauthn4j-core/src/test/java/integration/scenario/webauthn/FIDOU2FAuthenticatorAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/webauthn/FIDOU2FAuthenticatorAuthenticationValidationTest.java
@@ -65,6 +65,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         // create
         AttestationObject attestationObject = createAttestationObject(rpId, challenge);
+        byte[] credentialId = attestationObject.getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
         // get
         PublicKeyCredentialRequestOptions credentialRequestOptions = new PublicKeyCredentialRequestOptions(
@@ -101,6 +102,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        Collections.singletonList(credentialId),
                         false,
                         true
                 );
@@ -122,6 +124,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         // create
         AttestationObject attestationObject = createAttestationObject(rpId, challenge);
+        byte[] credentialId = attestationObject.getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
         // get
         PublicKeyCredentialRequestOptions credentialRequestOptions = new PublicKeyCredentialRequestOptions(
@@ -156,6 +159,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        Collections.singletonList(credentialId),
                         false
                 );
 
@@ -173,6 +177,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         // create
         AttestationObject attestationObject = createAttestationObject(rpId, challenge);
+        byte[] credentialId = attestationObject.getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
         // get
         PublicKeyCredentialRequestOptions credentialRequestOptions = new PublicKeyCredentialRequestOptions(
@@ -206,6 +211,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        Collections.singletonList(credentialId),
                         false
                 );
 
@@ -222,6 +228,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         // create
         AttestationObject attestationObject = createAttestationObject(rpId, challenge);
+        byte[] credentialId = attestationObject.getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
         // get
         PublicKeyCredentialRequestOptions credentialRequestOptions = new PublicKeyCredentialRequestOptions(
@@ -256,6 +263,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        Collections.singletonList(credentialId),
                         false
                 );
 
@@ -273,6 +281,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         // create
         AttestationObject attestationObject = createAttestationObject(rpId, challenge);
+        byte[] credentialId = attestationObject.getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
         // get
         PublicKeyCredentialRequestOptions credentialRequestOptions = new PublicKeyCredentialRequestOptions(
@@ -306,6 +315,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        Collections.singletonList(credentialId),
                         false
                 );
         assertThrows(BadRpIdException.class,
@@ -321,6 +331,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         // create
         AttestationObject attestationObject = createAttestationObject(rpId, challenge);
+        byte[] credentialId = attestationObject.getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
         // get
         PublicKeyCredentialRequestOptions credentialRequestOptions = new PublicKeyCredentialRequestOptions(
@@ -354,6 +365,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        Collections.singletonList(credentialId),
                         true
                 );
         assertThrows(UserNotVerifiedException.class,
@@ -372,6 +384,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         // create
         AttestationObject attestationObject = createAttestationObject(rpId, challenge);
+        byte[] credentialId = attestationObject.getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
         // get
         PublicKeyCredentialRequestOptions credentialRequestOptions = new PublicKeyCredentialRequestOptions(
@@ -405,6 +418,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        Collections.singletonList(credentialId),
                         false,
                         true
                 );
@@ -421,6 +435,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         // create
         AttestationObject attestationObject = createAttestationObject(rpId, challenge);
+        byte[] credentialId = attestationObject.getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
         // get
         PublicKeyCredentialRequestOptions credentialRequestOptions = new PublicKeyCredentialRequestOptions(
@@ -454,6 +469,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        Collections.singletonList(credentialId),
                         false,
                         true
                 );
@@ -470,6 +486,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
 
         // create
         AttestationObject attestationObject = createAttestationObject(rpId, challenge);
+        byte[] credentialId = attestationObject.getAuthenticatorData().getAttestedCredentialData().getCredentialId();
 
         // get
         PublicKeyCredentialRequestOptions credentialRequestOptions = new PublicKeyCredentialRequestOptions(
@@ -504,6 +521,7 @@ class FIDOU2FAuthenticatorAuthenticationValidationTest {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        Collections.singletonList(credentialId),
                         false,
                         true
                 );

--- a/webauthn4j-core/src/test/java/integration/scenario/webauthn/FIDOU2FAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/webauthn/FIDOU2FAuthenticatorRegistrationValidationTest.java
@@ -106,6 +106,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );
@@ -160,6 +161,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );
@@ -205,6 +207,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );
@@ -243,6 +246,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );
@@ -280,6 +284,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );
@@ -314,6 +319,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );
@@ -348,6 +354,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );
@@ -405,6 +412,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );
@@ -461,6 +469,7 @@ class FIDOU2FAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );

--- a/webauthn4j-core/src/test/java/integration/scenario/webauthn/TPMAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/webauthn/TPMAuthenticatorRegistrationValidationTest.java
@@ -109,6 +109,7 @@ class TPMAuthenticatorRegistrationValidationTest {
         RegistrationParameters registrationParameters
                 = new RegistrationParameters(
                 serverProperty,
+                null,
                 false,
                 true
         );

--- a/webauthn4j-core/src/test/java/integration/scenario/webauthn/UserVerifyingAuthenticatorAuthenticationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/webauthn/UserVerifyingAuthenticatorAuthenticationValidationTest.java
@@ -41,6 +41,7 @@ import com.webauthn4j.validator.exception.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -93,10 +94,12 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
                         clientExtensionJSON,
                         authenticationRequest.getSignature()
                 );
+        List<byte[]> allowCredentials = null;
         AuthenticationParameters authenticationParameters =
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         true
                 );
 
@@ -148,10 +151,12 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
                         clientExtensionJSON,
                         authenticationRequest.getSignature()
                 );
+        List<byte[]> allowCredentials = null;
         AuthenticationParameters authenticationParameters =
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         true
                 );
 
@@ -198,10 +203,12 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getSignature()
                 );
+        List<byte[]> allowCredentials = null;
         AuthenticationParameters authenticationParameters =
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         true
                 );
 
@@ -241,10 +248,12 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getSignature()
                 );
+        List<byte[]> allowCredentials = null;
         AuthenticationParameters authenticationParameters =
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         true
                 );
 
@@ -283,10 +292,12 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getSignature()
                 );
+        List<byte[]> allowCredentials = null;
         AuthenticationParameters authenticationParameters =
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         true
                 );
 
@@ -327,10 +338,12 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getSignature()
                 );
+        List<byte[]> allowCredentials = null;
         AuthenticationParameters authenticationParameters =
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         true
                 );
 
@@ -371,10 +384,12 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getSignature()
                 );
+        List<byte[]> allowCredentials = null;
         AuthenticationParameters authenticationParameters =
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         true
                 );
 
@@ -413,10 +428,12 @@ class UserVerifyingAuthenticatorAuthenticationValidationTest {
                         authenticationRequest.getClientDataJSON(),
                         authenticationRequest.getSignature()
                 );
+        List<byte[]> allowCredentials = null;
         AuthenticationParameters authenticationParameters =
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         true
                 );
 

--- a/webauthn4j-core/src/test/java/integration/scenario/webauthn/UserVerifyingAuthenticatorRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/webauthn/UserVerifyingAuthenticatorRegistrationValidationTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,8 +117,10 @@ class UserVerifyingAuthenticatorRegistrationValidationTest {
                 clientExtensionJSON,
                 transports
         );
+        List<PublicKeyCredentialParameters> pubKeyCredParams = null;
         RegistrationParameters registrationParameters = new RegistrationParameters(
                 serverProperty,
+                pubKeyCredParams,
                 false
         );
 
@@ -173,8 +176,10 @@ class UserVerifyingAuthenticatorRegistrationValidationTest {
                 clientExtensionJSON,
                 transports
         );
+        List<PublicKeyCredentialParameters> pubKeyCredParams = null;
         RegistrationParameters registrationParameters = new RegistrationParameters(
                 serverProperty,
+                pubKeyCredParams,
                 false
         );
 

--- a/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
@@ -62,11 +62,12 @@ public class WebAuthnManagerSample {
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
         // expectations
+        List<PublicKeyCredentialParameters> pubKeyCredParams = null;
         boolean userVerificationRequired = false;
         boolean userPresenceRequired = true;
 
         RegistrationRequest registrationRequest = new RegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
-        RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired);
+        RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, pubKeyCredParams, userVerificationRequired, userPresenceRequired);
         RegistrationData registrationData;
         try {
             registrationData = webAuthnManager.parse(registrationRequest);
@@ -109,6 +110,7 @@ public class WebAuthnManagerSample {
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
         // expectations
+        List<byte[]> allowCredentials = null;
         boolean userVerificationRequired = true;
         boolean userPresenceRequired = true;
         List<String> expectedExtensionIds = Collections.emptyList();
@@ -128,6 +130,7 @@ public class WebAuthnManagerSample {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         userVerificationRequired,
                         userPresenceRequired
                 );

--- a/webauthn4j-core/src/test/java/sample/WebAuthnRegistrationContextValidatorSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnRegistrationContextValidatorSample.java
@@ -24,6 +24,7 @@ import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.server.ServerProperty;
 
+import java.util.List;
 import java.util.Set;
 
 @SuppressWarnings("ConstantConditions")
@@ -41,6 +42,7 @@ class RegistrationContextValidatorSample {
         Challenge challenge = null /* set challenge */;
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+        List<PublicKeyCredentialParameters> pubKeyCredParams = null;
         boolean userVerificationRequired = false;
 
         RegistrationRequest registrationRequest = new RegistrationRequest(
@@ -50,6 +52,7 @@ class RegistrationContextValidatorSample {
         );
         RegistrationParameters registrationParameters = new RegistrationParameters(
                 serverProperty,
+                pubKeyCredParams,
                 userVerificationRequired
         );
 
@@ -86,6 +89,7 @@ class RegistrationContextValidatorSample {
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
         Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
+        List<byte[]> allowCredentials = null;
         boolean userVerificationRequired = true;
 
         AuthenticationRequest authenticationRequest =
@@ -99,6 +103,7 @@ class RegistrationContextValidatorSample {
                 new AuthenticationParameters(
                         serverProperty,
                         authenticator,
+                        allowCredentials,
                         userVerificationRequired
                 );
 

--- a/webauthn4j-device-check/src/main/java/com/webauthn4j/appattest/data/DCAssertionParameters.java
+++ b/webauthn4j-device-check/src/main/java/com/webauthn4j/appattest/data/DCAssertionParameters.java
@@ -26,6 +26,6 @@ public class DCAssertionParameters extends CoreAuthenticationParameters {
     public DCAssertionParameters(
             @NonNull DCServerProperty serverProperty,
             @NonNull DCAppleDevice dcAppleDevice) {
-        super(serverProperty, dcAppleDevice, false, false);
+        super(serverProperty, dcAppleDevice, null, false, false);
     }
 }


### PR DESCRIPTION
Addresses #533

- From WebAuthn Level2, `alg` parameter verification is introduced to the registration verification procedure (step16)
  https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#sctn-registering-a-new-credential
  As a expected value list,  `pubKeyCredParams` is added to `RegistrationParameters`
-  credential.`id` verification is also introduced to the authentication verification procedure (step7)
  https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#sctn-verifying-assertion
  As a expected value list,  `allowCredentials` is added to `AuthenticationParameters`

Breaking Changes:
- `pubKeyCredParams` is added to `RegistrationParameters`
- `allowCredentials` is added to `AuthenticationParameters`

For backward-compatibility, `RegistrationParameters` constructor without `pubKeyCredParams` parameter and `AuthenticationParameters` constructor without `allowCredentials` are still exists, but it is recommended to use new constructors with `pubKeyCredParams` parameter or `allowCredentials` parameter to express intent to verify or not to verify `alg` and credential.`id`.

