### PR TITLE
Remove expectedExtensionIds from quickstart and sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, toke
 List<byte[]> allowCredentials = null;
 boolean userVerificationRequired = true;
 boolean userPresenceRequired = true;
-List<String> expectedExtensionIds = Collections.emptyList();
 
 Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
 

--- a/docs/src/reference/asciidoc/en/quick-start.adoc
+++ b/docs/src/reference/asciidoc/en/quick-start.adoc
@@ -117,7 +117,6 @@ ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, toke
 List<byte[]> allowCredentials = null;
 boolean userVerificationRequired = true;
 boolean userPresenceRequired = true;
-List<String> expectedExtensionIds = Collections.emptyList();
 
 Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
 

--- a/docs/src/reference/asciidoc/ja/quick-start.adoc
+++ b/docs/src/reference/asciidoc/ja/quick-start.adoc
@@ -40,10 +40,9 @@ ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, toke
 // expectations
 boolean userVerificationRequired = false;
 boolean userPresenceRequired = true;
-List<String> expectedExtensionIds = Collections.emptyList();
 
 RegistrationRequest registrationRequest = new RegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
-RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired, expectedExtensionIds);
+RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired);
 RegistrationData registrationData;
 try{
     registrationData = webAuthnManager.parse(registrationRequest);
@@ -100,9 +99,9 @@ byte[] tokenBindingId = null /* set tokenBindingId */;
 ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
 // expectations
+List<byte[]> allowCredentials = null;
 boolean userVerificationRequired = true;
 boolean userPresenceRequired = true;
-List<String> expectedExtensionIds = Collections.emptyList();
 
 Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
 
@@ -119,9 +118,9 @@ AuthenticationParameters authenticationParameters =
         new AuthenticationParameters(
                 serverProperty,
                 authenticator,
+                allowCredentials,
                 userVerificationRequired,
-                userPresenceRequired,
-                expectedExtensionIds
+                userPresenceRequired
         );
 
 AuthenticationData authenticationData;

--- a/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
@@ -113,7 +113,6 @@ public class WebAuthnManagerSample {
         List<byte[]> allowCredentials = null;
         boolean userVerificationRequired = true;
         boolean userPresenceRequired = true;
-        List<String> expectedExtensionIds = Collections.emptyList();
 
         Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
 


### PR DESCRIPTION
RegistrationParameters's constructor accepts expectedExtensionIds is removed at https://github.com/webauthn4j/webauthn4j/pull/344/files#diff-abcde77c9698cbdec05c5532218a2cad603868308f22302eb6026a35eb1a2a8bL36