### PR TITLE
Remove explicit gson dependency from spring-security-passkeys integration test project

### DIFF
--- a/integration-tests/spring-security-passkeys/build.gradle.kts
+++ b/integration-tests/spring-security-passkeys/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(libs.playwright)
-    testImplementation("com.google.code.gson:gson:2.11.0")
 
     implementation("ch.qos.logback:logback-classic")
     


### PR DESCRIPTION
## Summary
- Remove explicit gson dependency (`com.google.code.gson:gson:2.11.0`) from spring-security-passkeys integration test
- Gson is already provided as a transitive dependency of Playwright, which uses `com.google.gson.JsonObject` in its CDPSession API
- The explicit declaration is unnecessary