### PR TITLE
Correct AuthenticationAlgorithm(0x0011) value

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationAlgorithm.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationAlgorithm.java
@@ -44,7 +44,7 @@ public enum AuthenticationAlgorithm {
     RSASSA_PKCSV15_SHA512_RAW(0x000E, "rsassa_pkcsv15_sha512_raw"),
     RSASSA_PKCSV15_SHA1_RAW(0x000F, "rsassa_pkcsv15_sha1_raw"),
     SECP384R1_ECDSA_SHA384_RAW(0x0010, "secp384r1_ecdsa_sha384_raw"),
-    SECP521R1_ECDSA_SHA256_RAW(0x0011, "secp521r1_ecdsa_sha256_raw"),
+    SECP521R1_ECDSA_SHA512_RAW(0x0011, "secp521r1_ecdsa_sha512_raw"),
     ED25519_EDDSA_SHA512_RAW(0x0012, "ed25519_eddsa_sha512_raw");
 
     private static final String VALUE_OUT_OF_RANGE_TEMPLATE = "value %s is out of range";

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationAlgorithmTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationAlgorithmTest.java
@@ -39,7 +39,7 @@ class AuthenticationAlgorithmTest {
                 () -> assertThat(AuthenticationAlgorithm.create(0x000E)).isEqualTo(AuthenticationAlgorithm.RSASSA_PKCSV15_SHA512_RAW),
                 () -> assertThat(AuthenticationAlgorithm.create(0x000F)).isEqualTo(AuthenticationAlgorithm.RSASSA_PKCSV15_SHA1_RAW),
                 () -> assertThat(AuthenticationAlgorithm.create(0x0010)).isEqualTo(AuthenticationAlgorithm.SECP384R1_ECDSA_SHA384_RAW),
-                () -> assertThat(AuthenticationAlgorithm.create(0x0011)).isEqualTo(AuthenticationAlgorithm.SECP521R1_ECDSA_SHA256_RAW),
+                () -> assertThat(AuthenticationAlgorithm.create(0x0011)).isEqualTo(AuthenticationAlgorithm.SECP521R1_ECDSA_SHA512_RAW),
                 () -> assertThat(AuthenticationAlgorithm.create(0x0012)).isEqualTo(AuthenticationAlgorithm.ED25519_EDDSA_SHA512_RAW),
                 () -> assertThat(AuthenticationAlgorithm.create("secp256r1_ecdsa_sha256_raw")).isEqualTo(AuthenticationAlgorithm.SECP256R1_ECDSA_SHA256_RAW),
                 () -> assertThat(AuthenticationAlgorithm.create("secp256r1_ecdsa_sha256_der")).isEqualTo(AuthenticationAlgorithm.SECP256R1_ECDSA_SHA256_DER),
@@ -57,11 +57,10 @@ class AuthenticationAlgorithmTest {
                 () -> assertThat(AuthenticationAlgorithm.create("rsassa_pkcsv15_sha512_raw")).isEqualTo(AuthenticationAlgorithm.RSASSA_PKCSV15_SHA512_RAW),
                 () -> assertThat(AuthenticationAlgorithm.create("rsassa_pkcsv15_sha1_raw")).isEqualTo(AuthenticationAlgorithm.RSASSA_PKCSV15_SHA1_RAW),
                 () -> assertThat(AuthenticationAlgorithm.create("secp384r1_ecdsa_sha384_raw")).isEqualTo(AuthenticationAlgorithm.SECP384R1_ECDSA_SHA384_RAW),
-                () -> assertThat(AuthenticationAlgorithm.create("secp521r1_ecdsa_sha256_raw")).isEqualTo(AuthenticationAlgorithm.SECP521R1_ECDSA_SHA256_RAW),
+                () -> assertThat(AuthenticationAlgorithm.create("secp521r1_ecdsa_sha512_raw")).isEqualTo(AuthenticationAlgorithm.SECP521R1_ECDSA_SHA512_RAW),
                 () -> assertThat(AuthenticationAlgorithm.create("ed25519_eddsa_sha512_raw")).isEqualTo(AuthenticationAlgorithm.ED25519_EDDSA_SHA512_RAW)
         );
     }
-
 
     @Test
     void getValue_test() {


### PR DESCRIPTION
from `secp512r1_ecdsa_sha256_raw` to` secp521r1_ecdsa_sha512_raw`

In fido-registry-v2.1-ps-20191217.html, AuthenticationAlgorithm(0x0011) is defined as `secp512r1_ecdsa_sha256_raw`, 
but in fido-registry-v2.2-rd-20210525.html, it was updated to `secp521r1_ecdsa_sha512_raw`.

https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html
https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-rd-20210525.html

In 391221f7, AuthenticationAlgorithm(0x0011) was updated to `secp521r1_ecdsa_sha256_raw` to pass FIDO conformance test tools, but the value was actually invalid.
Test tools v1.6.46 fixed the bug and it prevents webauthn4j to pass the test.
This pull-request make webauthn4j to conform fido-registry-v2.2-rd, and resolves Test tools v1.6.46 issue.

see:
https://github.com/webauthn4j/webauthn4j/discussions/651#discussioncomment-2693442