### PR TITLE
Bugfix: CoreAuthenticatorImpl#getAttestationStatement must be nullable

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/AuthenticatorImpl.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/AuthenticatorImpl.java
@@ -44,7 +44,7 @@ public class AuthenticatorImpl extends CoreAuthenticatorImpl implements Authenti
 
     public AuthenticatorImpl(
             @NonNull AttestedCredentialData attestedCredentialData,
-            @NonNull AttestationStatement attestationStatement,
+            @Nullable AttestationStatement attestationStatement,
             long counter,
             @Nullable Set<AuthenticatorTransport> transports,
             @Nullable AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions,
@@ -56,7 +56,7 @@ public class AuthenticatorImpl extends CoreAuthenticatorImpl implements Authenti
 
     public AuthenticatorImpl(
             @NonNull AttestedCredentialData attestedCredentialData,
-            @NonNull AttestationStatement attestationStatement,
+            @Nullable AttestationStatement attestationStatement,
             long counter,
             @Nullable Set<AuthenticatorTransport> transports) {
         this(attestedCredentialData, attestationStatement, counter, transports, new AuthenticationExtensionsClientOutputs<>(), new AuthenticationExtensionsAuthenticatorOutputs<>());
@@ -64,7 +64,7 @@ public class AuthenticatorImpl extends CoreAuthenticatorImpl implements Authenti
 
     public AuthenticatorImpl(
             @NonNull AttestedCredentialData attestedCredentialData,
-            @NonNull AttestationStatement attestationStatement,
+            @Nullable AttestationStatement attestationStatement,
             long counter) {
         this(attestedCredentialData, attestationStatement, counter, Collections.emptySet());
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/CoreAuthenticatorImpl.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/CoreAuthenticatorImpl.java
@@ -47,7 +47,6 @@ public class CoreAuthenticatorImpl implements CoreAuthenticator {
                                  @Nullable AuthenticationExtensionsAuthenticatorOutputs<RegistrationExtensionAuthenticatorOutput> authenticatorExtensions) {
 
         AssertUtil.notNull(attestedCredentialData, ATTESTED_CREDENTIAL_DATA_MUST_NOT_BE_NULL);
-        AssertUtil.notNull(attestationStatement, "attestationStatement must not be null");
 
         this.attestedCredentialData = attestedCredentialData;
         this.attestationStatement = attestationStatement;
@@ -60,7 +59,6 @@ public class CoreAuthenticatorImpl implements CoreAuthenticator {
         AssertUtil.notNull(coreRegistrationData.getAttestationObject(), "attestationObject must not be null");
         AssertUtil.notNull(coreRegistrationData.getAttestationObject().getAuthenticatorData(), "authenticatorData must not be null");
         AssertUtil.notNull(coreRegistrationData.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(), ATTESTED_CREDENTIAL_DATA_MUST_NOT_BE_NULL);
-        AssertUtil.notNull(coreRegistrationData.getAttestationObject().getAttestationStatement(), "attestationStatement must not be null");
 
         return new CoreAuthenticatorImpl(
                 coreRegistrationData.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),

--- a/webauthn4j-core/src/test/java/com/webauthn4j/authenticator/AuthenticatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/authenticator/AuthenticatorTest.java
@@ -30,6 +30,7 @@ import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
 import com.webauthn4j.test.TestAttestationStatementUtil;
 import com.webauthn4j.test.TestDataUtil;
 import com.webauthn4j.util.CollectionUtil;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -83,7 +84,7 @@ class AuthenticatorTest {
         }
 
         @Override
-        public AttestedCredentialData getAttestedCredentialData() {
+        public @NonNull AttestedCredentialData getAttestedCredentialData() {
             return attestedCredentialData;
         }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/authenticator/CoreAuthenticatorImplTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/authenticator/CoreAuthenticatorImplTest.java
@@ -22,8 +22,16 @@ import com.webauthn4j.test.TestDataUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class CoreAuthenticatorImplTest {
+
+    @Test
+    void constructor_attestationStatement_null_test(){
+        assertThatCode(()->{
+            new CoreAuthenticatorImpl(TestDataUtil.createAttestedCredentialData(), null, 0, null);
+        }).doesNotThrowAnyException();
+    }
 
     @Test
     void createFromRegistrationData_test() {


### PR DESCRIPTION
`CoreAuthenticatorImpl`#`getAttestationStatement` (and `AuthenticatorImpl`, which inherits `CoreAuthenticatorImpl` ) must be nullable because `CoreAuthenticator`#`getAttestationStatement` is nullable.