### PR TITLE
Remove dependabot for 0.24.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,3 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-
-# For 0.24.x branch
-
-  - package-ecosystem: gradle
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    target-branch: 0.24.x


### PR DESCRIPTION
as we no longer support 0.24.x