### PR TITLE
Add "WebAuthn4J Micronaut" to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ to declare nullability explicitly.
 * [WebAuthn4J Spring Security](https://github.com/webauthn4j/webauthn4j-spring-security)
   * extension for spring security to add webauthn(passkey) support
   * maintained by WebAuthn4J project
+* [WebAuthn4J Micronaut](https://github.com/baylorpaul/webauthn4j-micronaut)
+  * Provides passkeys support
+  * Repository includes sample Micronaut server app and sample web app
 * [Eclipse Vert.x Auth](https://github.com/eclipse-vertx/vertx-auth)
 * [OpenAM](https://github.com/OpenIdentityPlatform/OpenAM)
 * [OpenUnison](https://openunison.github.io)


### PR DESCRIPTION
Add "[WebAuthn4J Micronaut](https://github.com/baylorpaul/webauthn4j-micronaut)" to the README. This library provides passkeys support for Micronaut. The repository includes a sample Micronaut server app and a sample web app