### PR TITLE
Add constuctor parameter to DefaultSelfAttestationTrustworthinessVerifier and DefaultSelfAttestationTrustworthinessAsyncVerifier

### DIFF
--- a/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAttestationDataVerifier.java
+++ b/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAttestationDataVerifier.java
@@ -54,9 +54,7 @@ public class DCAttestationDataVerifier extends CoreRegistrationDataVerifier {
     }
 
     private static @NotNull SelfAttestationTrustworthinessVerifier createSelfAttestationTrustWorthinessValidator() {
-        DefaultSelfAttestationTrustworthinessVerifier selfAttestationTrustworthinessValidator = new DefaultSelfAttestationTrustworthinessVerifier();
-        selfAttestationTrustworthinessValidator.setSelfAttestationAllowed(false);
-        return selfAttestationTrustworthinessValidator;
+        return new DefaultSelfAttestationTrustworthinessVerifier(false);
     }
 
     @Override

--- a/webauthn4j-core-async/src/main/java/com/webauthn4j/async/verifier/attestation/trustworthiness/self/DefaultSelfAttestationTrustworthinessAsyncVerifier.java
+++ b/webauthn4j-core-async/src/main/java/com/webauthn4j/async/verifier/attestation/trustworthiness/self/DefaultSelfAttestationTrustworthinessAsyncVerifier.java
@@ -35,6 +35,12 @@ public class DefaultSelfAttestationTrustworthinessAsyncVerifier implements SelfA
 
     private boolean isSelfAttestationAllowed = true;
 
+    public DefaultSelfAttestationTrustworthinessAsyncVerifier() {}
+
+    public DefaultSelfAttestationTrustworthinessAsyncVerifier(boolean isSelfAttestationAllowed) {
+        this.isSelfAttestationAllowed = isSelfAttestationAllowed;
+    }
+
     public CompletionStage<Void> verify(@NotNull CertificateBaseAttestationStatement attestationStatement) {
         return CompletionStageUtil.supply(()->{
             AssertUtil.notNull(attestationStatement, "attestationStatement must not be null");

--- a/webauthn4j-core-async/src/test/java/com/webauthn4j/async/verifier/attestation/trustworthiness/self/DefaultSelfAttestationTrustworthinessAsyncVerifierTest.java
+++ b/webauthn4j-core-async/src/test/java/com/webauthn4j/async/verifier/attestation/trustworthiness/self/DefaultSelfAttestationTrustworthinessAsyncVerifierTest.java
@@ -30,8 +30,7 @@ class DefaultSelfAttestationTrustworthinessAsyncVerifierTest {
 
     @Test
     void verify_test_with_self_attestation_allowed_false() {
-        DefaultSelfAttestationTrustworthinessAsyncVerifier target = new DefaultSelfAttestationTrustworthinessAsyncVerifier();
-        target.setSelfAttestationAllowed(false);
+        DefaultSelfAttestationTrustworthinessAsyncVerifier target = new DefaultSelfAttestationTrustworthinessAsyncVerifier(false);
         PackedAttestationStatement attestationStatement = TestAttestationStatementUtil.createSelfPackedAttestationStatement(COSEAlgorithmIdentifier.ES256, new byte[32]);
 
         assertThatThrownBy(() -> target.verify(attestationStatement).toCompletableFuture().get()).getRootCause().isInstanceOf(SelfAttestationProhibitedException.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/attestation/trustworthiness/self/DefaultSelfAttestationTrustworthinessVerifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/attestation/trustworthiness/self/DefaultSelfAttestationTrustworthinessVerifier.java
@@ -32,6 +32,12 @@ public class DefaultSelfAttestationTrustworthinessVerifier implements SelfAttest
 
     private boolean isSelfAttestationAllowed = true;
 
+    public DefaultSelfAttestationTrustworthinessVerifier() {}
+
+    public DefaultSelfAttestationTrustworthinessVerifier(boolean isSelfAttestationAllowed) {
+        this.isSelfAttestationAllowed = isSelfAttestationAllowed;
+    }
+
     public void verify(@NotNull CertificateBaseAttestationStatement attestationStatement) {
         AssertUtil.notNull(attestationStatement, "attestationStatement must not be null");
         if (!isSelfAttestationAllowed()) {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/verifier/attestation/trustworthiness/self/DefaultSelfAttestationTrustworthinessVerifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/verifier/attestation/trustworthiness/self/DefaultSelfAttestationTrustworthinessVerifierTest.java
@@ -47,8 +47,7 @@ class DefaultSelfAttestationTrustworthinessVerifierTest {
 
     @Test
     void verify_test_with_self_attestation_allowed_false() {
-        DefaultSelfAttestationTrustworthinessVerifier validator = new DefaultSelfAttestationTrustworthinessVerifier();
-        validator.setSelfAttestationAllowed(false);
+        DefaultSelfAttestationTrustworthinessVerifier validator = new DefaultSelfAttestationTrustworthinessVerifier(false);
         PackedAttestationStatement attestationStatement = TestAttestationStatementUtil.createSelfPackedAttestationStatement(COSEAlgorithmIdentifier.ES256, new byte[32]);
 
         assertThrows(SelfAttestationProhibitedException.class,


### PR DESCRIPTION
Add constructor parameter to allow initializing the isSelfAttestationAllowed field in DefaultSelfAttestationTrustworthinessVerifier and DefaultSelfAttestationTrustworthinessAsyncVerifier.

ticket: #1178
