### PR TITLE
Add ClientCapability enum (WebAuthn Level 3)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/ClientCapability.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/ClientCapability.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.webauthn4j.util.AssertUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * This enumeration defines the capabilities that a WebAuthn Client can provide.
+ * These values are returned by the PublicKeyCredential.getClientCapabilities() static method.
+ *
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#enumdef-clientcapability">
+ * §5.8.7. Client Capability Enumeration (enum ClientCapability)</a>
+ */
+public class ClientCapability {
+
+    /**
+     * The WebAuthn Client is capable of conditional mediation for registration ceremonies.
+     */
+    public static final ClientCapability CONDITIONAL_CREATE = new ClientCapability("conditionalCreate");
+
+    /**
+     * The WebAuthn Client is capable of conditional mediation for authentication ceremonies.
+     */
+    public static final ClientCapability CONDITIONAL_GET = new ClientCapability("conditionalGet");
+
+    /**
+     * The WebAuthn Client supports hybrid transport.
+     */
+    public static final ClientCapability HYBRID_TRANSPORT = new ClientCapability("hybridTransport");
+
+    /**
+     * The WebAuthn Client has a passkey platform authenticator available.
+     */
+    public static final ClientCapability PASSKEY_PLATFORM_AUTHENTICATOR = new ClientCapability("passkeyPlatformAuthenticator");
+
+    /**
+     * The WebAuthn Client has a user-verifying platform authenticator available.
+     */
+    public static final ClientCapability USER_VERIFYING_PLATFORM_AUTHENTICATOR = new ClientCapability("userVerifyingPlatformAuthenticator");
+
+    /**
+     * The WebAuthn Client supports related origins.
+     */
+    public static final ClientCapability RELATED_ORIGINS = new ClientCapability("relatedOrigins");
+
+    /**
+     * The WebAuthn Client supports signalAllAcceptedCredentials signal method.
+     */
+    public static final ClientCapability SIGNAL_ALL_ACCEPTED_CREDENTIALS = new ClientCapability("signalAllAcceptedCredentials");
+
+    /**
+     * The WebAuthn Client supports signalCurrentUserDetails signal method.
+     */
+    public static final ClientCapability SIGNAL_CURRENT_USER_DETAILS = new ClientCapability("signalCurrentUserDetails");
+
+    /**
+     * The WebAuthn Client supports signalUnknownCredential signal method.
+     */
+    public static final ClientCapability SIGNAL_UNKNOWN_CREDENTIAL = new ClientCapability("signalUnknownCredential");
+
+    private final String value;
+
+    private ClientCapability(@NotNull String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static @NotNull ClientCapability create(@NotNull String value) {
+        AssertUtil.notNull(value, "value must not be null.");
+        switch (value) {
+            case "conditionalCreate":
+                return CONDITIONAL_CREATE;
+            case "conditionalGet":
+                return CONDITIONAL_GET;
+            case "hybridTransport":
+                return HYBRID_TRANSPORT;
+            case "passkeyPlatformAuthenticator":
+                return PASSKEY_PLATFORM_AUTHENTICATOR;
+            case "userVerifyingPlatformAuthenticator":
+                return USER_VERIFYING_PLATFORM_AUTHENTICATOR;
+            case "relatedOrigins":
+                return RELATED_ORIGINS;
+            case "signalAllAcceptedCredentials":
+                return SIGNAL_ALL_ACCEPTED_CREDENTIALS;
+            case "signalCurrentUserDetails":
+                return SIGNAL_CURRENT_USER_DETAILS;
+            case "signalUnknownCredential":
+                return SIGNAL_UNKNOWN_CREDENTIAL;
+            default:
+                return new ClientCapability(value);
+        }
+    }
+
+    @JsonValue
+    public @NotNull String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientCapability that = (ClientCapability) o;
+        return value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/PublicKeyCredentialClientCapabilities.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/PublicKeyCredentialClientCapabilities.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Represents the result of PublicKeyCredential.getClientCapabilities(),
+ * which is a record mapping {@link ClientCapability} keys to boolean values.
+ *
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#dom-publickeycredential-getclientcapabilities">
+ * §5.1.7. Availability of Client Capabilities</a>
+ */
+public class PublicKeyCredentialClientCapabilities extends AbstractImmutableMap<ClientCapability, Boolean> {
+
+    @JsonCreator
+    public PublicKeyCredentialClientCapabilities(@NotNull Map<ClientCapability, Boolean> map) {
+        super(map);
+    }
+
+    public PublicKeyCredentialClientCapabilities() {
+        this(Collections.emptyMap());
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/ClientCapabilityTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/ClientCapabilityTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class ClientCapabilityTest {
+
+    @Test
+    void create_test() {
+        assertAll(
+                () -> assertThat(ClientCapability.create("conditionalCreate")).isEqualTo(ClientCapability.CONDITIONAL_CREATE),
+                () -> assertThat(ClientCapability.create("conditionalGet")).isEqualTo(ClientCapability.CONDITIONAL_GET),
+                () -> assertThat(ClientCapability.create("hybridTransport")).isEqualTo(ClientCapability.HYBRID_TRANSPORT),
+                () -> assertThat(ClientCapability.create("passkeyPlatformAuthenticator")).isEqualTo(ClientCapability.PASSKEY_PLATFORM_AUTHENTICATOR),
+                () -> assertThat(ClientCapability.create("userVerifyingPlatformAuthenticator")).isEqualTo(ClientCapability.USER_VERIFYING_PLATFORM_AUTHENTICATOR),
+                () -> assertThat(ClientCapability.create("relatedOrigins")).isEqualTo(ClientCapability.RELATED_ORIGINS),
+                () -> assertThat(ClientCapability.create("signalAllAcceptedCredentials")).isEqualTo(ClientCapability.SIGNAL_ALL_ACCEPTED_CREDENTIALS),
+                () -> assertThat(ClientCapability.create("signalCurrentUserDetails")).isEqualTo(ClientCapability.SIGNAL_CURRENT_USER_DETAILS),
+                () -> assertThat(ClientCapability.create("signalUnknownCredential")).isEqualTo(ClientCapability.SIGNAL_UNKNOWN_CREDENTIAL)
+        );
+    }
+
+    @SuppressWarnings({"ConstantConditions"})
+    @Test
+    void create_null_test() {
+        assertThatThrownBy(() -> ClientCapability.create(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void getValue_test() {
+        assertThat(ClientCapability.CONDITIONAL_CREATE.getValue()).isEqualTo("conditionalCreate");
+    }
+
+    @Test
+    void create_unknown_value_test() {
+        assertDoesNotThrow(
+                () -> ClientCapability.create("unknown")
+        );
+    }
+
+    @Test
+    void equals_hashCode_test() {
+        ClientCapability instanceA = ClientCapability.create("conditionalCreate");
+        ClientCapability instanceB = ClientCapability.create("conditionalCreate");
+        ClientCapability instanceC = ClientCapability.create("conditionalGet");
+
+        assertAll(
+                () -> assertThat(instanceA).isEqualTo(instanceB),
+                () -> assertThat(instanceA).hasSameHashCodeAs(instanceB),
+                () -> assertThat(instanceA).isNotEqualTo(instanceC),
+                () -> assertThat(instanceA).isEqualTo(ClientCapability.CONDITIONAL_CREATE),
+                () -> assertThat(instanceA).hasSameHashCodeAs(ClientCapability.CONDITIONAL_CREATE)
+        );
+    }
+
+    @Test
+    void toString_test() {
+        assertThat(ClientCapability.CONDITIONAL_CREATE.toString()).isEqualTo("conditionalCreate");
+        assertThat(ClientCapability.HYBRID_TRANSPORT.toString()).isEqualTo("hybridTransport");
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialClientCapabilitiesTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialClientCapabilitiesTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PublicKeyCredentialClientCapabilitiesTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void deserialize_test() {
+        TestDTO dto = jsonMapper.readValue("{\"capabilities\":{\"conditionalCreate\":true,\"hybridTransport\":false}}", TestDTO.class);
+        assertThat(dto.capabilities)
+                .containsEntry(ClientCapability.CONDITIONAL_CREATE, true)
+                .containsEntry(ClientCapability.HYBRID_TRANSPORT, false);
+    }
+
+    @Test
+    void deserialize_test_with_unknown_value() {
+        assertDoesNotThrow(
+                () -> jsonMapper.readValue("{\"capabilities\":{\"unknown\":true}}", TestDTO.class)
+        );
+    }
+
+    @Test
+    void put_test() {
+        PublicKeyCredentialClientCapabilities target = new PublicKeyCredentialClientCapabilities();
+        assertThrows(UnsupportedOperationException.class,
+                () -> target.put(ClientCapability.CONDITIONAL_CREATE, true)
+        );
+    }
+
+    @Test
+    void entrySet_remove_test() {
+        Map<ClientCapability, Boolean> source = new HashMap<>();
+        source.put(ClientCapability.CONDITIONAL_CREATE, true);
+        PublicKeyCredentialClientCapabilities target = new PublicKeyCredentialClientCapabilities(source);
+        assertThrows(UnsupportedOperationException.class,
+                () -> target.entrySet().remove(target.entrySet().iterator().next())
+        );
+    }
+
+    static class TestDTO {
+        @SuppressWarnings("WeakerAccess")
+        public PublicKeyCredentialClientCapabilities capabilities;
+    }
+}


### PR DESCRIPTION
Add ClientCapability enum to support PublicKeyCredential.getClientCapabilities() method.

- Add ClientCapability class with 9 capability values:
  - conditionalCreate: Conditional mediation for registration
  - conditionalGet: Conditional mediation for authentication
  - hybridTransport: Hybrid transport support
  - passkeyPlatformAuthenticator: Passkey platform authenticator available
  - userVerifyingPlatformAuthenticator: User-verifying platform authenticator available
  - relatedOrigins: Related origins support
  - signalAllAcceptedCredentials: signalAllAcceptedCredentials signal method support
  - signalCurrentUserDetails: signalCurrentUserDetails signal method support
  - signalUnknownCredential: signalUnknownCredential signal method support

- Add comprehensive test coverage in ClientCapabilityTest

Spec reference: https://www.w3.org/TR/webauthn-3/#enumdef-clientcapability