### PR TITLE
Align AuthenticationDataValidator logic to WebAuthn Level3 working draft1

### DIFF
--- a/docs/src/reference/asciidoc/en/deep-dive.adoc
+++ b/docs/src/reference/asciidoc/en/deep-dive.adoc
@@ -1,19 +1,19 @@
 == Deep-Dive
 
-=== Representation of an authenticator
+=== Representation of a credential record
 
-WebAuthn4j provides `Authenticator` interface as a representation of an authenticator.
+WebAuthn4j provides `CredentialRecord` interface as a representation of a credential record.
 
-On registering the authenticator, you need to persist its representation by creating the instance implementing
-`Authenticator` interface in your application manner because it is used afterwards on authentication verification.
+On registering the credential, you need to persist its representation by creating the instance implementing
+`CredentialRecord` interface in your application manner because it is used afterwards on authentication verification.
 It might be better to use credentialId as a search key for this persisted instance.
 
-You can freely enhance the class implementing `Authenticator` interface in order to meet your application's requirements.
-For example, you can add the field for your application's user to identify the authenticator.
+You can freely enhance the class implementing `CredentialRecord` interface in order to meet your application's requirements.
+For example, you can add a field like `name` to identify the credential.
 
-=== Authenticator serialization and deserialization
+=== CredentialRecord serialization and deserialization
 
-While it is application's responsibility to serialize `Authenticator` instance at registration, WebAuthn4J provides an utility class to serialize or deserialize members of `Authenticator` class.
+While it is application's responsibility to serialize `CredentialRecord` instance at registration, WebAuthn4J provides an utility class to serialize or deserialize fields of `CredentialRecord` class.
 Please use them for implementing persistence in your application.
 
 ==== attestedCredentialData
@@ -110,8 +110,8 @@ String serializedClientExtensions = objectConverter.getJsonConverter().writeValu
 
 === DCAppleDevice serialization and deserialization
 
-When you use `webauthn4j-device-check`, you need to persist `DCAppleDevice` instead of `Authenticator` interface between attestation and assertion.
-In general, you can serialize and deserialize it by the method explained in <<Authenticator serialization and deserialization>>, but `ObjectConverter` must be the one with `DeviceCheckCBORModule` registered.
+When you use `webauthn4j-device-check`, you need to persist `DCAppleDevice` instead of `CredentialRecord` interface between attestation and assertion.
+In general, you can serialize and deserialize it by the method explained in <<CredentialRecord serialization and deserialization>>, but `ObjectConverter` must be the one with `DeviceCheckCBORModule` registered.
 A `ObjectConverter` with a `DeviceCheckCBORModule` can be obtained with `DeviceCheckManager.createObjectConverter` static method.
 
 === Using FIDO CTAP2 Security key in your own application other than WebAuthn

--- a/docs/src/reference/asciidoc/en/quick-start.adoc
+++ b/docs/src/reference/asciidoc/en/quick-start.adoc
@@ -35,16 +35,16 @@ It is the application's responsibility for retaining the issued Challenge.
 If you do not want to use it please specify `null`.
 
 If validation fails, an exception inheriting `ValidationException` is thrown.
-If validation succeeds, please create an `Authenticator` instance from the returned value and persist it to the database or something in your application manner.
+If validation succeeds, please create an `CredentialRecord` instance from the returned value and persist it to the database or something in your application manner.
 The instance is required at the time of authentication.
-For more details about `Authenticator` serialization, please refer <<./deep-dive.adoc#authenticator-serialization-and-deserialization,Authenticator serialization and deserialization>>.
+For more details about `CredentialRecord` serialization, please refer <<./deep-dive.adoc#CredentialRecord-serialization-and-deserialization,CredentialRecord serialization and deserialization>>.
 
 [source,java]
 ----
 // Client properties
 byte[] attestationObject = null /* set attestationObject */;
 byte[] clientDataJSON = null /* set clientDataJSON */;
-String clientExtensionJSON = null;  /* set clientExtensionJSON */
+String clientExtensionJSON = null;  /* set clientExtensionJSON */;
 Set<String> transports = null /* set transports */;
 
 // Server properties
@@ -61,27 +61,30 @@ boolean userPresenceRequired = true;
 RegistrationRequest registrationRequest = new RegistrationRequest(attestationObject, clientDataJSON, clientExtensionJSON, transports);
 RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, userVerificationRequired, userPresenceRequired);
 RegistrationData registrationData;
-try {
+try{
     registrationData = webAuthnManager.parse(registrationRequest);
-} catch (DataConversionException e) {
+}
+catch (DataConversionException e){
     // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
     throw e;
 }
-try {
+try{
     webAuthnManager.validate(registrationData, registrationParameters);
-} catch (ValidationException e) {
+}
+catch (ValidationException e){
     // If you would like to handle WebAuthn data validation error, please catch ValidationException
     throw e;
 }
 
-// please persist Authenticator object, which will be used in the authentication process.
-Authenticator authenticator =
-        new AuthenticatorImpl( // You may create your own Authenticator implementation to save friendly authenticator name
-                registrationData.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),
-                registrationData.getAttestationObject().getAttestationStatement(),
-                registrationData.getAttestationObject().getAuthenticatorData().getSignCount()
-        );
-save(authenticator); // please persist authenticator in your manner
+// please persist CredentialRecord object, which will be used in the authentication process.
+CredentialRecord credentialRecord =
+    new CredentialRecordImpl( // You may create your own CredentialRecord implementation to save friendly authenticator name
+        registrationData.getAttestationObject(),
+        registrationData.getCollectedClientData(),
+        registrationData.getClientExtensions(),
+        registrationData.getTransports()
+    );
+save(credentialRecord); // please persist credentialRecord in your manner
 ----
 
 === WebAuthn Assertion verification
@@ -118,7 +121,7 @@ List<byte[]> allowCredentials = null;
 boolean userVerificationRequired = true;
 boolean userPresenceRequired = true;
 
-Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
+CredentialRecord credentialRecord = load(credentialId); // please load authenticator object persisted in the registration process in your manner
 
 AuthenticationRequest authenticationRequest =
         new AuthenticationRequest(
@@ -132,7 +135,7 @@ AuthenticationRequest authenticationRequest =
 AuthenticationParameters authenticationParameters =
         new AuthenticationParameters(
                 serverProperty,
-                authenticator,
+                credentialRecord,
                 allowCredentials,
                 userVerificationRequired,
                 userPresenceRequired
@@ -174,7 +177,7 @@ If you are using maven, add the `webauthn4j-device-check` as a dependency in thi
 <properties>
   ...
   <!-- Use the latest version whenever possible. -->
-  <webauthn4j.version>0.13.0.RELEASE</webauthn4j.version>
+  <webauthn4j.version>0.24.0.RELEASE</webauthn4j.version>
   ...
 </properties>
 

--- a/docs/src/reference/asciidoc/ja/deep-dive.adoc
+++ b/docs/src/reference/asciidoc/ja/deep-dive.adoc
@@ -1,14 +1,14 @@
 == 詳細
 
-=== 認証デバイスの表現
+=== クレデンシャル情報の表現
 
-認証デバイスを表現するインタフェースとして、 `Authenticator` インタフェースが存在します。 登録時に、 `RegistrationData` クラスが含む値を用いて `Authenticator` インタフェースの インスタンスを作成し、アプリケーションの作法に則り永続化してください。認証時の検証に必要となります。 なお、永続化する際は、検索する際の利便性を考え、credentialIdをキーに永続化すると良いでしょう。
-`Authenticator` インタフェースの実装クラスを設計する際は、アプリケーションの要件に合わせて拡張すると良いでしょう。 典型的には、 `Authenticator` をユーザーが識別するための名前フィールドの追加などが考えられるでしょう。
+クレデンシャル情報を表現するインタフェースとして、 `CredentialRecord` インタフェースが存在します。 登録時に、 `RegistrationData` クラスが含む値を用いて `CredentialRecord` インタフェースの インスタンスを作成し、アプリケーションの作法に則り永続化してください。認証時の検証に必要となります。 なお、永続化する際は、検索する際の利便性を考え、credentialIdをキーに永続化すると良いでしょう。
+`CredentialRecord` インタフェースの実装クラスを設計する際は、アプリケーションの要件に合わせて拡張すると良いでしょう。 典型的には、 `CredentialRecord` をユーザーが識別するための名前フィールドの追加などが考えられるでしょう。
 
-=== Authenticatorのシリアライズ、デシリアライズ
+=== CredentialRecordのシリアライズ、デシリアライズ
 
-認証デバイスの登録時、`Authenticator` のインスタンスをデータベース等に永続化し、認証時に利用できるようにするのはアプリケーションの責務ですが、
-`Authenticator` を構成する各メンバをシリアライズ、デシリアライズする際に使用できるクラスをWebAuthn4Jでは用意しています。 アプリケーションで永続化を実装する際の補助としてご利用ください。
+認証デバイスの登録時、`CredentialRecord` のインスタンスをデータベース等に永続化し、認証時に利用できるようにするのはアプリケーションの責務ですが、
+`CredentialRecord` を構成する各メンバをシリアライズ、デシリアライズする際に使用できるクラスをWebAuthn4Jでは用意しています。 アプリケーションで永続化を実装する際の補助としてご利用ください。
 
 ==== attestedCredentialData
 
@@ -101,7 +101,7 @@ String serializedClientExtensions = objectConverter.getJsonConverter().writeValu
 
 === DCAppleDeviceのシリアライズ、デシリアライズ
 
-webauthn4j-device-checkでは、`Authenticator` インタフェースの代わりに、`DCAppleDevice` インタフェースを実装したクラスを、構成証明の検証時とアサーションの検証時の間で永続化する必要があります。 概ね<<Authenticatorのシリアライズ、デシリアライズ>>で解説した方法でシリアライズ、デシリアライズが可能ですが、一点気を付ける必要がある点として、 webauthn4j-device-check独自のクラス（例えば `AppleAppAttestAttestationStatement` )のシリアライズ、デシリアライズを行う為に、
+webauthn4j-device-checkでは、`CredentialRecord` インタフェースの代わりに、`DCAppleDevice` インタフェースを実装したクラスを、構成証明の検証時とアサーションの検証時の間で永続化する必要があります。 概ね<<CredentialRecordのシリアライズ、デシリアライズ>>で解説した方法でシリアライズ、デシリアライズが可能ですが、一点気を付ける必要がある点として、 webauthn4j-device-check独自のクラス（例えば `AppleAppAttestAttestationStatement` )のシリアライズ、デシリアライズを行う為に、
 `ObjectConverter` は `DeviceCheckCBORModule` が登録されたものを使用する必要があります。
 `DeviceCheckCBORModule` が登録された`ObjectConverter` は `DeviceCheckManager#createObjectConverter` で得ることが出来ます。
 

--- a/docs/src/reference/asciidoc/ja/quick-start.adoc
+++ b/docs/src/reference/asciidoc/ja/quick-start.adoc
@@ -20,7 +20,7 @@ WebAuthn認証は、事前に認証デバイスで生成した公開鍵をサー
 - `challenge` には発行したChallengeを指定して下さい。`challenge` はリプレイ攻撃を防ぐ為のパラメータです。 サーバー側で `challenge` としてランダムなバイト列を生成し、フロントエンド側でWebAuthn JS APIを実行する際に パラメータとして指定して署名対象に含め、サーバー側で値の一致を検証することで、リプレイ攻撃からユーザーを防御することが出来ます。 発行したChallengeを検証時まで永続化しておくのはアプリケーション側の責務です。セッションなどに格納しておくと良いでしょう。
 - `tokenBindingId` はToken bindingを利用する場合のパラメータです。利用しない場合は `null` を指定してください。
 
-検証に失敗した場合は、 `ValidationException` のサブクラスの例外が発生します。 検証に成功した場合は、返却された値から `Authenticator` インスタンスを作成し、データベース等へアプリケーション側で永続化して下さい。 認証時に必要となります。永続化方法について詳しくは、 <<./deep-dive.adoc#authenticatorのシリアライズデシリアライズ,Authenticatorのシリアライズ、デシリアライズ>> を参照して下さい。
+検証に失敗した場合は、 `ValidationException` のサブクラスの例外が発生します。 検証に成功した場合は、返却された値から `CredentialRecord` インスタンスを作成し、データベース等へアプリケーション側で永続化して下さい。 認証時に必要となります。永続化方法について詳しくは、 <<./deep-dive.adoc#CredentialRecordのシリアライズデシリアライズ,CredentialRecordのシリアライズ、デシリアライズ>> を参照して下さい。
 
 [source,java]
 ----
@@ -59,14 +59,15 @@ catch (ValidationException e){
     throw e;
 }
 
-// please persist Authenticator object, which will be used in the authentication process.
-Authenticator authenticator =
-        new AuthenticatorImpl( // You may create your own Authenticator implementation to save friendly authenticator name
-                registrationData.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),
-                registrationData.getAttestationObject().getAttestationStatement(),
-                registrationData.getAttestationObject().getAuthenticatorData().getSignCount()
-        );
-save(authenticator); // please persist authenticator in your manner
+// please persist CredentialRecord object, which will be used in the authentication process.
+CredentialRecord credentialRecord =
+    new CredentialRecordImpl( // You may create your own CredentialRecord implementation to save friendly authenticator name
+        registrationData.getAttestationObject(),
+        registrationData.getCollectedClientData(),
+        registrationData.getClientExtensions(),
+        registrationData.getTransports()
+    );
+save(credentialRecord); // please persist credentialRecord in your manner
 ----
 
 ==== WebAuthnアサーションの検証
@@ -76,9 +77,9 @@ save(authenticator); // please persist authenticator in your manner
 
 `userVerificationRequired` は認証デバイスでのユーザーの本人性確認が必要かどうかを示すパラメータです。 パスワード＋認証デバイスの「所持」による多要素認証を行う場合は、パスワードで本人性の確認が出来ている為 `false` で良いでしょう。 パスワードレス認証として、認証デバイスによる本人性確認＋「所持」による多要素認証を行う場合は `true` を指定する必要があります。
 
-`Authenticator` には、登録時に永続化した `Authenticator` を指定してください。
+`authenticator` には、登録時に永続化した `CredentialRecord` を指定してください。
 
-検証に失敗した場合は、 `ValidationException` のサブクラスの例外が発生します。 検証後は、 `Authenticator` に紐づけたカウンタの値を更新してください。カウンタは万が一認証デバイスのクローンが 作成された場合を検知するために用意されています。カウンタについて詳しくは
+検証に失敗した場合は、 `ValidationException` のサブクラスの例外が発生します。 検証後は、 `CredentialRecord` に紐づけたcounterおよび、uvInitialized、backedUpの値を更新してください。カウンタは万が一認証デバイスのクローンが 作成された場合を検知するために用意されています。カウンタについて詳しくは
 https://www.w3.org/TR/webauthn-1/#sign-counter[WebAuthnの仕様書のカウンタの項] を参照して下さい。
 
 [source,java]
@@ -103,7 +104,7 @@ List<byte[]> allowCredentials = null;
 boolean userVerificationRequired = true;
 boolean userPresenceRequired = true;
 
-Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
+CredentialRecord credentialRecord = load(credentialId); // please load authenticator object persisted in the registration process in your manner
 
 AuthenticationRequest authenticationRequest =
         new AuthenticationRequest(
@@ -117,24 +118,22 @@ AuthenticationRequest authenticationRequest =
 AuthenticationParameters authenticationParameters =
         new AuthenticationParameters(
                 serverProperty,
-                authenticator,
+                credentialRecord,
                 allowCredentials,
                 userVerificationRequired,
                 userPresenceRequired
         );
 
 AuthenticationData authenticationData;
-try{
+try {
     authenticationData = webAuthnManager.parse(authenticationRequest);
-}
-catch (DataConversionException e){
+} catch (DataConversionException e) {
     // If you would like to handle WebAuthn data structure parse error, please catch DataConversionException
     throw e;
 }
-try{
+try {
     webAuthnManager.validate(authenticationData, authenticationParameters);
-}
-catch (ValidationException e){
+} catch (ValidationException e) {
     // If you would like to handle WebAuthn data validation error, please catch ValidationException
     throw e;
 }
@@ -158,7 +157,7 @@ Apple App Attestの検証用クラスは、WebAuthn4J本体(webauthn4j-core)と�
 <properties>
   ...
   <!-- Use the latest version whenever possible. -->
-  <webauthn4j.version>0.13.0.RELEASE</webauthn4j.version>
+  <webauthn4j.version>0.24.0.RELEASE</webauthn4j.version>
   ...
 </properties>
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/Authenticator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/Authenticator.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.authenticator;
 
+import com.webauthn4j.credential.CredentialRecord;
 import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
@@ -25,7 +26,9 @@ import java.util.Set;
 
 /**
  * Core interface that represents WebAuthn authenticator
+ * @deprecated {@link Authenticator} is deprecated since WebAuthn Level3 added new fields to the credential record. To represent WebAuthn Level3 credential record, new {@link CredentialRecord} interface is introduced. Please upgrade from {@link Authenticator} interface to {@link CredentialRecord} interface. {@link Authenticator} interface will be removed in the future version.
  */
+@Deprecated
 public interface Authenticator extends CoreAuthenticator {
 
     /**

--- a/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/AuthenticatorImpl.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/AuthenticatorImpl.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.authenticator;
 
+import com.webauthn4j.credential.CredentialRecordImpl;
 import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.RegistrationData;
 import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
@@ -34,8 +35,10 @@ import java.util.Set;
 
 /**
  * An {@link Authenticator} implementation
+ * @deprecated {@link AuthenticatorImpl} is deprecated since WebAuthn Level3 added new fields to the credential record. To represent WebAuthn Level3 credential record, new {@link CredentialRecordImpl} class is introduced. Please upgrade from {@link AuthenticatorImpl} class to {@link CredentialRecordImpl} class. {@link AuthenticatorImpl} class will be removed in the future version.
  */
 @SuppressWarnings("ConstantConditions")
+@Deprecated
 public class AuthenticatorImpl extends CoreAuthenticatorImpl implements Authenticator {
 
     //~ Instance fields ================================================================================================

--- a/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/CoreAuthenticator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/CoreAuthenticator.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.authenticator;
 
+import com.webauthn4j.credential.CoreCredentialRecord;
 import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
@@ -25,8 +26,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 
 /**
- * Core interface that represents WebAuthn authenticator
+ * Core interface that represents WebAuthn authenticator (credential record)
+ * @deprecated {@link CoreAuthenticator} is deprecated since WebAuthn Level3 added new fields to the credential record. To represent WebAuthn Level3 credential record, new {@link CoreCredentialRecord} interface is introduced. Please upgrade from {@link CoreAuthenticator} interface to {@link CoreCredentialRecord} interface. {@link CoreAuthenticator} interface will be removed in the future version.
  */
+@Deprecated
 public interface CoreAuthenticator {
 
     /**

--- a/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/CoreAuthenticatorImpl.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/authenticator/CoreAuthenticatorImpl.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.authenticator;
 
+import com.webauthn4j.credential.CoreCredentialRecordImpl;
 import com.webauthn4j.data.CoreRegistrationData;
 import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
@@ -30,7 +31,9 @@ import java.util.Objects;
 
 /**
  * An {@link CoreAuthenticator} implementation
+ * @deprecated {@link CoreAuthenticatorImpl} is deprecated since WebAuthn Level3 added new fields to the credential record. To represent WebAuthn Level3 credential record, new {@link CoreCredentialRecordImpl} class is introduced. Please upgrade from {@link CoreAuthenticatorImpl} class to {@link CoreCredentialRecordImpl} class. {@link CoreAuthenticatorImpl} class will be removed in the future version.
  */
+@Deprecated
 public class CoreAuthenticatorImpl implements CoreAuthenticator {
 
     private static final String ATTESTED_CREDENTIAL_DATA_MUST_NOT_BE_NULL = "attestedCredentialData must not be null";

--- a/webauthn4j-core/src/main/java/com/webauthn4j/credential/CoreCredentialRecord.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/credential/CoreCredentialRecord.java
@@ -1,0 +1,36 @@
+package com.webauthn4j.credential;
+
+import com.webauthn4j.authenticator.CoreAuthenticator;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Core interface that represents FIDO CTAP2 credential record (Passkey credential record without ClientData)
+ */
+public interface CoreCredentialRecord extends CoreAuthenticator {
+
+    /**
+     *
+     * @return `true` if UV is initialized. `false` if UV is not initialized. `null` if no data is available(for backward compatibility).
+     */
+    @Nullable Boolean isUvInitialized() ;
+
+
+    void setUvInitialized(boolean value);
+
+    /**
+     *
+     * @return `true` if it is backup eligible. `false` if it is NOT backup eligible. `null` if no data is available(for backward compatibility).
+     */
+    @Nullable Boolean isBackupEligible();
+
+    void setBackupEligible(boolean value);
+
+    /**
+     *
+     * @return `true` if it is backed up. `false` if it is NOT backed up. `null` if no data is available(for backward compatibility).
+     */
+    @Nullable Boolean isBackedUp();
+
+    void setBackedUp(boolean value);
+
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/credential/CoreCredentialRecordImpl.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/credential/CoreCredentialRecordImpl.java
@@ -1,0 +1,92 @@
+package com.webauthn4j.credential;
+
+import com.webauthn4j.authenticator.CoreAuthenticatorImpl;
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
+import com.webauthn4j.data.attestation.statement.AttestationStatement;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+
+import static com.webauthn4j.data.attestation.authenticator.AuthenticatorData.*;
+
+public class CoreCredentialRecordImpl extends CoreAuthenticatorImpl implements CoreCredentialRecord{
+
+    private Boolean uvInitialized;
+    private Boolean backupEligible;
+    private Boolean backupState;
+
+    public CoreCredentialRecordImpl(@NonNull AttestationObject attestationObject){
+
+        //As AttestationObject always have AttestedCredentialData, this won't be an issue
+        //noinspection DataFlowIssue
+        super(attestationObject.getAuthenticatorData().getAttestedCredentialData(),
+                attestationObject.getAttestationStatement(),
+                attestationObject.getAuthenticatorData().getSignCount(),
+                attestationObject.getAuthenticatorData().getExtensions());
+        this.uvInitialized = (attestationObject.getAuthenticatorData().getFlags() & BIT_UV) != 0;
+        this.backupEligible = (attestationObject.getAuthenticatorData().getFlags() & BIT_BE) != 0;
+        this.backupState = (attestationObject.getAuthenticatorData().getFlags() & BIT_BS) != 0;
+    }
+
+    public CoreCredentialRecordImpl(
+            @Nullable AttestationStatement attestationStatement,
+            @Nullable Boolean uvInitialized,
+            @Nullable Boolean backupEligible,
+            @Nullable Boolean backupState,
+            long counter,
+            @NonNull AttestedCredentialData attestedCredentialData,
+            @Nullable AuthenticationExtensionsAuthenticatorOutputs<RegistrationExtensionAuthenticatorOutput> authenticatorExtensions) {
+        super(attestedCredentialData, attestationStatement, counter, authenticatorExtensions);
+        this.uvInitialized = uvInitialized;
+        this.backupEligible = backupEligible;
+        this.backupState = backupState;
+    }
+
+    @Override
+    public Boolean isUvInitialized() {
+        return this.uvInitialized;
+    }
+
+    @Override
+    public void setUvInitialized(boolean value) {
+        this.uvInitialized = value;
+    }
+
+    @Override
+    public Boolean isBackupEligible() {
+        return this.backupEligible;
+    }
+
+    @Override
+    public void setBackupEligible(boolean value) {
+        this.backupEligible = value;
+    }
+
+    @Override
+    public Boolean isBackedUp() {
+        return this.backupState;
+    }
+
+    @Override
+    public void setBackedUp(boolean value) {
+        this.backupState = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        CoreCredentialRecordImpl that = (CoreCredentialRecordImpl) o;
+        return Objects.equals(uvInitialized, that.uvInitialized) && Objects.equals(backupEligible, that.backupEligible) && Objects.equals(backupState, that.backupState);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), uvInitialized, backupEligible, backupState);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/credential/CredentialRecord.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/credential/CredentialRecord.java
@@ -1,0 +1,18 @@
+package com.webauthn4j.credential;
+
+import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.data.client.CollectedClientData;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Core interface that represents Passkey(WebAuthn) credential record
+ */
+public interface CredentialRecord extends CoreCredentialRecord, Authenticator {
+
+    /**
+     *
+     * @return client data. `null` if no data is available(for backward compatibility).
+     */
+    @Nullable CollectedClientData getClientData();
+
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/credential/CredentialRecordImpl.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/credential/CredentialRecordImpl.java
@@ -1,0 +1,80 @@
+package com.webauthn4j.credential;
+
+import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
+import com.webauthn4j.data.attestation.statement.AttestationStatement;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class CredentialRecordImpl extends CoreCredentialRecordImpl implements CredentialRecord{
+
+    private final CollectedClientData clientData;
+    private final AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions;
+    private final Set<AuthenticatorTransport> transports;
+
+    public CredentialRecordImpl(
+            @NonNull AttestationObject attestationObject,
+            @Nullable CollectedClientData clientData,
+            @Nullable AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions,
+            @Nullable Set<AuthenticatorTransport> transports) {
+        super(attestationObject);
+        this.clientData = clientData;
+        this.clientExtensions = clientExtensions;
+        this.transports = transports;
+    }
+
+    public CredentialRecordImpl(
+            @NonNull AttestationStatement attestationStatement,
+            @Nullable Boolean uvInitialized,
+            @Nullable Boolean backupEligible,
+            @Nullable Boolean backupState,
+            long counter,
+            @NonNull AttestedCredentialData attestedCredentialData,
+            @NonNull AuthenticationExtensionsAuthenticatorOutputs<RegistrationExtensionAuthenticatorOutput> authenticatorExtensions,
+            @Nullable CollectedClientData clientData,
+            @Nullable AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions,
+            @Nullable Set<AuthenticatorTransport> transports) {
+        super(attestationStatement, uvInitialized, backupEligible, backupState, counter, attestedCredentialData, authenticatorExtensions);
+        this.clientData = clientData;
+        this.clientExtensions = clientExtensions;
+        this.transports = transports;
+    }
+
+    @Override
+    public @Nullable CollectedClientData getClientData() {
+        return clientData;
+    }
+
+    @Override
+    public @Nullable AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> getClientExtensions() {
+        return clientExtensions;
+    }
+
+    @Override
+    public @Nullable Set<AuthenticatorTransport> getTransports() {
+        return transports;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        CredentialRecordImpl that = (CredentialRecordImpl) o;
+        return Objects.equals(clientData, that.clientData) && Objects.equals(clientExtensions, that.clientExtensions) && Objects.equals(transports, that.transports);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), clientData, clientExtensions, transports);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
@@ -94,30 +94,34 @@ public class AuthenticationDataValidator {
         validateCredentialId(credentialId, allowCredentials);
 
         //spec| Step6
-        //spec| Identify the user being authenticated and verify that this user is the owner of the public key credential source credentialSource identified by credential.id:
-        //spec| - If the user was identified before the authentication ceremony was initiated,
-        //spec|   verify that the identified user is the owner of credentialSource. If credential.response.userHandle is present,
-        //spec|   let userHandle be its value. Verify that userHandle also maps to the same user.
+        //spec| Identify the user being authenticated and let credentialRecord be the credential record for the credential:
+        //spec| - If the user was identified before the authentication ceremony was initiated, e.g., via a username or cookie,
+        //spec|   verify that the identified user account contains a credential record whose id equals credential.rawId.
+        //spec|   Let credentialRecord be that credential record. If response.userHandle is present,
+        //spec|   verify that it equals the user handle of the user account.
         //spec| - If the user was not identified before the authentication ceremony was initiated,
-        //spec|   verify that response.userHandle is present, and that the user identified by this value is the owner of credentialSource.
+        //spec|   verify that response.userHandle is present. Verify that the user account identified by response.userHandle
+        //spec|   contains a credential record whose id equals credential.rawId. Let credentialRecord be that credential record.
         //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
 
-        //spec| Step7
+        // Step7-8 is missing in the WebAuthn Level3 specification
+
+        //spec| Step9
         //spec| Using credential’s id attribute (or the corresponding rawId, if base64url encoding is inappropriate for your use case),
         //spec| look up the corresponding credential public key and let credentialPublicKey be that credential public key.
         //      (This step is out of WebAuthn4J scope. It's caller's responsibility.)
 
-        //spec| Step8
+        //spec| Step9
         //spec| Let cData, aData and sig denote the value of credential’s response's clientDataJSON, authenticatorData,
         //spec| and signature respectively.
         byte[] cData = authenticationData.getCollectedClientDataBytes();
         byte[] aData = authenticationData.getAuthenticatorDataBytes();
 
-        //spec| Step9
+        //spec| Step10
         //spec| Let JSONtext be the result of running UTF-8 decode on the value of cData.
         //      (This step is done on caller.)
 
-        //spec| Step10
+        //spec| Step11
         //spec| Let C, the client data claimed as used for the signature, be the result of running an implementation-specific JSON parser on JSONtext.
         //      (In the spec, claimed as "C", but use "collectedClientData" here)
         CollectedClientData collectedClientData = authenticationData.getCollectedClientData();
@@ -137,47 +141,69 @@ public class AuthenticationDataValidator {
                 serverProperty, authenticator
         );
 
-        //spec| Step11
+        //spec| Step12
         //spec| Verify that the value of C.type is the string webauthn.get.
         if (!Objects.equals(collectedClientData.getType(), ClientDataType.WEBAUTHN_GET)) {
             throw new InconsistentClientDataTypeException("ClientData.type must be 'get' on authentication, but it isn't.");
         }
 
-        //spec| Step12
-        //spec| Verify that the value of C.challenge matches the challenge that was sent to the authenticator in
-        //spec| the PublicKeyCredentialRequestOptions passed to the get() call.
+        //spec| Step13
+        //spec| Verify that the value of C.challenge equals the base64url encoding of options.challenge.
         challengeValidator.validate(collectedClientData, serverProperty);
 
-        //spec| Step13
-        //spec| Verify that the value of C.origin matches the Relying Party's origin.
+        //spec| Step14
+        //spec| Verify that the value of C.origin is an origin expected by the Relying Party. See §13.4.9 Validating the origin of a credential for guidance.
         originValidator.validate(authenticationObject);
 
         // Verify cross origin, which is not defined in the spec
         validateClientDataCrossOrigin(collectedClientData);
 
-        //spec| Step14
+        //spec| Step15
+        //spec| If C.topOrigin is present:
+        //spec| - Verify that the Relying Party expects this credential to be used within an iframe that is not same-origin with its ancestors.
+        //spec| - Verify that the value of C.topOrigin matches the origin of a page that the Relying Party expects to be sub-framed within.
+        //spec|   See §13.4.9 Validating the origin of a credential for guidance.
+        //TODO: Once Chrome starts supporting topOrigin, implement topOrigin verification
+
+        //spec| (Level2) Step14 (Kept for backward compatibility)
         //spec| Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over
         //spec| which the attestation was obtained. If Token Binding was used on that TLS connection,
         //spec| also verify that C.tokenBinding.id matches the base64url encoding of the Token Binding ID for the connection.
         tokenBindingValidator.validate(collectedClientData.getTokenBinding(), serverProperty.getTokenBindingId());
 
-        //spec| Step15
+        //spec| Step16
         //spec| Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID expected by the Relying Party.
         rpIdHashValidator.validate(authenticatorData.getRpIdHash(), serverProperty);
 
-        //spec| Step16
-        //spec| Verify that the User Present bit of the flags in authData is set.
+        //spec| Step17
+        //spec| Verify that the UP bit of the flags in authData is set.
         if (authenticationParameters.isUserPresenceRequired() && !authenticatorData.isFlagUP()) {
             throw new UserNotPresentException("Validator is configured to check user present, but UP flag in authenticatorData is not set.");
         }
 
-        //spec| Step17
-        //spec| If user verification is required for this assertion, verify that the User Verified bit of the flags in authData is set.
+        //spec| Step18
+        //spec| Determine whether user verification is required for this assertion.
+        //spec| User verification SHOULD be required if, and only if, options.userVerification is set to required.
+        //spec| If user verification was determined to be required, verify that the UV bit of the flags in authData is set.
+        //spec| Otherwise, ignore the value of the UV flag.
         if (authenticationParameters.isUserVerificationRequired() && !authenticatorData.isFlagUV()) {
             throw new UserNotVerifiedException("Validator is configured to check user verified, but UV flag in authenticatorData is not set.");
         }
 
-        //spec| Step18
+        //spec| Step19
+        //spec| If the BE bit of the flags in authData is not set, verify that the BS bit is not set.
+        //TODO
+
+        //spec| Step20
+        //spec| If the credential backup state is used as part of Relying Party business logic or policy,
+        //spec| let currentBe and currentBs be the values of the BE and BS bits, respectively, of the flags in authData.
+        //spec| Compare currentBe and currentBs with credentialRecord.backupEligible and credentialRecord.backupState:
+        //spec| - If credentialRecord.backupEligible is set, verify that currentBe is set.
+        //spec| - If credentialRecord.backupEligible is not set, verify that currentBe is not set.
+        //spec| - Apply Relying Party policy, if any.
+        //TODO
+
+        //spec| Step21
         //spec| Verify that the values of the client extension outputs in clientExtensionResults and the authenticator
         //spec| extension outputs in the extensions in authData are as expected, considering the client extension input
         //spec| values that were given as the extensions option in the get() call. In particular, any extension identifier
@@ -188,41 +214,62 @@ public class AuthenticationDataValidator {
         clientExtensionValidator.validate(clientExtensions);
         authenticatorExtensionValidator.validate(authenticationExtensionsAuthenticatorOutputs);
 
-        //spec| Step19
+        //spec| Step22
         //spec| Let hash be the result of computing a hash over the cData using SHA-256.
-        //spec| Step20
-        //spec| Using the credential public key, validate that sig is a valid signature over
-        //spec| the binary concatenation of the authenticatorData and the hash of the collectedClientData.
+        //spec| Step23
+        //spec| Using credentialRecord.publicKey, verify that sig is a valid signature over the binary concatenation of authData and hash.
         assertionSignatureValidator.validate(authenticationData, authenticator.getAttestedCredentialData().getCOSEKey());
 
-        //spec| Step21
-        //spec| Let storedSignCount be the stored signature counter value associated with credential.id.
-        //spec| If authData.signCount is nonzero or storedSignCount is nonzero, then run the following sub-step:
+        //spec| Step24
+        //spec| If authData.signCount is nonzero or credentialRecord.signCount is nonzero, then run the following sub-step:
         long presentedSignCount = authenticatorData.getSignCount();
         long storedSignCount = authenticator.getCounter();
         if (presentedSignCount > 0 || storedSignCount > 0) {
             //spec| If authData.signCount is
-            //spec| greater than storedSignCount:
+            //spec| greater than credentialRecord.signCount:
             if (presentedSignCount > storedSignCount) {
 
-                //spec| Update storedSignCount to be the value of authData.signCount.
-                //      (caller need to update the signature counter value based on the value set in the Authenticator instance)
+                //spec| The signature counter is valid.
                 authenticator.setCounter(presentedSignCount);
             }
-            //spec| less than or equal to storedSignCount:
-            //spec| This is a signal that the authenticator may be cloned, i.e. at least two copies of the credential private key may exist and are being used in parallel.
+            //spec| less than or equal to credentialRecord.signCount:
+            //spec| This is a signal that the authenticator may be cloned,
+            //spec| i.e. at least two copies of the credential private key may exist and are being used in parallel.
             //spec| Relying Parties should incorporate this information into their risk scoring.
-            //spec| Whether the Relying Party updates storedSignCount in this case, or not, or fails the authentication ceremony or not, is Relying Party-specific.
+            //spec| Whether the Relying Party updates credentialRecord.signCount below in this case, or not, or
+            //spec| fails the authentication ceremony or not, is Relying Party-specific.
             else {
                 maliciousCounterValueHandler.maliciousCounterValueDetected(authenticationObject);
             }
         }
 
+        //spec| Step25
+        //spec| If response.attestationObject is present and the Relying Party wishes to verify the attestation
+        //spec| then perform CBOR decoding on attestationObject to obtain the attestation statement format fmt, and the attestation statement attStmt.
+        //spec| - Verify that the AT bit in the flags field of authData is set, indicating that attested credential data is included.
+        //spec| - Verify that the credentialPublicKey and credentialId fields of the attested credential data in authData match
+        //spec|   credentialRecord.publicKey and credentialRecord.id, respectively.
+        //spec| - Determine the attestation statement format by performing a USASCII case-sensitive match on
+        //spec|   fmt against the set of supported WebAuthn Attestation Statement Format Identifier values.
+        //spec|   An up-to-date list of registered WebAuthn Attestation Statement Format Identifier values is maintained in
+        //spec|   the IANA "WebAuthn Attestation Statement Format Identifiers" registry [IANA-WebAuthn-Registries] established by [RFC8809].
+        //spec| - Verify that attStmt is a correct attestation statement, conveying a valid attestation signature,
+        //spec|   by using the attestation statement format fmt’s verification procedure given attStmt, authData and hash.
+        //TODO
+
+        //spec| Step26
+        //spec| Update credentialRecord with new state values:
+        //spec| - Update credentialRecord.signCount to the value of authData.signCount.
+        //spec| - Update credentialRecord.backupState to the value of currentBs.
+        //spec| - If credentialRecord.uvInitialized is false, update it to the value of the UV bit in the flags in authData. This change SHOULD require authorization by an additional authentication factor equivalent to WebAuthn user verification; if not authorized, skip this step.
+        //spec| - OPTIONALLY, if response.attestationObject is present, update credentialRecord.attestationObject to the value of response.attestationObject and update credentialRecord.attestationClientDataJSON to the value of response.clientDataJSON.
+        //spec| If the Relying Party performs additional security checks beyond these WebAuthn authentication ceremony steps, the above state updates SHOULD be deferred to after those additional checks are completed successfully.
+
         for (CustomAuthenticationValidator customAuthenticationValidator : customAuthenticationValidators) {
             customAuthenticationValidator.validate(authenticationObject);
         }
 
-        //spec| Step18
+        //spec| Step27
         //spec| If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the authentication ceremony.
 
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
@@ -256,7 +256,7 @@ public class AuthenticationDataValidator {
         //spec|   the IANA "WebAuthn Attestation Statement Format Identifiers" registry [IANA-WebAuthn-Registries] established by [RFC8809].
         //spec| - Verify that attStmt is a correct attestation statement, conveying a valid attestation signature,
         //spec|   by using the attestation statement format fmt’s verification procedure given attStmt, authData and hash.
-        //TODO
+        //TODO: Since Step25 is removed in the latest Editor's draft(as of 2024-04-07, see https://github.com/w3c/webauthn/pull/1997), this step is left not implemented. This step need to be removed when the next draft is released.
 
         //spec| Step26
         //spec| Update credentialRecord with new state values:

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/AuthenticationDataValidator.java
@@ -24,6 +24,7 @@ import com.webauthn4j.data.client.ClientDataType;
 import com.webauthn4j.data.client.CollectedClientData;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
 import com.webauthn4j.server.ServerProperty;
@@ -192,7 +193,7 @@ public class AuthenticationDataValidator {
 
         //spec| Step19
         //spec| If the BE bit of the flags in authData is not set, verify that the BS bit is not set.
-        //TODO
+        validateBEBSFlags(authenticatorData);
 
         //spec| Step20
         //spec| If the credential backup state is used as part of Relying Party business logic or policy,
@@ -292,6 +293,12 @@ public class AuthenticationDataValidator {
     void validateAuthenticatorData(@NonNull AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData) {
         if (authenticatorData.getAttestedCredentialData() != null) {
             throw new ConstraintViolationException("attestedCredentialData must be null on authentication");
+        }
+    }
+
+    void validateBEBSFlags(AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData) {
+        if(!authenticatorData.isFlagBE() && authenticatorData.isFlagBS()){
+            throw new IllegalBackupStateException("Backup state bit must not be set if backup eligibility bit is not set");
         }
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/exception/BadBackupEligibleFlagException.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/exception/BadBackupEligibleFlagException.java
@@ -1,0 +1,18 @@
+package com.webauthn4j.validator.exception;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class BadBackupEligibleFlagException extends ValidationException{
+
+    public BadBackupEligibleFlagException(@Nullable String message, @Nullable Throwable cause) {
+        super(message, cause);
+    }
+
+    public BadBackupEligibleFlagException(@Nullable String message) {
+        super(message);
+    }
+
+    public BadBackupEligibleFlagException(@Nullable Throwable cause) {
+        super(cause);
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/credential/CoreCredentialRecordImplTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/credential/CoreCredentialRecordImplTest.java
@@ -1,0 +1,77 @@
+package com.webauthn4j.credential;
+
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.test.TestDataUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CoreCredentialRecordImplTest {
+
+    @Test
+    void constructor_test() {
+        AttestationObject attestationObject = TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement();
+        CoreCredentialRecord coreCredentialRecord = new CoreCredentialRecordImpl(
+                attestationObject.getAttestationStatement(),
+                attestationObject.getAuthenticatorData().isFlagUV(),
+                attestationObject.getAuthenticatorData().isFlagBE(),
+                attestationObject.getAuthenticatorData().isFlagBS(),
+                attestationObject.getAuthenticatorData().getSignCount(),
+                attestationObject.getAuthenticatorData().getAttestedCredentialData(),
+                attestationObject.getAuthenticatorData().getExtensions()
+                );
+
+        assertAll(
+                () -> assertThat(coreCredentialRecord.isUvInitialized()).isEqualTo(attestationObject.getAuthenticatorData().isFlagUV()),
+                () -> assertThat(coreCredentialRecord.isBackupEligible()).isEqualTo(attestationObject.getAuthenticatorData().isFlagBE()),
+                () -> assertThat(coreCredentialRecord.isBackedUp()).isEqualTo(attestationObject.getAuthenticatorData().isFlagBS()),
+                () -> assertThat(coreCredentialRecord.getAttestedCredentialData()).isEqualTo(attestationObject.getAuthenticatorData().getAttestedCredentialData()),
+                () -> assertThat(coreCredentialRecord.getAttestationStatement()).isEqualTo(attestationObject.getAttestationStatement()),
+                () -> assertThat(coreCredentialRecord.getCounter()).isEqualTo(attestationObject.getAuthenticatorData().getSignCount())
+        );
+    }
+
+    @Test
+    void getter_test() {
+        AttestationObject attestationObject = TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement();
+        CoreCredentialRecord coreCredentialRecord = new CoreCredentialRecordImpl(attestationObject);
+
+        assertAll(
+                () -> assertThat(coreCredentialRecord.isUvInitialized()).isEqualTo(attestationObject.getAuthenticatorData().isFlagUV()),
+                () -> assertThat(coreCredentialRecord.isBackupEligible()).isEqualTo(attestationObject.getAuthenticatorData().isFlagBE()),
+                () -> assertThat(coreCredentialRecord.isBackedUp()).isEqualTo(attestationObject.getAuthenticatorData().isFlagBS()),
+                () -> assertThat(coreCredentialRecord.getAttestedCredentialData()).isEqualTo(attestationObject.getAuthenticatorData().getAttestedCredentialData()),
+                () -> assertThat(coreCredentialRecord.getAttestationStatement()).isEqualTo(attestationObject.getAttestationStatement()),
+                () -> assertThat(coreCredentialRecord.getCounter()).isEqualTo(attestationObject.getAuthenticatorData().getSignCount())
+        );
+    }
+
+    @Test
+    void setter_test() {
+        AttestationObject attestationObject = TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement();
+        CoreCredentialRecord coreCredentialRecord = new CoreCredentialRecordImpl(attestationObject);
+
+        coreCredentialRecord.setUvInitialized(true);
+        coreCredentialRecord.setBackupEligible(true);
+        coreCredentialRecord.setBackedUp(true);
+        coreCredentialRecord.setCounter(100);
+
+        assertAll(
+                () -> assertThat(coreCredentialRecord.isUvInitialized()).isTrue(),
+                () -> assertThat(coreCredentialRecord.isBackupEligible()).isTrue(),
+                () -> assertThat(coreCredentialRecord.isBackedUp()).isTrue(),
+                () -> assertThat(coreCredentialRecord.getCounter()).isEqualTo(100)
+        );
+    }
+
+    @Test
+    void equals_hashCode_test() {
+        AttestationObject attestationObject = TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement();
+        CoreCredentialRecord instanceA = new CoreCredentialRecordImpl(attestationObject);
+        CoreCredentialRecord instanceB = new CoreCredentialRecordImpl(attestationObject);
+
+        assertThat(instanceA).isEqualTo(instanceB).hasSameHashCodeAs(instanceB);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/credential/CredentialRecordImplTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/credential/CredentialRecordImplTest.java
@@ -1,0 +1,57 @@
+package com.webauthn4j.credential;
+
+import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.client.ClientDataType;
+import com.webauthn4j.data.client.CollectedClientData;
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
+import com.webauthn4j.test.TestDataUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CredentialRecordImplTest {
+
+    @Test
+    void constructor_test(){
+        AttestationObject attestationObject = TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement();
+        CollectedClientData clientData = TestDataUtil.createClientData(ClientDataType.WEBAUTHN_CREATE);
+        AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
+        Set<AuthenticatorTransport> transports = new HashSet<>();
+        CredentialRecord credentialRecord = new CredentialRecordImpl(
+                attestationObject,
+                clientData,
+                clientExtensions,
+                transports
+        );
+        assertThat(credentialRecord.getClientData()).isEqualTo(clientData);
+        assertThat(credentialRecord.getClientExtensions()).isEqualTo(clientExtensions);
+        assertThat(credentialRecord.getTransports()).isEqualTo(transports);
+    }
+
+    @Test
+    void equals_hashCode_test(){
+        AttestationObject attestationObject = TestDataUtil.createAttestationObjectWithFIDOU2FAttestationStatement();
+        CollectedClientData clientData = TestDataUtil.createClientData(ClientDataType.WEBAUTHN_CREATE);
+        AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
+        Set<AuthenticatorTransport> transports = new HashSet<>();
+        CredentialRecord instanceA = new CredentialRecordImpl(
+                attestationObject,
+                clientData,
+                clientExtensions,
+                transports
+        );
+        CredentialRecord instanceB = new CredentialRecordImpl(
+                attestationObject,
+                clientData,
+                clientExtensions,
+                transports
+        );
+        assertThat(instanceA).isEqualTo(instanceB).hasSameHashCodeAs(instanceB);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationDataValidatorTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/AuthenticationDataValidatorTest.java
@@ -22,9 +22,11 @@ import com.webauthn4j.data.client.ClientDataType;
 import com.webauthn4j.data.client.CollectedClientData;
 import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
 import com.webauthn4j.test.TestDataUtil;
 import com.webauthn4j.validator.exception.ConstraintViolationException;
 import com.webauthn4j.validator.exception.CrossOriginException;
+import com.webauthn4j.validator.exception.IllegalBackupStateException;
 import com.webauthn4j.validator.exception.NotAllowedCredentialIdException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,6 +65,14 @@ class AuthenticationDataValidatorTest {
         AttestedCredentialData attestedCredentialData = mock(AttestedCredentialData.class);
         when(authenticatorData.getAttestedCredentialData()).thenReturn(attestedCredentialData);
         assertThatThrownBy(() -> target.validateAuthenticatorData(authenticatorData)).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void validateBEBSFlags_only_BSFlag_set_test() {
+        AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData = new AuthenticatorData<>(new byte[32], AuthenticatorData.BIT_BS, 0);
+        assertThrows(IllegalBackupStateException.class,
+                () -> target.validateBEBSFlags(authenticatorData)
+        );
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/validator/exception/BadBackupEligibleFlagExceptionTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/validator/exception/BadBackupEligibleFlagExceptionTest.java
@@ -1,0 +1,30 @@
+package com.webauthn4j.validator.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BadBackupEligibleFlagExceptionTest {
+
+    private final RuntimeException cause = new RuntimeException();
+
+    @Test
+    void test() {
+        BadBackupEligibleFlagException exception1 = new BadBackupEligibleFlagException("dummy", cause);
+        BadBackupEligibleFlagException exception2 = new BadBackupEligibleFlagException("dummy");
+        BadBackupEligibleFlagException exception3 = new BadBackupEligibleFlagException(cause);
+
+        assertAll(
+                () -> assertThat(exception1.getMessage()).isEqualTo("dummy"),
+                () -> assertThat(exception1.getCause()).isEqualTo(cause),
+
+                () -> assertThat(exception2.getMessage()).isEqualTo("dummy"),
+                () -> assertThat(exception2.getCause()).isNull(),
+
+                () -> assertThat(exception3.getMessage()).isEqualTo(cause.toString()),
+                () -> assertThat(exception3.getCause()).isEqualTo(cause)
+        );
+    }
+
+}

--- a/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
+++ b/webauthn4j-core/src/test/java/sample/WebAuthnManagerSample.java
@@ -20,6 +20,8 @@ import com.webauthn4j.WebAuthnManager;
 import com.webauthn4j.authenticator.Authenticator;
 import com.webauthn4j.authenticator.AuthenticatorImpl;
 import com.webauthn4j.converter.exception.DataConversionException;
+import com.webauthn4j.credential.CredentialRecord;
+import com.webauthn4j.credential.CredentialRecordImpl;
 import com.webauthn4j.data.*;
 import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
@@ -81,14 +83,15 @@ public class WebAuthnManagerSample {
             throw e;
         }
 
-        // please persist Authenticator object, which will be used in the authentication process.
-        Authenticator authenticator =
-                new AuthenticatorImpl( // You may create your own Authenticator implementation to save friendly authenticator name
-                        registrationData.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),
-                        registrationData.getAttestationObject().getAttestationStatement(),
-                        registrationData.getAttestationObject().getAuthenticatorData().getSignCount()
+        // please persist CredentialRecord object, which will be used in the authentication process.
+        CredentialRecord credentialRecord =
+                new CredentialRecordImpl( // You may create your own CredentialRecord implementation to save friendly authenticator name
+                        registrationData.getAttestationObject(),
+                        registrationData.getCollectedClientData(),
+                        registrationData.getClientExtensions(),
+                        registrationData.getTransports()
                 );
-        save(authenticator); // please persist authenticator in your manner
+        save(credentialRecord); // please persist credentialRecord in your manner
     }
 
 
@@ -113,7 +116,7 @@ public class WebAuthnManagerSample {
         boolean userVerificationRequired = true;
         boolean userPresenceRequired = true;
 
-        Authenticator authenticator = load(credentialId); // please load authenticator object persisted in the registration process in your manner
+        CredentialRecord credentialRecord = load(credentialId); // please load authenticator object persisted in the registration process in your manner
 
         AuthenticationRequest authenticationRequest =
                 new AuthenticationRequest(
@@ -127,7 +130,7 @@ public class WebAuthnManagerSample {
         AuthenticationParameters authenticationParameters =
                 new AuthenticationParameters(
                         serverProperty,
-                        authenticator,
+                        credentialRecord,
                         allowCredentials,
                         userVerificationRequired,
                         userPresenceRequired
@@ -154,12 +157,12 @@ public class WebAuthnManagerSample {
     }
 
 
-    private void save(Authenticator authenticator) {
+    private void save(CredentialRecord credentialRecord) {
         // please persist in your manner
     }
 
-    private Authenticator load(byte[] credentialId) {
-        return null; // please load authenticator in your manner
+    private CredentialRecord load(byte[] credentialId) {
+        return null; // please load credentialRecord in your manner
     }
 
     private void updateCounter(byte[] credentialId, long signCount) {

--- a/webauthn4j-device-check/src/main/java/com/webauthn4j/appattest/authenticator/DCAppleDevice.java
+++ b/webauthn4j-device-check/src/main/java/com/webauthn4j/appattest/authenticator/DCAppleDevice.java
@@ -16,7 +16,7 @@
 
 package com.webauthn4j.appattest.authenticator;
 
-import com.webauthn4j.authenticator.CoreAuthenticator;
+import com.webauthn4j.credential.CoreCredentialRecord;
 
-public interface DCAppleDevice extends CoreAuthenticator {
+public interface DCAppleDevice extends CoreCredentialRecord {
 }

--- a/webauthn4j-device-check/src/main/java/com/webauthn4j/appattest/authenticator/DCAppleDeviceImpl.java
+++ b/webauthn4j-device-check/src/main/java/com/webauthn4j/appattest/authenticator/DCAppleDeviceImpl.java
@@ -16,7 +16,7 @@
 
 package com.webauthn4j.appattest.authenticator;
 
-import com.webauthn4j.authenticator.CoreAuthenticatorImpl;
+import com.webauthn4j.credential.CoreCredentialRecordImpl;
 import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs;
@@ -24,13 +24,13 @@ import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenti
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class DCAppleDeviceImpl extends CoreAuthenticatorImpl implements DCAppleDevice {
+public class DCAppleDeviceImpl extends CoreCredentialRecordImpl implements DCAppleDevice {
 
     public DCAppleDeviceImpl(
             @NonNull AttestedCredentialData attestedCredentialData,
             @Nullable AttestationStatement attestationStatement,
             long counter,
             @Nullable AuthenticationExtensionsAuthenticatorOutputs<RegistrationExtensionAuthenticatorOutput> authenticatorExtensions) {
-        super(attestedCredentialData, attestationStatement, counter, authenticatorExtensions);
+        super(attestationStatement, null, null, null, counter, attestedCredentialData, authenticatorExtensions);
     }
 }


### PR DESCRIPTION
New `CredentialRecord` interface and `CoreCredentialRecord` interface are introduced.
To represent Passkeys credentials, these interfaces have additional methods in addition to the legacy `Authenticator` and `CoreAuthenticator` interface.

**Breaking change**

* `Authenticator` interface and `CoreAuthenticator` interface which represent a legacy webauthn credential are now deprecated
* Since these `Authenticator` interfaces will be removed in the future version, please update your concrete classes to implement the `CredentialRecord` interface instead of the `Authenticator` interface.
