### PR TITLE
Add PublicKeyCredentialRequestOptions.hints

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/PublicKeyCredentialRequestOptions.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/PublicKeyCredentialRequestOptions.java
@@ -46,6 +46,7 @@ public class PublicKeyCredentialRequestOptions {
     private final String rpId;
     private final List<PublicKeyCredentialDescriptor> allowCredentials;
     private final UserVerificationRequirement userVerification;
+    private final List<PublicKeyCredentialHints> hints;
     private final AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> extensions;
 
     @JsonCreator
@@ -54,6 +55,7 @@ public class PublicKeyCredentialRequestOptions {
                                              @Nullable @JsonProperty("rpId") String rpId,
                                              @Nullable @JsonProperty("allowCredentials") List<PublicKeyCredentialDescriptor> allowCredentials,
                                              @Nullable @JsonProperty("userVerification") UserVerificationRequirement userVerification,
+                                             @Nullable @JsonProperty("hints") List<PublicKeyCredentialHints> hints,
                                              @Nullable @JsonProperty("extensions") AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> extensions) {
         AssertUtil.notNull(challenge, "challenge must not be null");
         this.challenge = challenge;
@@ -61,7 +63,17 @@ public class PublicKeyCredentialRequestOptions {
         this.rpId = rpId;
         this.allowCredentials = CollectionUtil.unmodifiableList(allowCredentials);
         this.userVerification = userVerification;
+        this.hints = CollectionUtil.unmodifiableList(hints);
         this.extensions = extensions;
+    }
+
+    public PublicKeyCredentialRequestOptions(@NotNull @JsonProperty("challenge") Challenge challenge,
+                                             @Nullable @JsonProperty("timeout") Long timeout,
+                                             @Nullable @JsonProperty("rpId") String rpId,
+                                             @Nullable @JsonProperty("allowCredentials") List<PublicKeyCredentialDescriptor> allowCredentials,
+                                             @Nullable @JsonProperty("userVerification") UserVerificationRequirement userVerification,
+                                             @Nullable @JsonProperty("extensions") AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> extensions) {
+        this(challenge, timeout, rpId, allowCredentials, userVerification, null, extensions);
     }
 
     public @NotNull Challenge getChallenge() {
@@ -84,6 +96,10 @@ public class PublicKeyCredentialRequestOptions {
         return userVerification;
     }
 
+    public @Nullable List<PublicKeyCredentialHints> getHints() {
+        return hints;
+    }
+
     public @Nullable AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> getExtensions() {
         return extensions;
     }
@@ -93,12 +109,12 @@ public class PublicKeyCredentialRequestOptions {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PublicKeyCredentialRequestOptions that = (PublicKeyCredentialRequestOptions) o;
-        return Objects.equals(challenge, that.challenge) && Objects.equals(timeout, that.timeout) && Objects.equals(rpId, that.rpId) && Objects.equals(allowCredentials, that.allowCredentials) && Objects.equals(userVerification, that.userVerification) && Objects.equals(extensions, that.extensions);
+        return Objects.equals(challenge, that.challenge) && Objects.equals(timeout, that.timeout) && Objects.equals(rpId, that.rpId) && Objects.equals(allowCredentials, that.allowCredentials) && Objects.equals(userVerification, that.userVerification) && Objects.equals(hints, that.hints) && Objects.equals(extensions, that.extensions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(challenge, timeout, rpId, allowCredentials, userVerification, extensions);
+        return Objects.hash(challenge, timeout, rpId, allowCredentials, userVerification, hints, extensions);
     }
 
     @Override
@@ -109,6 +125,7 @@ public class PublicKeyCredentialRequestOptions {
                 ", rpId=" + rpId +
                 ", allowCredentials=" + allowCredentials +
                 ", userVerification=" + userVerification +
+                ", hints=" + hints +
                 ", extensions=" + extensions +
                 ')';
     }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialRequestOptionsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialRequestOptionsTest.java
@@ -19,6 +19,7 @@ package com.webauthn4j.data;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.util.CollectionUtil;
+import com.webauthn4j.util.HexUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -49,6 +50,7 @@ class PublicKeyCredentialRequestOptionsTest {
                 rpId,
                 allowCredentials,
                 UserVerificationRequirement.DISCOURAGED,
+                Collections.singletonList(PublicKeyCredentialHints.HYBRID),
                 null
         );
 
@@ -58,9 +60,36 @@ class PublicKeyCredentialRequestOptionsTest {
                 () -> assertThat(credentialRequestOptions.getRpId()).isEqualTo(rpId),
                 () -> assertThat(credentialRequestOptions.getAllowCredentials()).isEqualTo(allowCredentials),
                 () -> assertThat(credentialRequestOptions.getUserVerification()).isEqualTo(UserVerificationRequirement.DISCOURAGED),
+                () -> assertThat(credentialRequestOptions.getHints()).containsExactly(PublicKeyCredentialHints.HYBRID),
                 () -> assertThat(credentialRequestOptions.getExtensions()).isNull()
         );
     }
+
+    @Test
+    void toString_test(){
+        String rpId = "example.com";
+        long timeout = 0;
+        Challenge challenge = new DefaultChallenge(HexUtil.decode("F23EA2BB2171405F8E13D60358B2D683"));
+        byte[] credentialId = new byte[32];
+        List<PublicKeyCredentialDescriptor> allowCredentials = Collections.singletonList(
+                new PublicKeyCredentialDescriptor(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        credentialId,
+                        CollectionUtil.unmodifiableSet(AuthenticatorTransport.USB, AuthenticatorTransport.NFC, AuthenticatorTransport.BLE)
+                )
+        );
+        PublicKeyCredentialRequestOptions target = new PublicKeyCredentialRequestOptions(
+                challenge,
+                timeout,
+                rpId,
+                allowCredentials,
+                UserVerificationRequirement.REQUIRED,
+                Collections.singletonList(PublicKeyCredentialHints.CLIENT_DEVICE),
+                null
+        );
+        assertThat(target).hasToString("PublicKeyCredentialRequestOptions(challenge=F23EA2BB2171405F8E13D60358B2D683, timeout=0, rpId=example.com, allowCredentials=[PublicKeyCredentialDescriptor(type=public-key, id=0000000000000000000000000000000000000000000000000000000000000000, transports=[usb, nfc, ble])], userVerification=required, hints=[client-device], extensions=null)");
+    }
+
 
     @Test
     void equals_hashCode_test() {
@@ -82,6 +111,7 @@ class PublicKeyCredentialRequestOptionsTest {
                 rpId,
                 allowCredentials,
                 UserVerificationRequirement.DISCOURAGED,
+                Collections.singletonList(PublicKeyCredentialHints.CLIENT_DEVICE),
                 null
         );
         PublicKeyCredentialRequestOptions instanceB = new PublicKeyCredentialRequestOptions(
@@ -90,6 +120,7 @@ class PublicKeyCredentialRequestOptionsTest {
                 rpId,
                 allowCredentials,
                 UserVerificationRequirement.DISCOURAGED,
+                Collections.singletonList(PublicKeyCredentialHints.CLIENT_DEVICE),
                 null
         );
 


### PR DESCRIPTION
https://github.com/webauthn4j/webauthn4j/pull/956 added `PublicKeyCredentialCreationOptions.hints`, but `PublicKeyCredentialRequestOptions.hints` was left untouched. This pull-request adds `PublicKeyCredentialRequestOptions.hints`.