### PR TITLE
Set target version Java 11 again

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,11 @@ subprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "jacoco")
 
+    java {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11 // Although webauthn4j uses JDK 15+ API to support EdDSA, keep target version 11 to support JDK11 users who don't need EdDSA.
+    }
+
     tasks.test {
         useJUnitPlatform()
         testLogging {


### PR DESCRIPTION
Adresses #1042
From 0.28.0.RELEASE, target version configuration was dropped by mistake. This commit adds it again