### PR TITLE
Enable passing AAGUID into emulator authenticators

### DIFF
--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
@@ -314,8 +314,12 @@ public class TestDataUtil {
         return createAttestedCredentialData(createEC2COSEPublicKey());
     }
 
+    public static AttestedCredentialData createAttestedCredentialData(AAGUID aaguid, COSEKey coseKey) {
+        return new AttestedCredentialData(aaguid, new byte[32], coseKey);
+    }
+
     public static AttestedCredentialData createAttestedCredentialData(COSEKey coseKey) {
-        return new AttestedCredentialData(AAGUID.ZERO, new byte[32], coseKey);
+        return createAttestedCredentialData(AAGUID.ZERO, coseKey);
     }
 
     public static EC2COSEKey createEC2COSEPublicKey() {

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/AndroidKeyAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/AndroidKeyAuthenticator.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.test.authenticator.webauthn;
 
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.statement.AndroidKeyAttestationStatement;
 import com.webauthn4j.data.attestation.statement.AttestationCertificatePath;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
@@ -30,6 +31,13 @@ import javax.security.auth.x500.X500Principal;
 import java.security.cert.X509Certificate;
 
 public class AndroidKeyAuthenticator extends WebAuthnModelAuthenticator {
+
+    public AndroidKeyAuthenticator(AAGUID aaguid) {
+        super(aaguid);
+    }
+
+    public AndroidKeyAuthenticator() {
+    }
 
     @Override
     public AttestationStatement createAttestationStatement(AttestationStatementRequest attestationStatementRequest, RegistrationEmulationOption registrationEmulationOption) {

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/AndroidSafetyNetAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/AndroidSafetyNetAuthenticator.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.test.authenticator.webauthn;
 
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.statement.AndroidSafetyNetAttestationStatement;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import com.webauthn4j.data.attestation.statement.Response;
@@ -37,6 +38,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AndroidSafetyNetAuthenticator extends WebAuthnModelAuthenticator {
+
+    public AndroidSafetyNetAuthenticator(AAGUID aaguid) {
+        super(aaguid);
+    }
+
+    public AndroidSafetyNetAuthenticator() {
+    }
 
     private JWSFactory jwsFactory;
 

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/NoneAttestationAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/NoneAttestationAuthenticator.java
@@ -36,13 +36,12 @@ public class NoneAttestationAuthenticator extends WebAuthnModelAuthenticator {
         super(aaguid, null, null, null, counter, capableOfUserVerification, objectConverter);
     }
 
+    public NoneAttestationAuthenticator(AAGUID aaguid) {
+        this(aaguid, 0, true, new ObjectConverter());
+    }
+
     public NoneAttestationAuthenticator() {
-        this(
-            AAGUID.ZERO,
-            0,
-            true,
-            new ObjectConverter()
-        );
+        this(AAGUID.ZERO);
     }
 
     @Override

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticator.java
@@ -18,6 +18,7 @@ package com.webauthn4j.test.authenticator.webauthn;
 
 import com.webauthn4j.data.attestation.authenticator.EC2COSEKey;
 import com.webauthn4j.data.attestation.statement.AttestationCertificatePath;
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.data.attestation.statement.PackedAttestationStatement;
@@ -30,6 +31,13 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPrivateKey;
 
 public class PackedAuthenticator extends WebAuthnModelAuthenticator {
+
+    public PackedAuthenticator(AAGUID aaguid) {
+        super(aaguid);
+    }
+
+    public PackedAuthenticator() {
+    }
 
     @Override
     public AttestationStatement createAttestationStatement(AttestationStatementRequest attestationStatementRequest, RegistrationEmulationOption registrationEmulationOption) {

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/TPMAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/TPMAuthenticator.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.test.authenticator.webauthn;
 
 import com.webauthn4j.data.SignatureAlgorithm;
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.authenticator.EC2COSEKey;
 import com.webauthn4j.data.attestation.statement.*;
 import com.webauthn4j.test.AttestationCertificateBuilder;
@@ -40,6 +41,13 @@ import java.security.spec.EllipticCurve;
 
 @SuppressWarnings("ConstantConditions")
 public class TPMAuthenticator extends WebAuthnModelAuthenticator {
+
+    public TPMAuthenticator(AAGUID aaguid) {
+        super(aaguid);
+    }
+
+    public TPMAuthenticator() {
+    }
 
     @Override
     public AttestationStatement createAttestationStatement(AttestationStatementRequest attestationStatementRequest, RegistrationEmulationOption registrationEmulationOption) {

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/authenticator/webauthn/WebAuthnModelAuthenticator.java
@@ -99,9 +99,9 @@ public abstract class WebAuthnModelAuthenticator implements WebAuthnAuthenticato
         secureRandom.nextBytes(this.credentialEncryptionKey);
     }
 
-    public WebAuthnModelAuthenticator() {
+    public WebAuthnModelAuthenticator(AAGUID aaguid) {
         this(
-                AAGUID.ZERO,
+                aaguid,
                 new KeyPair(
                         TestAttestationUtil.load3tierTestAuthenticatorAttestationPublicKey(),
                         TestAttestationUtil.load3tierTestAuthenticatorAttestationPrivateKey()),
@@ -111,6 +111,10 @@ public abstract class WebAuthnModelAuthenticator implements WebAuthnAuthenticato
                 true,
                 new ObjectConverter()
         );
+    }
+
+    public WebAuthnModelAuthenticator() {
+        this(AAGUID.ZERO);
     }
 
     public PublicKeyCredentialSource lookup(byte[] credentialId) {

--- a/webauthn4j-test/src/test/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticatorTest.java
+++ b/webauthn4j-test/src/test/java/com/webauthn4j/test/authenticator/webauthn/PackedAuthenticatorTest.java
@@ -19,6 +19,7 @@ package com.webauthn4j.test.authenticator.webauthn;
 
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.*;
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import org.junit.jupiter.api.Test;
@@ -83,6 +84,26 @@ class PackedAuthenticatorTest {
                 false,
                 null));
         assertThat(assertion.getCredentialId()).isEqualTo(credentialId);
+    }
+
+    @Test
+    void constructorWithAaguid_test() {
+        AAGUID aaguid = new AAGUID("f8a011f3-8c0a-4d15-8006-17111f9edc7d");
+        PackedAuthenticator authenticator = new PackedAuthenticator(aaguid);
+        MakeCredentialResponse response = authenticator.makeCredential(new MakeCredentialRequest(
+                new byte[32],
+                new PublicKeyCredentialRpEntity("test-rp", "Test RP"),
+                new PublicKeyCredentialUserEntity(new byte[32], "test-user", "Test User"),
+                false,
+                true,
+                false,
+                Collections.singletonList(new PublicKeyCredentialParameters(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        COSEAlgorithmIdentifier.ES256
+                ))
+        ));
+        assertThat(response.getAttestationObject().getAuthenticatorData()
+                .getAttestedCredentialData().getAaguid()).isEqualTo(aaguid);
     }
 
     private String serialize(PublicKeyCredentialCreationOptions options) {

--- a/webauthn4j-test/src/test/java/com/webauthn4j/test/authenticator/webauthn/TPMAuthenticatorTest.java
+++ b/webauthn4j-test/src/test/java/com/webauthn4j/test/authenticator/webauthn/TPMAuthenticatorTest.java
@@ -17,12 +17,20 @@
 package com.webauthn4j.test.authenticator.webauthn;
 
 
+import com.webauthn4j.data.PublicKeyCredentialParameters;
+import com.webauthn4j.data.PublicKeyCredentialRpEntity;
+import com.webauthn4j.data.PublicKeyCredentialType;
+import com.webauthn4j.data.PublicKeyCredentialUserEntity;
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.authenticator.EC2COSEKey;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.test.client.RegistrationEmulationOption;
 import com.webauthn4j.util.ECUtil;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 class TPMAuthenticatorTest {
@@ -35,5 +43,25 @@ class TPMAuthenticatorTest {
         RegistrationEmulationOption option = new RegistrationEmulationOption();
         AttestationStatementRequest attestationStatementRequest = new AttestationStatementRequest(signedData, EC2COSEKey.create(ECUtil.createKeyPair(), COSEAlgorithmIdentifier.ES256), new byte[0]);
         assertThatCode(() -> target.createAttestationStatement(attestationStatementRequest, option)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void constructorWithAaguid_test() {
+        AAGUID aaguid = new AAGUID("f8a011f3-8c0a-4d15-8006-17111f9edc7d");
+        TPMAuthenticator authenticator = new TPMAuthenticator(aaguid);
+        MakeCredentialResponse response = authenticator.makeCredential(new MakeCredentialRequest(
+                new byte[32],
+                new PublicKeyCredentialRpEntity("test-rp", "Test RP"),
+                new PublicKeyCredentialUserEntity(new byte[32], "test-user", "Test User"),
+                false,
+                true,
+                false,
+                Collections.singletonList(new PublicKeyCredentialParameters(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        COSEAlgorithmIdentifier.ES256
+                ))
+        ));
+        assertThat(response.getAttestationObject().getAuthenticatorData()
+                .getAttestedCredentialData().getAaguid()).isEqualTo(aaguid);
     }
 }


### PR DESCRIPTION
Add AAGUID-parameterized constructors to WebAuthnModelAuthenticator and all concrete subclasses (PackedAuthenticator, TPMAuthenticator, AndroidKeyAuthenticator, AndroidSafetyNetAuthenticator, NoneAttestationAuthenticator) so users can supply custom AAGUID values during integration testing.

Also add createAttestedCredentialData(AAGUID, COSEKey) overload to TestDataUtil.

Closes #1152