### PR TITLE
Support FIDO Registry v2.3 (SMART_CARD, SYNC_FABRIC)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AttachmentHint.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AttachmentHint.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * The supported attachment hint type(s).
  *
- * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#authenticator-attachment-hints">§3.4 Authenticator Attachment Hints</a>
+ * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#authenticator-attachment-hints">§3.4 Authenticator Attachment Hints</a>
  */
 public enum AttachmentHint {
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AttachmentHint.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AttachmentHint.java
@@ -36,7 +36,8 @@ public enum AttachmentHint {
     BLUETOOTH(0x0020, "bluetooth"),
     NETWORK(0x0040, "network"),
     READY(0x0080, "ready"),
-    WIFI_DIRECT(0x0100, "wifi_direct");
+    WIFI_DIRECT(0x0100, "wifi_direct"),
+    SMART_CARD(0x0200, "smart-card");
 
     private static final String VALUE_OUT_OF_RANGE_TEMPLATE = "value %s is out of range";
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationAlgorithm.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationAlgorithm.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * The supported authentication algorithm(s).
  *
- * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#authentication-algorithms">§3.6.1 Authentication Algorithms</a>
+ * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#authentication-algorithms">§3.6.1 Authentication Algorithms</a>
  */
 public enum AuthenticationAlgorithm {
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticatorAttestationType.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticatorAttestationType.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * The supported attestation type(s). (e.g. ATTESTATION_BASIC_FULL(0x3E07), ATTESTATION_BASIC_SURROGATE(0x3E08)).
  *
- * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#authenticator-attestation-types">§3.6.3 Authenticator Attestation Types</a>
+ * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#authenticator-attestation-types">§3.6.3 Authenticator Attestation Types</a>
  */
 public enum AuthenticatorAttestationType {
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/KeyProtectionType.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/KeyProtectionType.java
@@ -32,7 +32,8 @@ public enum KeyProtectionType {
     HARDWARE(0x0002, "hardware"),
     TEE(0x0004, "tee"),
     SECURE_ELEMENT(0x0008, "secure_element"),
-    REMOTE_HANDLE(0x0010, "remote_handle");
+    REMOTE_HANDLE(0x0010, "remote_handle"),
+    SYNC_FABRIC(0x0020, "sync_fabric");
 
     private static final String VALUE_OUT_OF_RANGE_TEMPLATE = "value %s is out of range";
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/KeyProtectionType.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/KeyProtectionType.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * The supported key protection type(s).
  *
- * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#key-protection-types">§3.2 Key Protection Types</a>
+ * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#key-protection-types">§3.2 Key Protection Types</a>
  */
 public enum KeyProtectionType {
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/MatcherProtectionType.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/MatcherProtectionType.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * The supported matcher protection type(s).
  *
- * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#matcher-protection-types">§3.3 Matcher Protection Types</a>
+ * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#matcher-protection-types">§3.3 Matcher Protection Types</a>
  */
 public enum MatcherProtectionType {
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/PublicKeyRepresentationFormat.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/PublicKeyRepresentationFormat.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * The supported publik key representation format(s).
  *
- * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#public-key-representation-formats">§3.6.2 Public Key Representation Formats</a>
+ * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#public-key-representation-formats">§3.6.2 Public Key Representation Formats</a>
  */
 public enum PublicKeyRepresentationFormat {
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/TransactionConfirmationDisplay.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/TransactionConfirmationDisplay.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * The supported transaction confirmation display type(s).
  *
- * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#transaction-confirmation-display-types">§3.5 Transaction Confirmation Display Types</a>
+ * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#transaction-confirmation-display-types">§3.5 Transaction Confirmation Display Types</a>
  */
 public enum TransactionConfirmationDisplay {
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/UserVerificationMethod.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/UserVerificationMethod.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * The supported user verification method(s).
  *
- * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#user-verification-methods">§3.1 User Verification Methods</a>
+ * @see <a href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#user-verification-methods">§3.1 User Verification Methods</a>
  */
 public enum UserVerificationMethod {
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AttachmentHintTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AttachmentHintTest.java
@@ -34,7 +34,8 @@ class AttachmentHintTest {
                     () -> assertThat(AttachmentHint.BLUETOOTH.getValue()).isEqualTo(0x0020),
                     () -> assertThat(AttachmentHint.NETWORK.getValue()).isEqualTo(0x0040),
                     () -> assertThat(AttachmentHint.READY.getValue()).isEqualTo(0x0080),
-                    () -> assertThat(AttachmentHint.WIFI_DIRECT.getValue()).isEqualTo(0x0100)
+                    () -> assertThat(AttachmentHint.WIFI_DIRECT.getValue()).isEqualTo(0x0100),
+                    () -> assertThat(AttachmentHint.SMART_CARD.getValue()).isEqualTo(0x0200)
             );
         }
 
@@ -58,7 +59,8 @@ class AttachmentHintTest {
                     () -> assertThat(AttachmentHint.create(0x0020)).isEqualTo(AttachmentHint.BLUETOOTH),
                     () -> assertThat(AttachmentHint.create(0x0040)).isEqualTo(AttachmentHint.NETWORK),
                     () -> assertThat(AttachmentHint.create(0x0080)).isEqualTo(AttachmentHint.READY),
-                    () -> assertThat(AttachmentHint.create(0x0100)).isEqualTo(AttachmentHint.WIFI_DIRECT)
+                    () -> assertThat(AttachmentHint.create(0x0100)).isEqualTo(AttachmentHint.WIFI_DIRECT),
+                    () -> assertThat(AttachmentHint.create(0x0200)).isEqualTo(AttachmentHint.SMART_CARD)
             );
         }
 
@@ -73,7 +75,8 @@ class AttachmentHintTest {
                     () -> assertThat(AttachmentHint.create("bluetooth")).isEqualTo(AttachmentHint.BLUETOOTH),
                     () -> assertThat(AttachmentHint.create("network")).isEqualTo(AttachmentHint.NETWORK),
                     () -> assertThat(AttachmentHint.create("ready")).isEqualTo(AttachmentHint.READY),
-                    () -> assertThat(AttachmentHint.create("wifi_direct")).isEqualTo(AttachmentHint.WIFI_DIRECT)
+                    () -> assertThat(AttachmentHint.create("wifi_direct")).isEqualTo(AttachmentHint.WIFI_DIRECT),
+                    () -> assertThat(AttachmentHint.create("smart-card")).isEqualTo(AttachmentHint.SMART_CARD)
             );
         }
         

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/KeyProtectionTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/KeyProtectionTypeTest.java
@@ -44,11 +44,13 @@ class KeyProtectionTypeTest {
                 () -> assertThat(KeyProtectionType.create(0x0004)).isEqualTo(KeyProtectionType.TEE),
                 () -> assertThat(KeyProtectionType.create(0x0008)).isEqualTo(KeyProtectionType.SECURE_ELEMENT),
                 () -> assertThat(KeyProtectionType.create(0x0010)).isEqualTo(KeyProtectionType.REMOTE_HANDLE),
+                () -> assertThat(KeyProtectionType.create(0x0020)).isEqualTo(KeyProtectionType.SYNC_FABRIC),
                 () -> assertThat(KeyProtectionType.create("software")).isEqualTo(KeyProtectionType.SOFTWARE),
                 () -> assertThat(KeyProtectionType.create("hardware")).isEqualTo(KeyProtectionType.HARDWARE),
                 () -> assertThat(KeyProtectionType.create("tee")).isEqualTo(KeyProtectionType.TEE),
                 () -> assertThat(KeyProtectionType.create("secure_element")).isEqualTo(KeyProtectionType.SECURE_ELEMENT),
-                () -> assertThat(KeyProtectionType.create("remote_handle")).isEqualTo(KeyProtectionType.REMOTE_HANDLE)
+                () -> assertThat(KeyProtectionType.create("remote_handle")).isEqualTo(KeyProtectionType.REMOTE_HANDLE),
+                () -> assertThat(KeyProtectionType.create("sync_fabric")).isEqualTo(KeyProtectionType.SYNC_FABRIC)
         );
     }
 


### PR DESCRIPTION
- Add `SMART_CARD` (`0x0200`, `"smart-card"`) to `AttachmentHint` enum
  (based on #1317 by @sksuraj7, with test fix applied)
- Add `SYNC_FABRIC` (`0x0020`, `"sync_fabric"`) to `KeyProtectionType` enum
- Update Javadoc spec reference links from FIDO Registry v2.2 to v2.3

Closes #1317