### PR TITLE
Deprecate AuthenticationParameters constructor that takes Authenticator as a parameter

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
@@ -17,6 +17,9 @@
 package com.webauthn4j.data;
 
 import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.authenticator.CoreAuthenticator;
+import com.webauthn4j.credential.CoreCredentialRecord;
+import com.webauthn4j.credential.CredentialRecord;
 import com.webauthn4j.server.ServerProperty;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,20 +31,49 @@ public class AuthenticationParameters extends CoreAuthenticationParameters {
     /**
      * {@link AuthenticationParameters} constructor
      * @param serverProperty server property
+     * @param credentialRecord credential record
      * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
      * @param userVerificationRequired true if user verification is required. Otherwise, false
      * @param userPresenceRequired true if user presence is required. Otherwise, false
      */
-    public AuthenticationParameters(@NotNull ServerProperty serverProperty, @NotNull Authenticator authenticator, @Nullable List<byte[]> allowCredentials, boolean userVerificationRequired, boolean userPresenceRequired) {
-        super(serverProperty, authenticator, allowCredentials, userVerificationRequired, userPresenceRequired);
+    public AuthenticationParameters(@NotNull ServerProperty serverProperty, @NotNull CredentialRecord credentialRecord, @Nullable List<byte[]> allowCredentials, boolean userVerificationRequired, boolean userPresenceRequired) {
+        super(serverProperty, credentialRecord, allowCredentials, userVerificationRequired, userPresenceRequired);
     }
 
     /**
      * {@link AuthenticationParameters} constructor
      * @param serverProperty server property
+     * @param credentialRecord credential record
      * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
      * @param userVerificationRequired true if user verification is required. Otherwise, false
      */
+    public AuthenticationParameters(@NotNull ServerProperty serverProperty, @NotNull CredentialRecord credentialRecord, @Nullable List<byte[]> allowCredentials, boolean userVerificationRequired) {
+        super(serverProperty, credentialRecord, allowCredentials, userVerificationRequired);
+    }
+
+    /**
+     * @deprecated Deprecated as {@link Authenticator} is replaced with {@link CredentialRecord}
+     * {@link AuthenticationParameters} constructor
+     * @param serverProperty server property
+     * @param authenticator authenticator
+     * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     * @param userPresenceRequired true if user presence is required. Otherwise, false
+     */
+    @Deprecated
+    public AuthenticationParameters(@NotNull ServerProperty serverProperty, @NotNull Authenticator authenticator, @Nullable List<byte[]> allowCredentials, boolean userVerificationRequired, boolean userPresenceRequired) {
+        super(serverProperty, authenticator, allowCredentials, userVerificationRequired, userPresenceRequired);
+    }
+
+    /**
+     * @deprecated Deprecated as {@link Authenticator} is replaced with {@link CredentialRecord}
+     * {@link AuthenticationParameters} constructor
+     * @param serverProperty server property
+     * @param authenticator authenticator
+     * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     */
+    @Deprecated
     public AuthenticationParameters(@NotNull ServerProperty serverProperty, @NotNull Authenticator authenticator, @Nullable List<byte[]> allowCredentials, boolean userVerificationRequired) {
         super(serverProperty, authenticator, allowCredentials, userVerificationRequired);
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreAuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/CoreAuthenticationParameters.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.data;
 
 import com.webauthn4j.authenticator.CoreAuthenticator;
+import com.webauthn4j.credential.CoreCredentialRecord;
 import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.util.CollectionUtil;
@@ -39,10 +40,57 @@ public class CoreAuthenticationParameters {
     /**
      * {@link CoreAuthenticationParameters} constructor
      * @param serverProperty server property
+     * @param coreCredentialRecord core credential record
      * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
      * @param userVerificationRequired true if user verification is required. Otherwise, false
      * @param userPresenceRequired true if user presence is required. Otherwise, false
      */
+    public CoreAuthenticationParameters(
+            @NotNull CoreServerProperty serverProperty,
+            @NotNull CoreCredentialRecord coreCredentialRecord,
+            @Nullable List<byte[]> allowCredentials,
+            boolean userVerificationRequired,
+            boolean userPresenceRequired) {
+        AssertUtil.notNull(serverProperty, "serverProperty must not be null");
+        AssertUtil.notNull(coreCredentialRecord, "coreCredentialRecord must not be null");
+        this.serverProperty = serverProperty;
+        this.authenticator = coreCredentialRecord;
+        this.allowCredentials = CollectionUtil.unmodifiableList(allowCredentials);
+        this.userVerificationRequired = userVerificationRequired;
+        this.userPresenceRequired = userPresenceRequired;
+    }
+
+    /**
+     * {@link CoreAuthenticationParameters} constructor
+     * @param serverProperty server property
+     * @param coreCredentialRecord core credential record
+     * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     */
+    public CoreAuthenticationParameters(
+            @NotNull CoreServerProperty serverProperty,
+            @NotNull CoreCredentialRecord coreCredentialRecord,
+            @Nullable List<byte[]> allowCredentials,
+            boolean userVerificationRequired) {
+        this(
+                serverProperty,
+                coreCredentialRecord,
+                allowCredentials,
+                userVerificationRequired,
+                true
+        );
+    }
+
+    /**
+     * @deprecated Deprecated as {@link CoreAuthenticator} is replaced with {@link CoreCredentialRecord}
+     * {@link CoreAuthenticationParameters} constructor
+     * @param serverProperty server property
+     * @param authenticator authenticator
+     * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
+     * @param userVerificationRequired true if user verification is required. Otherwise, false
+     * @param userPresenceRequired true if user presence is required. Otherwise, false
+     */
+    @Deprecated
     public CoreAuthenticationParameters(
             @NotNull CoreServerProperty serverProperty,
             @NotNull CoreAuthenticator authenticator,
@@ -59,11 +107,14 @@ public class CoreAuthenticationParameters {
     }
 
     /**
+     * @deprecated Deprecated as {@link CoreAuthenticator} is replaced with {@link CoreCredentialRecord}
      * {@link CoreAuthenticationParameters} constructor
      * @param serverProperty server property
+     * @param authenticator authenticator
      * @param allowCredentials allowed credentialId list. If all credentialId(s) are allowed, pass null
      * @param userVerificationRequired true if user verification is required. Otherwise, false
      */
+    @Deprecated
     public CoreAuthenticationParameters(
             @NotNull CoreServerProperty serverProperty,
             @NotNull CoreAuthenticator authenticator,

--- a/webauthn4j-core/src/test/java/com/webauthn4j/authenticator/AuthenticatorImplTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/authenticator/AuthenticatorImplTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.authenticator;
 
+import com.webauthn4j.credential.CredentialRecord;
 import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.RegistrationData;
 import com.webauthn4j.data.attestation.AttestationObject;
@@ -44,7 +45,7 @@ class AuthenticatorImplTest {
     void constructor_test() {
         AttestedCredentialData attestedCredentialData = TestDataUtil.createAttestedCredentialData();
         AttestationStatement attestationStatement = TestAttestationStatementUtil.createFIDOU2FAttestationStatement();
-        Authenticator authenticator = TestDataUtil.createAuthenticator(attestedCredentialData, attestationStatement);
+        CredentialRecord authenticator = TestDataUtil.createCredentialRecord(attestedCredentialData, attestationStatement);
 
         assertAll(
                 () -> assertThat(authenticator.getAttestedCredentialData()).isEqualTo(attestedCredentialData),
@@ -112,8 +113,8 @@ class AuthenticatorImplTest {
 
     @Test
     void equals_hashCode_test() {
-        Authenticator authenticatorA = TestDataUtil.createAuthenticator();
-        Authenticator authenticatorB = TestDataUtil.createAuthenticator();
+        Authenticator authenticatorA = TestDataUtil.createCredentialRecord();
+        Authenticator authenticatorB = TestDataUtil.createCredentialRecord();
 
         assertAll(
                 () -> assertThat(authenticatorA).isEqualTo(authenticatorB),

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticationParametersTest.java
@@ -16,7 +16,7 @@
 
 package com.webauthn4j.data;
 
-import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.credential.CredentialRecord;
 import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
@@ -39,7 +39,7 @@ class AuthenticationParametersTest {
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
-        Authenticator authenticator = mock(Authenticator.class);
+        CredentialRecord authenticator = mock(CredentialRecord.class);
 
         // expectations
         boolean userVerificationRequired = true;
@@ -68,7 +68,7 @@ class AuthenticationParametersTest {
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
-        Authenticator authenticator = mock(Authenticator.class);
+        CredentialRecord authenticator = mock(CredentialRecord.class);
 
         AuthenticationParameters instance =
                 new AuthenticationParameters(
@@ -95,7 +95,7 @@ class AuthenticationParametersTest {
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
-        Authenticator authenticator = mock(Authenticator.class);
+        CredentialRecord authenticator = mock(CredentialRecord.class);
 
         // expectations
         boolean userVerificationRequired = true;
@@ -115,10 +115,10 @@ class AuthenticationParametersTest {
 
     @Test
     void constructor_with_serverProperty_null_test() {
-        Authenticator authenticator = TestDataUtil.createAuthenticator();
+        CredentialRecord credentialRecord = TestDataUtil.createCredentialRecord();
         assertThatThrownBy(() -> new AuthenticationParameters(
                 null,
-                authenticator,
+                credentialRecord,
                 null,
                 true,
                 true
@@ -146,7 +146,7 @@ class AuthenticationParametersTest {
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
-        Authenticator authenticator = mock(Authenticator.class);
+        CredentialRecord authenticator = mock(CredentialRecord.class);
 
         // expectations
         boolean userVerificationRequired = true;
@@ -184,7 +184,7 @@ class AuthenticationParametersTest {
         byte[] tokenBindingId = null /* set tokenBindingId */;
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
 
-        Authenticator authenticator = mock(Authenticator.class);
+        CredentialRecord authenticator = mock(CredentialRecord.class);
 
         // expectations
         boolean userVerificationRequired = true;

--- a/webauthn4j-core/src/test/java/com/webauthn4j/verifier/AuthenticationObjectTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/verifier/AuthenticationObjectTest.java
@@ -47,7 +47,7 @@ class AuthenticationObjectTest {
         byte[] authenticatorDataBytes = new AuthenticatorDataConverter(objectConverter).convert(authenticatorData);
         AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
-        Authenticator authenticator = TestDataUtil.createAuthenticator();
+        Authenticator authenticator = TestDataUtil.createCredentialRecord();
         AuthenticationObject authenticationObject = new AuthenticationObject(
                 credentialId,
                 authenticatorData,
@@ -81,7 +81,7 @@ class AuthenticationObjectTest {
         byte[] authenticatorDataBytes = new AuthenticatorDataConverter(objectConverter).convert(authenticatorData);
         AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
-        Authenticator authenticator = TestDataUtil.createAuthenticator();
+        Authenticator authenticator = TestDataUtil.createCredentialRecord();
 
         AuthenticationObject instanceA = new AuthenticationObject(
                 credentialId,

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
@@ -27,6 +27,8 @@ import com.webauthn4j.converter.AttestationObjectConverter;
 import com.webauthn4j.converter.AuthenticatorDataConverter;
 import com.webauthn4j.converter.CollectedClientDataConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.credential.CredentialRecord;
+import com.webauthn4j.credential.CredentialRecordImpl;
 import com.webauthn4j.data.AuthenticatorAttestationResponse;
 import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.PublicKeyCredential;
@@ -411,12 +413,12 @@ public class TestDataUtil {
         return new ServerProperty(TestDataUtil.createOrigin(), "example.com", challenge, new byte[32]);
     }
 
-    public static Authenticator createAuthenticator(AttestedCredentialData attestedCredentialData, AttestationStatement attestationStatement) {
-        return new AuthenticatorImpl(attestedCredentialData, attestationStatement, 1);
+    public static CredentialRecord createCredentialRecord(AttestedCredentialData attestedCredentialData, AttestationStatement attestationStatement) {
+        return new CredentialRecordImpl(attestationStatement, false, false, false, 1L, attestedCredentialData, null, null, null, null);
     }
 
-    public static Authenticator createAuthenticator() {
-        return createAuthenticator(TestDataUtil.createAttestedCredentialData(), TestAttestationStatementUtil.createFIDOU2FAttestationStatement());
+    public static CredentialRecord createCredentialRecord() {
+        return createCredentialRecord(TestDataUtil.createAttestedCredentialData(), TestAttestationStatementUtil.createFIDOU2FAttestationStatement());
     }
 
 


### PR DESCRIPTION
to guide library users to pass `CredentialRecord` as a parameter