### PR TITLE
add support for additional BE and BS flags

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AuthenticatorData.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AuthenticatorData.java
@@ -41,6 +41,8 @@ import java.util.Objects;
 public class AuthenticatorData<T extends ExtensionAuthenticatorOutput> implements Serializable {
     public static final byte BIT_UP = (byte) 0b00000001;
     public static final byte BIT_UV = (byte) 0b00000100;
+    public static final byte BIT_BE = (byte) 0b00001000;
+    public static final byte BIT_BS = (byte) 0b00010000;
     public static final byte BIT_AT = (byte) 0b01000000;
     public static final byte BIT_ED = (byte) 0b10000000;
 
@@ -100,6 +102,14 @@ public class AuthenticatorData<T extends ExtensionAuthenticatorOutput> implement
         return (flags & BIT_UV) != 0;
     }
 
+    public static boolean checkFlagBE(byte flags) {
+        return (flags & BIT_BE) != 0;
+    }
+
+    public static boolean checkFlagBS(byte flags) {
+        return (flags & BIT_BS) != 0;
+    }
+
     public static boolean checkFlagAT(byte flags) {
         return (flags & BIT_AT) != 0;
     }
@@ -122,6 +132,14 @@ public class AuthenticatorData<T extends ExtensionAuthenticatorOutput> implement
 
     public boolean isFlagUV() {
         return checkFlagUV(this.flags);
+    }
+
+    public boolean isFlagBE() {
+        return checkFlagBE(this.flags);
+    }
+
+    public boolean isFlagBS() {
+        return checkFlagBS(this.flags);
     }
 
     public boolean isFlagAT() {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/AuthenticatorDataTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/AuthenticatorDataTest.java
@@ -35,27 +35,52 @@ class AuthenticatorDataTest {
         AuthenticatorData<RegistrationExtensionAuthenticatorOutput> target2 = new AuthenticatorData<>(new byte[32], BIT_UV, 0);
         AuthenticatorData<RegistrationExtensionAuthenticatorOutput> target3 = new AuthenticatorData<>(new byte[32], BIT_AT, 0);
         AuthenticatorData<RegistrationExtensionAuthenticatorOutput> target4 = new AuthenticatorData<>(new byte[32], BIT_ED, 0);
+        AuthenticatorData<RegistrationExtensionAuthenticatorOutput> target5 = new AuthenticatorData<>(new byte[32], BIT_BE, 0);
+        AuthenticatorData<RegistrationExtensionAuthenticatorOutput> target6 = new AuthenticatorData<>(new byte[32], BIT_BS, 0);
 
         assertAll(
                 () -> assertThat(target1.isFlagUP()).isTrue(),
                 () -> assertThat(target1.isFlagUV()).isFalse(),
                 () -> assertThat(target1.isFlagAT()).isFalse(),
                 () -> assertThat(target1.isFlagED()).isFalse(),
+                () -> assertThat(target1.isFlagBE()).isFalse(),
+                () -> assertThat(target1.isFlagBS()).isFalse(),
 
                 () -> assertThat(target2.isFlagUP()).isFalse(),
                 () -> assertThat(target2.isFlagUV()).isTrue(),
                 () -> assertThat(target2.isFlagAT()).isFalse(),
                 () -> assertThat(target2.isFlagED()).isFalse(),
+                () -> assertThat(target2.isFlagBE()).isFalse(),
+                () -> assertThat(target2.isFlagBS()).isFalse(),
 
                 () -> assertThat(target3.isFlagUP()).isFalse(),
                 () -> assertThat(target3.isFlagUV()).isFalse(),
                 () -> assertThat(target3.isFlagAT()).isTrue(),
                 () -> assertThat(target3.isFlagED()).isFalse(),
+                () -> assertThat(target3.isFlagBE()).isFalse(),
+                () -> assertThat(target3.isFlagBS()).isFalse(),
 
                 () -> assertThat(target4.isFlagUP()).isFalse(),
                 () -> assertThat(target4.isFlagUV()).isFalse(),
                 () -> assertThat(target4.isFlagAT()).isFalse(),
-                () -> assertThat(target4.isFlagED()).isTrue()
+                () -> assertThat(target4.isFlagED()).isTrue(),
+                () -> assertThat(target4.isFlagBE()).isFalse(),
+                () -> assertThat(target4.isFlagBS()).isFalse(),
+
+                () -> assertThat(target5.isFlagUP()).isFalse(),
+                () -> assertThat(target5.isFlagUV()).isFalse(),
+                () -> assertThat(target5.isFlagAT()).isFalse(),
+                () -> assertThat(target5.isFlagED()).isFalse(),
+                () -> assertThat(target5.isFlagBE()).isTrue(),
+                () -> assertThat(target5.isFlagBS()).isFalse(),
+
+                () -> assertThat(target6.isFlagUP()).isFalse(),
+                () -> assertThat(target6.isFlagUV()).isFalse(),
+                () -> assertThat(target6.isFlagAT()).isFalse(),
+                () -> assertThat(target6.isFlagED()).isFalse(),
+                () -> assertThat(target6.isFlagBE()).isFalse(),
+                () -> assertThat(target6.isFlagBS()).isTrue()
+
         );
     }
 


### PR DESCRIPTION
As per the documentation https://w3c.github.io/webauthn/#authenticator-data , there are two additional flags available in authData to indicate backupEligbility and backupState for the authenticators. The flags essentially help us to resolve if an authenticator is a multi-device credential and has the credentials backedup. This change exposes the method to read the bits for the BE and BS flags.