### PR TITLE
Redesign HttpClient to align with HttpAsyncClient

### DIFF
--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/HttpClient.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/HttpClient.java
@@ -26,7 +26,7 @@ import java.io.InputStream;
  */
 public interface HttpClient {
 
-    @NotNull String fetch(@NotNull String uri) throws MDSException;
+    @NotNull Response fetch(@NotNull String uri) throws MDSException;
 
     class Response{
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/SimpleHttpClient.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/SimpleHttpClient.java
@@ -19,13 +19,10 @@ package com.webauthn4j.metadata;
 import com.webauthn4j.metadata.exception.MDSException;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Tiny implementation of {@link HttpClient}. If you prefer more powerful one, implement {@link HttpClient} with
@@ -34,7 +31,7 @@ import java.nio.charset.StandardCharsets;
 public class SimpleHttpClient implements HttpClient {
 
     @Override
-    public @NotNull String fetch(@NotNull String url) {
+    public @NotNull Response fetch(@NotNull String url) {
         try {
             URL fetchUrl = new URL(url);
             HttpURLConnection urlConnection = (HttpURLConnection) fetchUrl.openConnection();
@@ -45,15 +42,7 @@ public class SimpleHttpClient implements HttpClient {
 
             if (status == HttpURLConnection.HTTP_OK) {
                 InputStream inputStream = urlConnection.getInputStream();
-                BufferedInputStream bis = new BufferedInputStream(inputStream);
-                ByteArrayOutputStream buf = new ByteArrayOutputStream();
-                int result = bis.read();
-                while (result != -1) {
-                    buf.write((byte) result);
-                    result = bis.read();
-                }
-                bis.close();
-                return buf.toString(StandardCharsets.UTF_8);
+                return new Response(status, inputStream);
             }
             throw new MDSException("failed to fetch " + url);
         } catch (IOException e) {

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/FidoMDS3MetadataBLOBProviderTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/FidoMDS3MetadataBLOBProviderTest.java
@@ -24,10 +24,11 @@ import com.webauthn4j.util.CertificateUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.cert.TrustAnchor;
@@ -74,10 +75,10 @@ class FidoMDS3MetadataBLOBProviderTest {
 
         @BeforeEach
         void setup() throws IOException, URISyntaxException {
-            HttpClient httpClient = mock(HttpClient.class);
+            HttpClient httpClient = mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
             Path blobJwtPath = Paths.get(ClassLoader.getSystemResource("integration/component/blob.jwt").toURI()); //expired blob
-            String blobJwtString = Files.readString(blobJwtPath);
-            when(httpClient.fetch(FidoMDS3MetadataBLOBProvider.DEFAULT_BLOB_ENDPOINT)).thenReturn(blobJwtString);
+            FileInputStream inputStream = new FileInputStream(blobJwtPath.toFile());
+            when(httpClient.fetch(FidoMDS3MetadataBLOBProvider.DEFAULT_BLOB_ENDPOINT).getBody()).thenReturn(inputStream);
             target = new FidoMDS3MetadataBLOBProvider(new ObjectConverter(), FidoMDS3MetadataBLOBProvider.DEFAULT_BLOB_ENDPOINT, httpClient, Collections.singleton(new TrustAnchor(rootCertificate, null)));
         }
 


### PR DESCRIPTION
Redesign `HttpClient#fetch` to return `Response` instead of `String`. 

This only affects if you have implemented your own `HttpClient`. `HttpAsyncClient` is not affected.