### PR TITLE
Fix URL for Apache license

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ subprojects {
                     licenses {
                         license {
                             name = 'The Apache Software License, Version 2.0'
-                            url = 'http://www.apache.org/license/LICENSE-2.0.txt'
+                            url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                             distribution = 'repo'
                         }
                     }


### PR DESCRIPTION
`http://www.apache.org/license/LICENSE-2.0.txt` returns 404, the correct link is `https://www.apache.org/licenses/LICENSE-2.0.txt`