### PR TITLE
WIP: add SPC ClientDataType (payment.get)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnAuthenticationManager.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnAuthenticationManager.java
@@ -117,6 +117,23 @@ public class WebAuthnAuthenticationManager {
         return authenticationData;
     }
 
+    @SuppressWarnings("squid:S1130")
+    public @NonNull AuthenticationData validatePayment(
+            @NonNull AuthenticationRequest authenticationRequest,
+            @NonNull AuthenticationParameters authenticationParameters) throws DataConversionException, ValidationException {
+        AuthenticationData authenticationData = parse(authenticationRequest);
+        validatePayment(authenticationData, authenticationParameters);
+        return authenticationData;
+    }
+
+    @SuppressWarnings("squid:S1130")
+    public @NonNull AuthenticationData validatePayment(
+            @NonNull AuthenticationData authenticationData,
+            @NonNull AuthenticationParameters authenticationParameters) throws ValidationException {
+        authenticationDataValidator.validatePayment(authenticationData, authenticationParameters);
+        return authenticationData;
+    }
+
     public @NonNull AuthenticationDataValidator getAuthenticationDataValidator() {
         return authenticationDataValidator;
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnManager.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/WebAuthnManager.java
@@ -176,6 +176,16 @@ public class WebAuthnManager {
         return this.webAuthnAuthenticationManager.validate(authenticationData, authenticationParameters);
     }
 
+    @SuppressWarnings("squid:S1130")
+    public @NonNull AuthenticationData validatePayment(@NonNull AuthenticationRequest authenticationRequest, @NonNull AuthenticationParameters authenticationParameters) throws DataConversionException, ValidationException {
+        return this.webAuthnAuthenticationManager.validatePayment(authenticationRequest, authenticationParameters);
+    }
+
+    @SuppressWarnings("squid:S1130")
+    public @NonNull AuthenticationData validatePayment(@NonNull AuthenticationData authenticationData, @NonNull AuthenticationParameters authenticationParameters) throws ValidationException {
+        return this.webAuthnAuthenticationManager.validatePayment(authenticationData, authenticationParameters);
+    }
+
 
     public @NonNull RegistrationDataValidator getRegistrationDataValidator() {
         return this.webAuthnRegistrationManager.getRegistrationDataValidator();

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/client/ClientDataType.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/client/ClientDataType.java
@@ -25,7 +25,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public enum ClientDataType {
     CREATE("webauthn.create"),
     GET("webauthn.get"),
-    PAYMENT_CREATE("payment.create"),
     PAYMENT_GET("payment.get");
 
     private final String value;
@@ -43,8 +42,6 @@ public enum ClientDataType {
                 return CREATE;
             case "webauthn.get":
                 return GET;
-            case "payment.create":
-                return PAYMENT_CREATE;
             case "payment.get":
                 return PAYMENT_GET;
             default:

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/client/ClientDataType.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/client/ClientDataType.java
@@ -24,7 +24,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum ClientDataType {
     CREATE("webauthn.create"),
-    GET("webauthn.get");
+    GET("webauthn.get"),
+    PAYMENT_CREATE("payment.create"),
+    PAYMENT_GET("payment.get");
 
     private final String value;
 
@@ -41,6 +43,10 @@ public enum ClientDataType {
                 return CREATE;
             case "webauthn.get":
                 return GET;
+            case "payment.create":
+                return PAYMENT_CREATE;
+            case "payment.get":
+                return PAYMENT_GET;
             default:
                 throw new IllegalArgumentException("value '" + value + "' is out of range");
         }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
@@ -139,7 +139,7 @@ public class AuthenticationDataValidator {
 
         //spec| Step11
         //spec| Verify that the value of C.type is the string webauthn.get.
-        if (!Objects.equals(collectedClientData.getType(), ClientDataType.GET)) {
+        if (!Objects.equals(collectedClientData.getType(), ClientDataType.GET) && !Objects.equals(collectedClientData.getType(), ClientDataType.PAYMENT_GET)) {
             throw new InconsistentClientDataTypeException("ClientData.type must be 'get' on authentication, but it isn't.");
         }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
@@ -138,7 +138,7 @@ public class RegistrationDataValidator {
 
         //spec| Step7
         //spec| Verify that the value of C.type is webauthn.create.
-        if (!Objects.equals(collectedClientData.getType(), ClientDataType.CREATE) && !Objects.equals(collectedClientData.getType(), ClientDataType.PAYMENT_CREATE)) {
+        if (!Objects.equals(collectedClientData.getType(), ClientDataType.CREATE)) {
             throw new InconsistentClientDataTypeException("ClientData.type must be 'create' on registration, but it isn't.");
         }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/RegistrationDataValidator.java
@@ -138,7 +138,7 @@ public class RegistrationDataValidator {
 
         //spec| Step7
         //spec| Verify that the value of C.type is webauthn.create.
-        if (!Objects.equals(collectedClientData.getType(), ClientDataType.CREATE)) {
+        if (!Objects.equals(collectedClientData.getType(), ClientDataType.CREATE) && !Objects.equals(collectedClientData.getType(), ClientDataType.PAYMENT_CREATE)) {
             throw new InconsistentClientDataTypeException("ClientData.type must be 'create' on registration, but it isn't.");
         }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
@@ -37,6 +37,8 @@ class ClientDataTypeTest {
         assertAll(
                 () -> assertThat(ClientDataType.create("webauthn.create")).isEqualTo(ClientDataType.CREATE),
                 () -> assertThat(ClientDataType.create("webauthn.get")).isEqualTo(ClientDataType.GET),
+                () -> assertThat(ClientDataType.create("payment.create")).isEqualTo(ClientDataType.PAYMENT_CREATE),
+                () -> assertThat(ClientDataType.create("payment.get")).isEqualTo(ClientDataType.PAYMENT_GET),
                 () -> assertThat(ClientDataType.create(null)).isNull(),
                 () -> assertThatThrownBy(() -> ClientDataType.create("invalid")).isInstanceOf(IllegalArgumentException.class)
         );

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
@@ -37,7 +37,6 @@ class ClientDataTypeTest {
         assertAll(
                 () -> assertThat(ClientDataType.create("webauthn.create")).isEqualTo(ClientDataType.CREATE),
                 () -> assertThat(ClientDataType.create("webauthn.get")).isEqualTo(ClientDataType.GET),
-                () -> assertThat(ClientDataType.create("payment.create")).isEqualTo(ClientDataType.PAYMENT_CREATE),
                 () -> assertThat(ClientDataType.create("payment.get")).isEqualTo(ClientDataType.PAYMENT_GET),
                 () -> assertThat(ClientDataType.create(null)).isNull(),
                 () -> assertThatThrownBy(() -> ClientDataType.create("invalid")).isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
Hello, I would like to validate credentials created using [secure payment confirmation (SPC)](https://w3c.github.io/secure-payment-confirmation/) using this library.

SPC is a Web API to support streamlined authentication during a payment transaction and is built on top of Webauthn standards. One of the differences is that the `type` of the returned `clientDataJSON` is `payment.create` during enrollment and `payment.get` during authentication. This pull request adds those two types as valid `ClientDataType` values.