### PR TITLE
Add SMART_CARD to AttachmentHint enum to support FIDO MDS Blob v242

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AttachmentHint.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AttachmentHint.java
@@ -36,7 +36,8 @@ public enum AttachmentHint {
     BLUETOOTH(0x0020, "bluetooth"),
     NETWORK(0x0040, "network"),
     READY(0x0080, "ready"),
-    WIFI_DIRECT(0x0100, "wifi_direct");
+    WIFI_DIRECT(0x0100, "wifi_direct"),
+    SMART_CARD(0x0200, "smart-card");
 
     private static final String VALUE_OUT_OF_RANGE_TEMPLATE = "value %s is out of range";
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AttachmentHintTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AttachmentHintTest.java
@@ -35,6 +35,7 @@ class AttachmentHintTest {
                     () -> assertThat(AttachmentHint.NETWORK.getValue()).isEqualTo(0x0040),
                     () -> assertThat(AttachmentHint.READY.getValue()).isEqualTo(0x0080),
                     () -> assertThat(AttachmentHint.WIFI_DIRECT.getValue()).isEqualTo(0x0100)
+                    () -> assertThat(AttachmentHint.SMART_CARD.getValue()).isEqualTo(0x0200)
             );
         }
 
@@ -59,6 +60,7 @@ class AttachmentHintTest {
                     () -> assertThat(AttachmentHint.create(0x0040)).isEqualTo(AttachmentHint.NETWORK),
                     () -> assertThat(AttachmentHint.create(0x0080)).isEqualTo(AttachmentHint.READY),
                     () -> assertThat(AttachmentHint.create(0x0100)).isEqualTo(AttachmentHint.WIFI_DIRECT)
+                    () -> assertThat(AttachmentHint.create(0x0200)).isEqualTo(AttachmentHint.SMART_CARD)
             );
         }
 
@@ -74,6 +76,7 @@ class AttachmentHintTest {
                     () -> assertThat(AttachmentHint.create("network")).isEqualTo(AttachmentHint.NETWORK),
                     () -> assertThat(AttachmentHint.create("ready")).isEqualTo(AttachmentHint.READY),
                     () -> assertThat(AttachmentHint.create("wifi_direct")).isEqualTo(AttachmentHint.WIFI_DIRECT)
+                    () -> assertThat(AttachmentHint.create("smart-card")).isEqualTo(AttachmentHint.SMART_CARD)
             );
         }
         


### PR DESCRIPTION
## Problem

FIDO Alliance MDS Blob version 242 (the latest) includes `"smart-card"` as an 
`attachmentHint` value for certain AAGUIDs. When webauthn4j attempts to parse 
this blob, it fails with an `InvalidFormatException` because `"smart-card"` is 
not a recognized value in the `AttachmentHint` enum.

The failure path:
1. `AttachmentHintFromStringDeserializer` calls `AttachmentHint.create("smart-card")`
2. No matching enum constant is found → `IllegalArgumentException` is thrown
3. Deserializer re-throws it as `InvalidFormatException`, breaking MDS blob parsing

### Real-world example

In MDS Blob v242, the entry at index 83:
- **AAGUID**: `24083bcb-3034-4867-99de-a3b52e1d426a`
- **Authenticator**: `Enterprise Security Key Series with NFC (Consumer Profile)`
- **attachmentHints**: includes `"smart-card"`

Attempting to parse this blob with the current code throws:
InvalidFormatException: value is out of range


## Fix

Add `SMART_CARD(0x0200, "smart-card")` as a new enum constant in `AttachmentHint`, 
using `0x0200` as the next bit-flag in sequence after `WIFI_DIRECT(0x0100)`, 
consistent with the existing bitmask pattern defined in the FIDO Registry spec.

Updated tests to cover the new enum value in value, int-create, and string-create assertions.
