### PR TITLE
Unuseless Codes Have Been Removed and Refactored in `ClientPlatform.processRegistrationExtensions()` Method

### DIFF
--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/client/ClientPlatform.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/client/ClientPlatform.java
@@ -125,12 +125,8 @@ public class ClientPlatform {
 
         AuthenticationExtensionsClientOutputs.BuilderForRegistration builder = new AuthenticationExtensionsClientOutputs.BuilderForRegistration();
         extensions.getKeys().forEach((key) -> {
-            switch (key) {
-                case CredentialPropertiesExtensionClientOutput.ID:
-                    builder.setCredProps(new CredentialPropertiesOutput(true));
-                    break;
-                default:
-                    //nop
+            if (key.equals(CredentialPropertiesExtensionClientOutput.ID)) {
+                builder.setCredProps(new CredentialPropertiesOutput(true));
             }
         });
         return builder.build();


### PR DESCRIPTION
During refactoring, I identified several pieces of unused code in `ClientPlatform.java`:
- An unused `Map<String, RegistrationExtensionClientOutput>` instance was being created but never used.
- Unnecessary imports (`HashMap`, `Map`) remained in the class.
- A verbose switch block was used only to handle a single known key, which was replaced with a simpler conditional check.

These changes remove dead code, simplify the logic, and improve overall readability and maintainability.