### PR TITLE
Change the default serialization method of byte arrays from Base64 to Base64Url

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/ByteArrayBase64ConverterModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/ByteArrayBase64ConverterModule.java
@@ -1,0 +1,13 @@
+package com.webauthn4j.converter.jackson;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.webauthn4j.converter.jackson.deserializer.json.ByteArrayBase64Deserializer;
+import com.webauthn4j.converter.jackson.serializer.json.ByteArrayBase64Serializer;
+
+public class ByteArrayBase64ConverterModule extends SimpleModule {
+
+    public ByteArrayBase64ConverterModule(){
+        this.addDeserializer(byte[].class, new ByteArrayBase64Deserializer());
+        this.addSerializer(new ByteArrayBase64Serializer());
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
@@ -52,6 +52,8 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(UserVerificationMethod.class, new UserVerificationMethodFromLongDeserializer());
         this.addDeserializer(X509Certificate.class, new X509CertificateDeserializer());
 
+        this.addDeserializer(byte[].class, new ByteArrayBase64UrlDeserializer());
+
         this.addSerializer(AttachmentHint.class, new AttachmentHintToLongSerializer());
         this.addSerializer(AuthenticatorAttestationType.class, new AuthenticatorAttestationTypeToIntSerializer());
         this.addSerializer(AuthenticationAlgorithm.class, new AuthenticationAlgorithmToIntSerializer());
@@ -65,6 +67,8 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addSerializer(TransactionConfirmationDisplay.class, new TransactionConfirmationDisplayToIntSerializer());
         this.addSerializer(UserVerificationMethod.class, new UserVerificationMethodToLongSerializer());
         this.addSerializer(new X509CertificateSerializer());
+
+        this.addSerializer(new ByteArrayBase64UrlSerializer());
 
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/ByteArrayBase64Deserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/ByteArrayBase64Deserializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.webauthn4j.util.Base64Util;
+
+import java.io.IOException;
+
+public class ByteArrayBase64Deserializer extends StdDeserializer<byte[]> {
+
+    public ByteArrayBase64Deserializer() {
+        super(byte[].class);
+    }
+
+    @Override
+    public byte[] deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return Base64Util.decode(p.getValueAsString());
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/ByteArrayBase64UrlDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/ByteArrayBase64UrlDeserializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.webauthn4j.util.Base64UrlUtil;
+
+import java.io.IOException;
+
+public class ByteArrayBase64UrlDeserializer extends StdDeserializer<byte[]> {
+
+    public ByteArrayBase64UrlDeserializer() {
+        super(byte[].class);
+    }
+
+    @Override
+    public byte[] deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return Base64UrlUtil.decode(p.getValueAsString());
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/ByteArrayBase64Serializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/ByteArrayBase64Serializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.serializer.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.webauthn4j.util.Base64Util;
+
+import java.io.IOException;
+
+public class ByteArrayBase64Serializer extends StdSerializer<byte[]> {
+
+    public ByteArrayBase64Serializer() {
+        super(byte[].class);
+    }
+
+    @Override
+    public void serialize(byte[] value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeString(Base64Util.encodeToString(value));
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/ByteArrayBase64UrlSerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/ByteArrayBase64UrlSerializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.serializer.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.webauthn4j.util.Base64UrlUtil;
+
+import java.io.IOException;
+
+public class ByteArrayBase64UrlSerializer extends StdSerializer<byte[]> {
+
+    public ByteArrayBase64UrlSerializer() {
+        super(byte[].class);
+    }
+
+    @Override
+    public void serialize(byte[] value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeString(Base64UrlUtil.encodeToString(value));
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/CborConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/CborConverter.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
@@ -47,6 +48,10 @@ public class CborConverter {
         AssertUtil.isTrue(cborMapper.getFactory() instanceof CBORFactory, "factory of cborMapper must be CBORFactory.");
 
         this.cborMapper = cborMapper;
+    }
+
+    public void registerModule(Module module){
+        this.cborMapper.registerModule(module);
     }
 
     public @Nullable <T> T readValue(@NotNull byte[] src, @NotNull Class<T> valueType) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/JsonConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/JsonConverter.java
@@ -19,6 +19,7 @@ package com.webauthn4j.converter.util;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
@@ -46,6 +47,10 @@ public class JsonConverter {
         AssertUtil.isTrue(!(jsonMapper.getFactory() instanceof CBORFactory), "factory of jsonMapper must be JsonFactory.");
 
         this.jsonMapper = jsonMapper;
+    }
+
+    public void registerModule(Module module){
+        this.jsonMapper.registerModule(module);
     }
 
     public <T> @Nullable T readValue(@NotNull String src, @NotNull Class<T> valueType) {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/ByteArrayBase64ConverterModuleTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/ByteArrayBase64ConverterModuleTest.java
@@ -1,0 +1,30 @@
+package com.webauthn4j.converter.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.webauthn4j.converter.util.JsonConverter;
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.attestation.statement.TPMISTAttest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class ByteArrayBase64ConverterModuleTest {
+
+    @Test
+    void test(){
+        ObjectConverter objectConverter = new ObjectConverter();
+        JsonConverter jsonConverter = objectConverter.getJsonConverter();
+        jsonConverter.registerModule(new ByteArrayBase64ConverterModule());
+
+        byte[] source = TPMISTAttest.TPM_ST_ATTEST_CERTIFY.getValue();
+        String sourceString = "{\"tpmi_st_attest\":\"" + Base64.getEncoder().encodeToString(source) + "\"}";
+        assertThatCode(() -> jsonConverter.readValue(sourceString, TestDTO.class)).doesNotThrowAnyException();
+    }
+
+    static class TestDTO {
+        @JsonProperty("tpmi_st_attest")
+        public TPMISTAttest tpmiStAttest;
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
@@ -19,9 +19,8 @@ package com.webauthn4j.data.attestation.statement;
 import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.util.Base64UrlUtil;
 import org.junit.jupiter.api.Test;
-
-import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -45,14 +44,14 @@ class TPMGeneratedTest {
     @Test
     void fromString_test() {
         byte[] source = new byte[]{(byte) 0xff, (byte) 0x54, (byte) 0x43, (byte) 0x47};
-        TestDTO dto = jsonConverter.readValue("{\"tpm_generated\":\"" + Base64.getEncoder().encodeToString(source) + "\"}", TestDTO.class);
+        TestDTO dto = jsonConverter.readValue("{\"tpm_generated\":\"" + Base64UrlUtil.encodeToString(source) + "\"}", TestDTO.class);
         assertThat(dto.tpm_generated).isEqualTo(TPMGenerated.TPM_GENERATED_VALUE);
     }
 
     @Test
     void fromString_test_with_invalid_value() {
         byte[] source = new byte[]{(byte) 0xff, (byte) 0xaa, (byte) 0xff, (byte) 0xaa};
-        String sourceString = "{\"tpm_generated\":\"" + Base64.getEncoder().encodeToString(source) + "\"}";
+        String sourceString = "{\"tpm_generated\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
         assertThrows(DataConversionException.class,
                 () -> jsonConverter.readValue(sourceString, TestDTO.class)
         );

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
@@ -19,9 +19,8 @@ package com.webauthn4j.data.attestation.statement;
 import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.JsonConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.util.Base64UrlUtil;
 import org.junit.jupiter.api.Test;
-
-import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -56,14 +55,14 @@ class TPMISTAttestTest {
     @Test
     void fromString_test() {
         byte[] source = new byte[]{(byte) 0x80, (byte) 0x17};
-        TestDTO dto = jsonConverter.readValue("{\"tpmi_st_attest\":\"" + Base64.getEncoder().encodeToString(source) + "\"}", TestDTO.class);
+        TestDTO dto = jsonConverter.readValue("{\"tpmi_st_attest\":\"" + Base64UrlUtil.encodeToString(source) + "\"}", TestDTO.class);
         assertThat(dto.tpmi_st_attest).isEqualTo(TPMISTAttest.TPM_ST_ATTEST_CERTIFY);
     }
 
     @Test
     void fromString_test_with_invalid_value() {
         byte[] source = new byte[]{(byte) 0xff, (byte) 0xaa};
-        String sourceString = "{\"tpmi_st_attest\":\"" + Base64.getEncoder().encodeToString(source) + "\"}";
+        String sourceString = "{\"tpmi_st_attest\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
         assertThrows(DataConversionException.class,
                 () -> jsonConverter.readValue(sourceString, TestDTO.class)
         );


### PR DESCRIPTION
Since WebAuthn Level3 working draft uses base64url encoding for byte array encoding, we change the default byte array encoding method from base64 to base64url.

If you use WebAuthn4J for JSON serialization, you may be impacted by this breaking change.
You can still decode base64 encoded WebAuthn data types by registering `ByteArrayBase64ConverterModule` to your `JsonConverter` in this way:
```
        ObjectConverter objectConverter = new ObjectConverter();
        JsonConverter jsonConverter = objectConverter.getJsonConverter();
        jsonConverter.registerModule(new ByteArrayBase64ConverterModule());

        jsonConverter.readValue(sourceString, YourDTO.class);
```