### PR TITLE
Replace jreleaser with a lightweight custom Maven Central publish plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,4 +83,4 @@ jobs:
           PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
           PGP_SIGNING_KEY_PASSPHRASE: ${{ secrets.PGP_SIGNING_KEY_PASSPHRASE }}
         run: |
-          ./gradlew publishStandardPublicationToLocalStagingRepository jreleaserDeploy
+          ./gradlew publishToCentralPortal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import com.webauthn4j.gradle.BuildUtils
 import com.webauthn4j.gradle.VersionUtils
 import org.asciidoctor.gradle.jvm.AsciidoctorTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.jreleaser.model.Active
 import java.net.URI
 import java.nio.charset.StandardCharsets
 
@@ -12,7 +11,7 @@ plugins {
     id("maven-publish")
     id("jacoco")
 
-    id(libs.plugins.jreleaser.get().pluginId) version libs.versions.jreleaser
+    id("net.sharplab.maven-central-publish")
     id(libs.plugins.asciidoctor.get().pluginId) version libs.versions.asciidoctor
     id(libs.plugins.sonarqube.get().pluginId) version libs.versions.sonarqube
 }
@@ -78,7 +77,6 @@ subprojects {
 configure(subprojects.filter { it.name.startsWith("webauthn4j-") }) {
     apply(plugin = "signing")
     apply(plugin = "maven-publish")
-    apply(plugin = "org.jreleaser")
 
     val githubUrl = "https://github.com/webauthn4j/webauthn4j"
     val mavenCentralUser = BuildUtils.getVariable(project, "MAVEN_CENTRAL_USER", "mavenCentralUser")
@@ -130,10 +128,6 @@ configure(subprojects.filter { it.name.startsWith("webauthn4j-") }) {
 
         repositories {
             maven {
-                name = "localStaging"
-                url = layout.buildDirectory.dir("local-staging").get().asFile.toURI()
-            }
-            maven {
                 name = "snapshot"
                 url = URI("https://central.sonatype.com/repository/maven-snapshots/")
                 credentials {
@@ -155,41 +149,6 @@ configure(subprojects.filter { it.name.startsWith("webauthn4j-") }) {
             onlyIf { isSnapshot }
         }
 
-        jreleaser {
-            project {
-                authors.set(listOf("Yoshikazu Nojima"))
-                license = "Apache-2.0"
-                links {
-                    homepage = githubUrl
-                }
-                version = effectiveVersion
-            }
-
-            release{
-                github{
-                    token.set("dummy")
-                    skipRelease = true
-                    skipTag = true
-                }
-            }
-
-            deploy {
-                maven {
-                    mavenCentral {
-                        this.register("mavenCentral"){
-                            active = Active.RELEASE
-                            sign = false // artifacts are signed by gradle native feature. signing by jreleaser is not required.
-                            username = mavenCentralUser
-                            password = mavenCentralPassword
-                            url = "https://central.sonatype.com/api/v1/publisher/"
-                            stagingRepository(layout.buildDirectory.dir("local-staging").get().asFile.absolutePath)
-                            retryDelay = 10
-                            maxRetries = 1000
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -340,4 +299,12 @@ sonarqube {
         property("sonar.issue.ignore.multicriteria.e4.ruleKey", "java:S5778")
         property("sonar.issue.ignore.multicriteria.e4.resourceKey", "**/*.java")
     }
+}
+
+val publishedSubprojects = subprojects.filter { it.name.startsWith("webauthn4j-") }
+
+mavenCentralPublish {
+    targetProjects = publishedSubprojects
+    username = providers.environmentVariable("MAVEN_CENTRAL_USER")
+    password = providers.environmentVariable("MAVEN_CENTRAL_PASSWORD")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,6 @@ bouncycastle = "1.84"
 jetbrains-annotations = "26.1.0"
 asciidoctor = "4.0.5"
 
-jreleaser = "1.24.0"
-
 # Test dependencies
 
 spring-boot-bom = "4.0.6"
@@ -49,7 +47,6 @@ playwright = { module = "com.microsoft.playwright:playwright", version.ref = "pl
 
 
 [plugins]
-jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
 asciidoctor = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor"}
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot-bom" }

--- a/maven-central-publish-plugin/ARCHITECTURE.md
+++ b/maven-central-publish-plugin/ARCHITECTURE.md
@@ -1,0 +1,338 @@
+# Architecture
+
+## Overview
+
+This plugin uploads locally staged Maven artifacts to Maven Central via the [Sonatype Central Portal Publisher API](https://central.sonatype.org/publish/publish-portal-api/).
+
+Signing, POM generation, and source/javadoc JAR creation are out of scope — those are handled by Gradle's built-in `maven-publish` and `signing` plugins. This plugin is responsible for:
+
+- Automatically configuring staging repositories on target subprojects
+- Bundling staged artifacts into a single ZIP
+- Uploading the bundle to Central Portal and waiting for deployment to complete
+
+### Prerequisites
+
+This plugin requires the following Gradle plugins to be applied to each target subproject:
+
+- **`maven-publish`** — Defines publications (artifacts and POM metadata) and outputs them to the staging repository. The plugin waits for `maven-publish` to be applied via `pluginManager.withPlugin` and silently skips subprojects without it.
+- **`signing`** — Signs artifacts with GPG. Required by Maven Central.
+
+## Processing flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Gradle build (root project)                                    │
+│                                                                 │
+│  mavenCentralPublish {                                          │
+│      targetProjects = publishedSubprojects                      │
+│  }                                                              │
+│    │                                                            │
+│    │  After evaluation, the plugin automatically:               │
+│    │  - Adds mavenCentralStaging repository to each subproject  │
+│    │  - Configures publishToCentralPortal dependsOn             │
+│    │                                                            │
+│  ┌───────────┐  ┌───────────┐  ┌───────────┐                   │
+│  │ module-a  │  │ module-b  │  │ module-c  │  ...               │
+│  │           │  │           │  │           │                    │
+│  │ maven-    │  │ maven-    │  │ maven-    │                    │
+│  │ publish   │  │ publish   │  │ publish   │                    │
+│  │ + signing │  │ + signing │  │ + signing │                    │
+│  └─────┬─────┘  └─────┬─────┘  └─────┬─────┘                   │
+│        │              │              │                          │
+│        ▼              ▼              ▼                          │
+│   build/maven-   build/maven-   build/maven-                    │
+│   central-       central-       central-                        │
+│   publish-       publish-       publish-                        │
+│   staging/       staging/       staging/                        │
+│        │              │              │                          │
+│        └──────────────┼──────────────┘                          │
+│                       │                                         │
+│                       ▼                                         │
+│  ┌─────────────────────────────────────────────────────┐        │
+│  │  PublishToCentralPortalTask (publishToCentralPortal) │        │
+│  │                                                     │        │
+│  │  1. Collect files from all staging directories      │        │
+│  │  2. Create a single ZIP bundle                      │        │
+│  │  3. Upload to Central Portal API                    │        │
+│  │  4. Poll status until PUBLISHED                     │        │
+│  └─────────────────────────────────────────────────────┘        │
+│                       │                                         │
+└───────────────────────┼─────────────────────────────────────────┘
+                        │
+                        ▼
+              ┌───────────────────┐
+              │  Central Portal   │
+              │  Publisher API    │
+              │                   │
+              │  POST /upload     │
+              │  POST /status     │
+              └───────────────────┘
+```
+
+All module artifacts are bundled into a single ZIP and uploaded as one deployment. This provides **atomic publishing** — all modules are published together or not at all.
+
+## Project structure
+
+```
+maven-central-publish-plugin/
+├── build.gradle.kts
+├── settings.gradle.kts
+├── README.md
+├── ARCHITECTURE.md
+└── src/
+    ├── main/kotlin/net/sharplab/gradle/mavencentral/
+    │   ├── MavenCentralPublishPlugin.kt      # Plugin entry point
+    │   ├── MavenCentralPublishExtension.kt   # DSL configuration (properties only)
+    │   ├── PublishToCentralPortalTask.kt     # Gradle task
+    │   ├── BundleCreator.kt                  # ZIP bundle creation
+    │   ├── DeploymentFailedException.kt      # FAILED state exception
+    │   ├── DeploymentTimeoutException.kt     # Polling timeout exception
+    │   └── client/                           # API client layer (no Gradle dependency)
+    │       ├── CentralPortalClient.kt        # HTTP communication
+    │       ├── DeploymentStatus.kt           # API response data class
+    │       └── CentralPortalApiException.kt  # API error exception
+    └── test/kotlin/net/sharplab/gradle/mavencentral/
+        ├── MavenCentralPublishPluginTest.kt  # Gradle TestKit tests
+        ├── BundleCreatorTest.kt              # ZIP creation tests
+        └── client/
+            └── CentralPortalClientTest.kt    # MockWebServer tests
+```
+
+### Package design
+
+```
+net.sharplab.gradle.mavencentral              Gradle plugin layer
+├── MavenCentralPublishPlugin                 Plugin<Project>
+├── MavenCentralPublishExtension              DSL properties (targetProjects, credentials, etc.)
+├── PublishToCentralPortalTask                Gradle task
+├── BundleCreator                             ZIP bundle creation utility
+├── DeploymentFailedException                 Thrown when deployment reaches FAILED
+└── DeploymentTimeoutException                Thrown when polling exceeds maxRetries
+
+net.sharplab.gradle.mavencentral.client       API client layer (no Gradle dependency)
+├── CentralPortalClient                       HTTP communication only
+├── DeploymentStatus                          API response data class
+└── CentralPortalApiException                 API error exception
+```
+
+The `client` package has no dependency on Gradle APIs, making it independently usable and testable outside of Gradle.
+
+## Components
+
+### MavenCentralPublishPlugin
+
+Plugin entry point. Implements `Plugin<Project>` and performs the following on apply:
+
+1. Creates `MavenCentralPublishExtension` as the `mavenCentralPublish` extension
+2. Registers `PublishToCentralPortalTask` as the `publishToCentralPortal` task
+3. Wires extension properties to task inputs
+4. Sets convention values (defaults) for configurable properties
+
+After the build script is evaluated (`afterEvaluate`), the plugin reads `targetProjects` and for each subproject:
+
+1. Waits for `maven-publish` to be applied (`pluginManager.withPlugin`)
+2. Adds a `mavenCentralStaging` Maven repository (path: `build/maven-central-publish-staging/`)
+3. Adds the staging directory to the task's `stagingDirectories`
+4. Adds `dependsOn` on `publishAllPublicationsToMavenCentralStagingRepository`
+
+### MavenCentralPublishExtension
+
+Declarative DSL interface for user configuration. All members are Gradle `Property` types — no methods with side effects.
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `targetProjects` | `SetProperty<Project>` | empty | Subprojects to publish to Maven Central |
+| `username` | `Property<String>` | (none) | Central Portal username |
+| `password` | `Property<String>` | (none) | Central Portal password |
+| `publishingType` | `Property<String>` | `"AUTOMATIC"` | `AUTOMATIC` or `USER_MANAGED` |
+| `retryDelay` | `Property<Int>` | `10` | Seconds between status polls |
+| `maxRetries` | `Property<Int>` | `1000` | Maximum number of poll attempts |
+| `apiBaseUrl` | `Property<String>` | `https://central.sonatype.com/api/v1/publisher` | API base URL |
+| `deploymentName` | `Property<String>` | `$group:$name:$version` | Name shown in Central Portal UI |
+
+Credentials have no default — the consuming build script is responsible for providing them (e.g., via `providers.environmentVariable()` or `providers.gradleProperty()`).
+
+### PublishToCentralPortalTask
+
+Gradle task that performs the actual deployment. Extends `DefaultTask`.
+
+**Task input annotations:**
+
+| Property | Annotation | Rationale |
+|---|---|---|
+| `stagingDirectories` | `@InputFiles` | Detect file content changes |
+| `deploymentName` | `@Input` | Track value changes |
+| `publishingType` | `@Input` | Track value changes |
+| `username` | `@Internal` | Prevent credential leakage to build cache keys or build scans |
+| `password` | `@Internal` | Same as above |
+| `retryDelay` | `@Internal` | Polling config does not affect deployment result |
+| `maxRetries` | `@Internal` | Same as above |
+| `apiBaseUrl` | `@Internal` | Same as above |
+
+`outputs.upToDateWhen { false }` ensures the task always runs, since deployment is a non-idempotent side effect.
+
+**Execution flow:**
+
+```
+publish()
+  │
+  ├── collectStagingDirectories()
+  │     Validate directories exist and contain files
+  │
+  ├── BundleCreator.createZipBundle(dirs)
+  │     Merge all directories into a single ZIP
+  │
+  ├── CentralPortalClient.upload(zipBytes, name, publishingType)
+  │     Upload and receive deployment ID
+  │
+  └── awaitPublished(client, deploymentId)
+        Poll loop (max maxRetries, interval retryDelay seconds):
+          │
+          ├── PUBLISHED → success, return
+          ├── FAILED    → throw DeploymentFailedException
+          ├── PENDING / VALIDATING / VALIDATED / PUBLISHING → sleep, continue
+          └── unknown   → warn, continue
+```
+
+Status changes are logged only when the state transitions, preventing log spam during long polling.
+
+### BundleCreator
+
+Utility object that creates a ZIP deployment bundle from staging directories.
+
+```kotlin
+object BundleCreator {
+    fun createZipBundle(stagingDirs: List<File>): ByteArray
+}
+```
+
+Files are added to the ZIP with their relative paths from the staging directory root, preserving the Maven repository layout. The ZIP is created in memory (`ByteArrayOutputStream`).
+
+### CentralPortalClient
+
+HTTP client for the Central Portal Publisher API. Has no Gradle dependency.
+
+**Dependencies:**
+
+| Purpose | Library | Rationale |
+|---|---|---|
+| HTTP | `java.net.http.HttpClient` | Java 11+ standard library |
+| JSON | `com.fasterxml.jackson.databind.ObjectMapper` | Bundled with Gradle runtime; declared as `compileOnly` |
+
+**API interactions:**
+
+| Operation | Method | Endpoint | Response |
+|---|---|---|---|
+| Upload bundle | `upload()` | `POST /upload?publishingType=...&name=...` | `201` + deployment ID (plain text) |
+| Check status | `getStatus()` | `POST /status?id=<deploymentId>` | `200` + JSON with `deploymentState` and `errors` |
+
+Authentication uses `Authorization: Bearer <Base64(username:password)>`.
+
+The multipart/form-data body for upload is constructed manually since `java.net.http.HttpClient` does not provide multipart support.
+
+### Exceptions
+
+| Exception | Package | Thrown by | Description |
+|---|---|---|---|
+| `CentralPortalApiException` | `client` | `CentralPortalClient` | Unexpected HTTP status or unparseable response |
+| `DeploymentFailedException` | (root) | `PublishToCentralPortalTask` | Deployment reached `FAILED` state |
+| `DeploymentTimeoutException` | (root) | `PublishToCentralPortalTask` | Polling exceeded `maxRetries` |
+
+## Deployment state machine
+
+```
+PENDING ──► VALIDATING ──► VALIDATED ──► PUBLISHING ──► PUBLISHED
+                │                                        (terminal)
+                │
+                └──► FAILED (terminal)
+```
+
+| State | Meaning |
+|---|---|
+| `PENDING` | Upload complete, waiting for validation |
+| `VALIDATING` | Validation in progress (POM, signatures, checksums) |
+| `VALIDATED` | Validation passed. Stops here if `publishingType=USER_MANAGED` |
+| `PUBLISHING` | Syncing to Maven Central |
+| `PUBLISHED` | Available on Maven Central |
+| `FAILED` | Error occurred. Details in `errors` field |
+
+With `publishingType=AUTOMATIC` (default), `VALIDATED` automatically transitions to `PUBLISHING` → `PUBLISHED`.
+
+## Test structure
+
+### CentralPortalClientTest (MockWebServer)
+
+Unit tests for the `client` package. Uses OkHttp's `MockWebServer` as a local HTTP server to test client logic without making real API calls.
+
+The mock boundary is at the HTTP transport layer — multipart body construction, auth token generation, and JSON parsing all execute as real code.
+
+| Test group | Coverage |
+|---|---|
+| `UploadTest` | Success, query parameters, auth header, multipart body, HTTP errors |
+| `GetStatusTest` | PUBLISHED/PENDING/FAILED JSON parsing, request format, HTTP errors |
+
+### BundleCreatorTest
+
+Unit tests for ZIP bundle creation.
+
+| Test | Coverage |
+|---|---|
+| Single directory | Files are added with correct relative paths |
+| Multiple directories | Files from all directories are merged |
+| Empty directory | Produces an empty ZIP |
+
+### MavenCentralPublishPluginTest (Gradle TestKit)
+
+Integration tests using `GradleRunner` to execute real Gradle builds in temporary directories.
+
+| Test group | Coverage |
+|---|---|
+| `PluginApplicationTest` | Task and extension registration |
+| `TargetProjectsTest` | Staging repository auto-added, dependsOn configured, artifacts staged, non-maven-publish projects skipped |
+| `PublishToCentralPortalTaskTest` | Error message when credentials are missing |
+
+## Configuration cache compatibility
+
+- **Gradle managed types** (`Property<T>`, `ConfigurableFileCollection`) for all task inputs
+- **No `Project` access at execution time** — all values are captured into properties during configuration
+- **`CentralPortalClient` created at execution time** — `HttpClient` is not serializable, so it is instantiated inside `@TaskAction`
+
+## Integration as an included build
+
+This plugin is integrated via [Gradle included build](https://docs.gradle.org/current/userguide/composite_builds.html):
+
+```kotlin
+// settings.gradle.kts
+pluginManagement {
+    includeBuild("maven-central-publish-plugin")
+}
+```
+
+Benefits:
+- Plugin source lives in the same repository as the host project
+- No need to publish to a plugin registry
+- Changes to the plugin are immediately reflected in the host build
+
+Applying the plugin via the `plugins { }` block causes Gradle to generate type-safe extension accessors (`mavenCentralPublish { ... }`).
+
+## Error handling
+
+| Condition | Exception | Source |
+|---|---|---|
+| No staging directories found | `GradleException` | `PublishToCentralPortalTask` |
+| All staging directories empty | `GradleException` | `PublishToCentralPortalTask` |
+| Credentials not configured | `MissingValueException` | Gradle `Property.get()` |
+| Upload HTTP error (non-201) | `CentralPortalApiException` | `CentralPortalClient.upload()` |
+| Status check HTTP error (non-200) | `CentralPortalApiException` | `CentralPortalClient.getStatus()` |
+| Deployment state `FAILED` | `DeploymentFailedException` | `PublishToCentralPortalTask` |
+| Polling timeout (maxRetries exceeded) | `DeploymentTimeoutException` | `PublishToCentralPortalTask` |
+| Network error | `IOException` | `HttpClient.send()` |
+
+## Reference
+
+- [Central Portal Publisher API](https://central.sonatype.org/publish/publish-portal-api/) — Endpoints, authentication, request/response format
+- [Generate Portal Token](https://central.sonatype.org/publish/generate-portal-token/) — How to obtain API credentials
+- [Upload Requirements](https://central.sonatype.org/publish/publish-portal-upload/) — ZIP bundle format, required files (POM, signatures, checksums)
+- [Gradle maven-publish Plugin](https://docs.gradle.org/current/userguide/publishing_maven.html) — Publication definition, repository configuration
+- [Gradle signing Plugin](https://docs.gradle.org/current/userguide/signing_plugin.html) — GPG artifact signing
+- [Gradle Composite Builds](https://docs.gradle.org/current/userguide/composite_builds.html) — Included build mechanism

--- a/maven-central-publish-plugin/README.md
+++ b/maven-central-publish-plugin/README.md
@@ -1,0 +1,218 @@
+# maven-central-publish-plugin
+
+A lightweight Gradle plugin that publishes artifacts to Maven Central via the [Central Portal Publisher API](https://central.sonatype.org/publish/publish-portal-api/).
+
+This plugin focuses on **one thing only**: uploading pre-staged Maven artifacts to the Central Portal and waiting for deployment to complete.
+It does **not** handle signing, POM generation, or source/javadoc JAR creation — those are already well-served by Gradle's built-in `maven-publish` and `signing` plugins.
+
+## Why?
+
+- **Minimal** — No external runtime dependencies. Uses Gradle's bundled Jackson 2 for JSON parsing and Java standard library for HTTP and ZIP handling.
+- **Central Portal native** — Directly uses the [Publisher API](https://central.sonatype.org/publish/publish-portal-api/), not the legacy OSSRH/Nexus staging API.
+- **Atomic multi-module publishing** — Aggregates all subproject artifacts into a single deployment bundle, ensuring all modules are published together or not at all.
+
+## Requirements
+
+- Java 17+
+- Gradle 9.0+
+- `maven-publish` plugin — applied to each subproject that produces publishable artifacts
+- `signing` plugin — applied to each subproject to sign artifacts with GPG (required by Maven Central)
+
+## Quick start
+
+**settings.gradle.kts**
+
+```kotlin
+pluginManagement {
+    includeBuild("maven-central-publish-plugin") // adjust the path
+}
+```
+
+**build.gradle.kts** (root project)
+
+```kotlin
+plugins {
+    id("net.sharplab.maven-central-publish")
+}
+
+mavenCentralPublish {
+    targetProjects = subprojects.filter { it.name.startsWith("my-library-") }
+    username = providers.environmentVariable("MAVEN_CENTRAL_USER")
+    password = providers.environmentVariable("MAVEN_CENTRAL_PASSWORD")
+}
+```
+
+```bash
+./gradlew publishToCentralPortal
+```
+
+## How it works
+
+1. **Configure** — The plugin reads `targetProjects` after the build script is evaluated. For each target project that has the `maven-publish` plugin applied, it adds a `mavenCentralStaging` Maven repository and sets up task dependencies automatically.
+2. **Stage** — When `publishToCentralPortal` runs, it first triggers each subproject's `publishAllPublicationsToMavenCentralStagingRepository` task (via `dependsOn`), which stages signed artifacts to `build/maven-central-publish-staging/`.
+3. **Bundle** — Gathers files from all staging directories into a single ZIP in Maven repository layout.
+4. **Upload & wait** — Uploads the bundle to Central Portal, then polls until `PUBLISHED` or `FAILED`.
+
+## Multi-module project setup
+
+In a multi-module project, you typically have subprojects that should be published to Maven Central and others that should not (test utilities, integration tests, etc.).
+
+The `targetProjects` property controls which subprojects are included. The plugin only configures subprojects that have the `maven-publish` plugin applied — if a project in the list does not have `maven-publish`, it is silently skipped.
+
+### Full example
+
+Consider a project with this structure:
+
+```
+my-project/
+├── my-library-core/          # publish to Maven Central
+├── my-library-extra/         # publish to Maven Central
+├── my-library-test-utils/    # NOT published (internal test helper)
+├── integration-tests/        # NOT published
+└── build.gradle.kts
+```
+
+**build.gradle.kts** (root project)
+
+```kotlin
+plugins {
+    id("net.sharplab.maven-central-publish")
+}
+
+// Define which subprojects are published to Maven Central
+val publishedSubprojects = subprojects.filter { it.name.startsWith("my-library-") }
+
+// Configure maven-publish and signing for published subprojects
+configure(publishedSubprojects) {
+    apply(plugin = "java-library")
+    apply(plugin = "maven-publish")
+    apply(plugin = "signing")
+
+    java {
+        withSourcesJar()
+        withJavadocJar()
+    }
+
+    publishing {
+        publications {
+            create<MavenPublication>("standard") {
+                from(components["java"])
+                pom {
+                    // ... name, description, license, developers, scm ...
+                }
+            }
+        }
+        // No need to define a staging repository — the plugin adds one automatically
+    }
+
+    signing {
+        useInMemoryPgpKeys(/* ... */)
+        sign(publishing.publications["standard"])
+    }
+}
+
+// Register published subprojects with the plugin
+mavenCentralPublish {
+    targetProjects = publishedSubprojects
+    username = providers.environmentVariable("MAVEN_CENTRAL_USER")
+    password = providers.environmentVariable("MAVEN_CENTRAL_PASSWORD")
+}
+```
+
+With this setup:
+- `my-library-core` and `my-library-extra` have `maven-publish` + `signing` applied, so they are included in the deployment bundle
+- `my-library-test-utils` also matches the filter but does NOT have `maven-publish` applied, so it is skipped
+- `integration-tests` does not match the filter at all
+- Running `./gradlew publishToCentralPortal` stages all published subprojects, bundles them into one ZIP, and uploads atomically
+
+### Single-module projects
+
+For a single-module project, pass the root project itself:
+
+```kotlin
+plugins {
+    id("java-library")
+    id("maven-publish")
+    id("signing")
+    id("net.sharplab.maven-central-publish")
+}
+
+mavenCentralPublish {
+    targetProjects = listOf(project)
+    username = providers.environmentVariable("MAVEN_CENTRAL_USER")
+    password = providers.environmentVariable("MAVEN_CENTRAL_PASSWORD")
+}
+```
+
+## Credentials
+
+The `username` and `password` properties are `Property<String>` with no default value. The consuming build script is responsible for providing them. Common approaches:
+
+**From environment variables:**
+
+```kotlin
+mavenCentralPublish {
+    username = providers.environmentVariable("MAVEN_CENTRAL_USER")
+    password = providers.environmentVariable("MAVEN_CENTRAL_PASSWORD")
+}
+```
+
+**From Gradle properties** (`~/.gradle/gradle.properties` or `-P` flag):
+
+```kotlin
+mavenCentralPublish {
+    username = providers.gradleProperty("mavenCentralUsername")
+    password = providers.gradleProperty("mavenCentralPassword")
+}
+```
+
+> **Note:** These are the [user tokens](https://central.sonatype.org/publish/generate-portal-token/) generated from your Central Portal account, not your login credentials.
+
+## Configuration reference
+
+```kotlin
+mavenCentralPublish {
+    // Projects to publish (required)
+    // The plugin automatically adds staging repositories and task dependencies
+    targetProjects = subprojects.filter { /* ... */ }
+
+    // Credentials (required)
+    username = providers.environmentVariable("MAVEN_CENTRAL_USER")
+    password = providers.environmentVariable("MAVEN_CENTRAL_PASSWORD")
+
+    // AUTOMATIC: publish immediately after validation passes
+    // USER_MANAGED: stop at VALIDATED state, require manual publish via Central Portal UI
+    publishingType = "AUTOMATIC"  // default
+
+    // Status polling configuration
+    retryDelay = 10    // seconds between polls (default)
+    maxRetries = 1000  // maximum poll attempts (default)
+
+    // Deployment name shown in Central Portal UI
+    deploymentName = "${project.group}:${project.name}:${project.version}"  // default
+
+    // API base URL (override for testing)
+    apiBaseUrl = "https://central.sonatype.com/api/v1/publisher"  // default
+}
+```
+
+## CI/CD example (GitHub Actions)
+
+```yaml
+- name: Publish to Maven Central
+  env:
+    MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
+    MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+    PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
+    PGP_SIGNING_KEY_PASSPHRASE: ${{ secrets.PGP_SIGNING_KEY_PASSPHRASE }}
+  run: |
+    ./gradlew publishToCentralPortal
+```
+
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for internal design details.
+
+## License
+
+Apache License, Version 2.0

--- a/maven-central-publish-plugin/build.gradle.kts
+++ b/maven-central-publish-plugin/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly("com.fasterxml.jackson.core:jackson-databind:2.18.6")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.18.6")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.assertj:assertj-core:3.27.7")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+// Make compileOnly dependencies (e.g. jackson-databind provided by Gradle at runtime)
+// available in Gradle TestKit's plugin classpath.
+tasks.pluginUnderTestMetadata {
+    pluginClasspath.from(configurations.compileClasspath)
+}
+
+
+gradlePlugin {
+    plugins {
+        register("mavenCentralPublish") {
+            id = "net.sharplab.maven-central-publish"
+            implementationClass = "net.sharplab.gradle.mavencentral.MavenCentralPublishPlugin"
+        }
+    }
+}

--- a/maven-central-publish-plugin/settings.gradle.kts
+++ b/maven-central-publish-plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "maven-central-publish-plugin"

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/BundleCreator.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/BundleCreator.kt
@@ -1,0 +1,35 @@
+package net.sharplab.gradle.mavencentral
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Creates a ZIP deployment bundle from staging directories in Maven repository layout.
+ */
+object BundleCreator {
+
+    /**
+     * Creates a ZIP bundle from staging directories.
+     * Files from all directories are merged into a single ZIP,
+     * preserving their relative paths in Maven repository layout.
+     */
+    fun createZipBundle(stagingDirs: List<File>): ByteArray {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            for (stagingDir in stagingDirs) {
+                stagingDir.walkTopDown()
+                    .filter { it.isFile }
+                    .forEach { file ->
+                        val relativePath = stagingDir.toPath().relativize(file.toPath()).toString()
+                        zos.putNextEntry(ZipEntry(relativePath))
+                        Files.copy(file.toPath(), zos)
+                        zos.closeEntry()
+                    }
+            }
+        }
+        return baos.toByteArray()
+    }
+}

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/DeploymentFailedException.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/DeploymentFailedException.kt
@@ -1,0 +1,11 @@
+package net.sharplab.gradle.mavencentral
+
+/**
+ * Thrown when a deployment reaches the FAILED state on Central Portal.
+ */
+class DeploymentFailedException(
+    val deploymentId: String,
+    val errors: List<String>
+) : RuntimeException(
+    "Deployment $deploymentId failed:\n${errors.joinToString("\n")}"
+)

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/DeploymentTimeoutException.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/DeploymentTimeoutException.kt
@@ -1,0 +1,14 @@
+package net.sharplab.gradle.mavencentral
+
+/**
+ * Thrown when status polling exceeds the configured maximum number of retries.
+ */
+class DeploymentTimeoutException(
+    val deploymentId: String,
+    val lastState: String,
+    val maxRetries: Int,
+    val retryDelay: Int
+) : RuntimeException(
+    "Deployment $deploymentId did not complete within ${maxRetries * retryDelay} seconds. " +
+        "Last state: $lastState"
+)

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishExtension.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishExtension.kt
@@ -1,0 +1,35 @@
+package net.sharplab.gradle.mavencentral
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+
+/**
+ * Extension for configuring Maven Central deployment via the Central Portal Publisher API.
+ */
+abstract class MavenCentralPublishExtension {
+
+    /** Projects to publish to Maven Central. Each must have the `maven-publish` plugin applied. */
+    abstract val targetProjects: SetProperty<Project>
+
+    /** Sonatype Central Portal username */
+    abstract val username: Property<String>
+
+    /** Sonatype Central Portal password */
+    abstract val password: Property<String>
+
+    /** Deployment name shown in Central Portal UI */
+    abstract val deploymentName: Property<String>
+
+    /** Publishing type: AUTOMATIC or USER_MANAGED */
+    abstract val publishingType: Property<String>
+
+    /** Delay in seconds between status poll retries */
+    abstract val retryDelay: Property<Int>
+
+    /** Maximum number of status poll retries */
+    abstract val maxRetries: Property<Int>
+
+    /** Base URL for Central Portal API */
+    abstract val apiBaseUrl: Property<String>
+}

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishPlugin.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishPlugin.kt
@@ -1,0 +1,75 @@
+package net.sharplab.gradle.mavencentral
+
+import org.gradle.api.Action
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.publish.PublishingExtension
+
+/**
+ * Gradle plugin that aggregates artifacts from multiple subprojects and publishes them
+ * to Maven Central as a single bundle via the Central Portal Publisher API.
+ *
+ * Credentials are resolved automatically from environment variables
+ * (`MAVEN_CENTRAL_USER`, `MAVEN_CENTRAL_PASSWORD`) or Gradle project properties
+ * (`mavenCentralUser`, `mavenCentralPassword`).
+ */
+class MavenCentralPublishPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val extension = project.extensions.create(
+            "mavenCentralPublish",
+            MavenCentralPublishExtension::class.java
+        )
+
+        extension.publishingType.convention("AUTOMATIC")
+        extension.retryDelay.convention(10)
+        extension.maxRetries.convention(1000)
+        extension.apiBaseUrl.convention("https://central.sonatype.com/api/v1/publisher")
+        extension.deploymentName.convention(
+            project.provider { "${project.group}:${project.name}:${project.version}" }
+        )
+
+        val taskProvider = project.tasks.register(
+            "publishToCentralPortal",
+            PublishToCentralPortalTask::class.java
+        )
+        taskProvider.configure {
+            description = "Publishes aggregated artifacts to Maven Central via the Central Portal Publisher API"
+            group = "publishing"
+
+            username.set(extension.username)
+            password.set(extension.password)
+            deploymentName.set(extension.deploymentName)
+            publishingType.set(extension.publishingType)
+            retryDelay.set(extension.retryDelay)
+            maxRetries.set(extension.maxRetries)
+            apiBaseUrl.set(extension.apiBaseUrl)
+        }
+
+        // After the build script has been evaluated, configure staging repositories
+        // and task dependencies based on the declared targetProjects.
+        project.afterEvaluate {
+            for (subproject in extension.targetProjects.get()) {
+                subproject.pluginManager.withPlugin("maven-publish") {
+                    val stagingDir = subproject.layout.buildDirectory.dir("maven-central-publish-staging")
+
+                    subproject.extensions.configure(PublishingExtension::class.java) {
+                        repositories.maven(Action<MavenArtifactRepository> {
+                            name = "mavenCentralStaging"
+                            url = stagingDir.get().asFile.toURI()
+                        })
+                    }
+
+                    taskProvider.configure {
+                        stagingDirectories.from(stagingDir)
+                    }
+                }
+
+                taskProvider.configure {
+                    dependsOn("${subproject.path}:publishAllPublicationsToMavenCentralStagingRepository")
+                }
+            }
+        }
+    }
+
+}

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/PublishToCentralPortalTask.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/PublishToCentralPortalTask.kt
@@ -1,0 +1,139 @@
+package net.sharplab.gradle.mavencentral
+
+import net.sharplab.gradle.mavencentral.client.CentralPortalClient
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Task that publishes aggregated artifacts to Maven Central
+ * as a single bundle via the Central Portal Publisher API.
+ *
+ * This ensures atomic publishing of all modules in a multi-project build.
+ */
+abstract class PublishToCentralPortalTask : DefaultTask() {
+
+    @get:InputFiles
+    abstract val stagingDirectories: ConfigurableFileCollection
+
+    @get:Internal
+    abstract val username: Property<String>
+
+    @get:Internal
+    abstract val password: Property<String>
+
+    @get:Input
+    abstract val deploymentName: Property<String>
+
+    @get:Input
+    abstract val publishingType: Property<String>
+
+    @get:Internal
+    abstract val retryDelay: Property<Int>
+
+    @get:Internal
+    abstract val maxRetries: Property<Int>
+
+    @get:Internal
+    abstract val apiBaseUrl: Property<String>
+
+    init {
+        outputs.upToDateWhen { false }
+    }
+
+    @TaskAction
+    fun publish() {
+        val stagingDirs = collectStagingDirectories()
+
+        logger.lifecycle("Creating deployment bundle from ${stagingDirs.size} staging directories")
+
+        val zipBytes = BundleCreator.createZipBundle(stagingDirs)
+        logger.lifecycle("Created bundle: ${zipBytes.size} bytes")
+
+        val client = CentralPortalClient(
+            apiBaseUrl = apiBaseUrl.get(),
+            username = username.get(),
+            password = password.get()
+        )
+
+        val deploymentId = client.upload(
+            zipBytes = zipBytes,
+            name = deploymentName.get(),
+            publishingType = publishingType.get()
+        )
+        logger.lifecycle("Upload complete. Deployment ID: $deploymentId")
+
+        awaitPublished(client, deploymentId)
+    }
+
+    private fun collectStagingDirectories(): List<java.io.File> {
+        val dirs = stagingDirectories.files
+            .filter { it.exists() && it.isDirectory }
+            .toList()
+
+        if (dirs.isEmpty()) {
+            throw GradleException("No staging directories found")
+        }
+
+        val totalFiles = dirs.sumOf { dir ->
+            dir.walkTopDown().filter { it.isFile }.count()
+        }
+        if (totalFiles == 0) {
+            throw GradleException("All staging directories are empty")
+        }
+
+        return dirs
+    }
+
+    private fun awaitPublished(client: CentralPortalClient, deploymentId: String) {
+        val maxRetries = maxRetries.get()
+        val retryDelay = retryDelay.get()
+        var lastState = ""
+
+        for (attempt in 1..maxRetries) {
+            val status = client.getStatus(deploymentId)
+            val state = status.deploymentState
+
+            if (state != lastState) {
+                logger.lifecycle("Deployment state: $state")
+                lastState = state
+            }
+
+            when (state) {
+                "PUBLISHED" -> {
+                    logger.lifecycle("Deployment published successfully!")
+                    return
+                }
+                "FAILED" -> {
+                    throw DeploymentFailedException(
+                        deploymentId = deploymentId,
+                        errors = status.errors ?: listOf("No error details available")
+                    )
+                }
+                "PENDING", "VALIDATING", "VALIDATED", "PUBLISHING" -> {
+                    if (attempt < maxRetries) {
+                        Thread.sleep(retryDelay * 1000L)
+                    }
+                }
+                else -> {
+                    logger.warn("Unknown deployment state: $state")
+                    if (attempt < maxRetries) {
+                        Thread.sleep(retryDelay * 1000L)
+                    }
+                }
+            }
+        }
+
+        throw DeploymentTimeoutException(
+            deploymentId = deploymentId,
+            lastState = lastState,
+            maxRetries = maxRetries,
+            retryDelay = retryDelay
+        )
+    }
+}

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/client/CentralPortalApiException.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/client/CentralPortalApiException.kt
@@ -1,0 +1,10 @@
+package net.sharplab.gradle.mavencentral.client
+
+/**
+ * Thrown when the Central Portal Publisher API returns an unexpected response.
+ */
+class CentralPortalApiException(
+    val statusCode: Int,
+    val responseBody: String,
+    message: String = "Central Portal API error (status $statusCode): $responseBody"
+) : RuntimeException(message)

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/client/CentralPortalClient.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/client/CentralPortalClient.kt
@@ -1,0 +1,117 @@
+package net.sharplab.gradle.mavencentral.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import java.util.UUID
+
+/**
+ * HTTP client for the Sonatype Central Portal Publisher API.
+ */
+class CentralPortalClient(
+    private val apiBaseUrl: String,
+    username: String,
+    password: String
+) {
+    private val authToken: String = Base64.getEncoder()
+        .encodeToString("$username:$password".toByteArray(StandardCharsets.UTF_8))
+
+    private val httpClient: HttpClient = HttpClient.newBuilder()
+        .followRedirects(HttpClient.Redirect.NORMAL)
+        .build()
+
+    private val objectMapper: ObjectMapper = ObjectMapper()
+
+    /**
+     * Uploads the ZIP bundle to Central Portal.
+     * @return the deployment ID
+     */
+    fun upload(zipBytes: ByteArray, name: String, publishingType: String): String {
+        val boundary = UUID.randomUUID().toString()
+        val bodyBytes = buildMultipartBody(boundary, "bundle", "$name.zip", zipBytes)
+
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("$apiBaseUrl/upload?publishingType=$publishingType&name=$name"))
+            .header("Authorization", "Bearer $authToken")
+            .header("Content-Type", "multipart/form-data; boundary=$boundary")
+            .POST(HttpRequest.BodyPublishers.ofByteArray(bodyBytes))
+            .build()
+
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() != 201) {
+            throw CentralPortalApiException(response.statusCode(), response.body())
+        }
+
+        return response.body().trim()
+    }
+
+    /**
+     * Queries the deployment status.
+     */
+    fun getStatus(deploymentId: String): DeploymentStatus {
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("$apiBaseUrl/status?id=$deploymentId"))
+            .header("Authorization", "Bearer $authToken")
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build()
+
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() != 200) {
+            throw CentralPortalApiException(response.statusCode(), response.body())
+        }
+
+        val tree = objectMapper.readTree(response.body())
+        val state = tree.get("deploymentState")?.asText()
+            ?: throw CentralPortalApiException(response.statusCode(), response.body())
+        val errorsNode = tree.get("errors")
+        val errors: List<String>? = if (errorsNode != null && errorsNode.isArray) {
+            val list = mutableListOf<String>()
+            for (node in errorsNode) {
+                list.add(node.asText())
+            }
+            list
+        } else {
+            null
+        }
+
+        return DeploymentStatus(
+            deploymentState = state,
+            errors = errors
+        )
+    }
+
+    /**
+     * Builds a multipart/form-data body manually.
+     */
+    private fun buildMultipartBody(
+        boundary: String,
+        fieldName: String,
+        fileName: String,
+        fileContent: ByteArray
+    ): ByteArray {
+        val baos = ByteArrayOutputStream()
+        val lineEnd = "\r\n"
+
+        baos.write("--$boundary$lineEnd".toByteArray())
+        baos.write(
+            "Content-Disposition: form-data; name=\"$fieldName\"; filename=\"$fileName\"$lineEnd"
+                .toByteArray()
+        )
+        baos.write("Content-Type: application/octet-stream$lineEnd".toByteArray())
+        baos.write(lineEnd.toByteArray())
+
+        baos.write(fileContent)
+        baos.write(lineEnd.toByteArray())
+
+        baos.write("--$boundary--$lineEnd".toByteArray())
+
+        return baos.toByteArray()
+    }
+}

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/client/DeploymentStatus.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/client/DeploymentStatus.kt
@@ -1,0 +1,9 @@
+package net.sharplab.gradle.mavencentral.client
+
+/**
+ * Deployment status returned by the Central Portal Publisher API.
+ */
+data class DeploymentStatus(
+    val deploymentState: String,
+    val errors: List<String>?
+)

--- a/maven-central-publish-plugin/src/test/kotlin/net/sharplab/gradle/mavencentral/BundleCreatorTest.kt
+++ b/maven-central-publish-plugin/src/test/kotlin/net/sharplab/gradle/mavencentral/BundleCreatorTest.kt
@@ -1,0 +1,73 @@
+package net.sharplab.gradle.mavencentral
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.util.zip.ZipInputStream
+
+class BundleCreatorTest {
+
+    @Test
+    fun `creates ZIP from single staging directory`(@TempDir tempDir: File) {
+        val stagingDir = File(tempDir, "staging").apply { mkdirs() }
+        val artifactDir = File(stagingDir, "com/example/mylib/1.0").apply { mkdirs() }
+        File(artifactDir, "mylib-1.0.jar").writeText("jar-content")
+        File(artifactDir, "mylib-1.0.pom").writeText("pom-content")
+
+        val zipBytes = BundleCreator.createZipBundle(listOf(stagingDir))
+
+        val entries = readZipEntries(zipBytes)
+        assertThat(entries).containsKeys(
+            "com/example/mylib/1.0/mylib-1.0.jar",
+            "com/example/mylib/1.0/mylib-1.0.pom"
+        )
+        assertThat(entries["com/example/mylib/1.0/mylib-1.0.jar"]).isEqualTo("jar-content")
+        assertThat(entries["com/example/mylib/1.0/mylib-1.0.pom"]).isEqualTo("pom-content")
+    }
+
+    @Test
+    fun `creates ZIP from multiple staging directories`(@TempDir tempDir: File) {
+        val stagingA = File(tempDir, "staging-a").apply { mkdirs() }
+        File(stagingA, "com/example/module-a/1.0").mkdirs()
+        File(stagingA, "com/example/module-a/1.0/module-a-1.0.jar").writeText("a-content")
+
+        val stagingB = File(tempDir, "staging-b").apply { mkdirs() }
+        File(stagingB, "com/example/module-b/1.0").mkdirs()
+        File(stagingB, "com/example/module-b/1.0/module-b-1.0.jar").writeText("b-content")
+
+        val zipBytes = BundleCreator.createZipBundle(listOf(stagingA, stagingB))
+
+        val entries = readZipEntries(zipBytes)
+        assertThat(entries).containsKeys(
+            "com/example/module-a/1.0/module-a-1.0.jar",
+            "com/example/module-b/1.0/module-b-1.0.jar"
+        )
+        assertThat(entries["com/example/module-a/1.0/module-a-1.0.jar"]).isEqualTo("a-content")
+        assertThat(entries["com/example/module-b/1.0/module-b-1.0.jar"]).isEqualTo("b-content")
+    }
+
+    @Test
+    fun `creates empty ZIP from empty directory`(@TempDir tempDir: File) {
+        val stagingDir = File(tempDir, "staging").apply { mkdirs() }
+
+        val zipBytes = BundleCreator.createZipBundle(listOf(stagingDir))
+
+        val entries = readZipEntries(zipBytes)
+        assertThat(entries).isEmpty()
+    }
+
+    private fun readZipEntries(zipBytes: ByteArray): Map<String, String> {
+        val entries = mutableMapOf<String, String>()
+        ZipInputStream(zipBytes.inputStream()).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                entries[entry.name] = zis.readBytes().toString(StandardCharsets.UTF_8)
+                zis.closeEntry()
+                entry = zis.nextEntry
+            }
+        }
+        return entries
+    }
+}

--- a/maven-central-publish-plugin/src/test/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishPluginIntegrationTest.kt
+++ b/maven-central-publish-plugin/src/test/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishPluginIntegrationTest.kt
@@ -1,0 +1,321 @@
+package net.sharplab.gradle.mavencentral
+
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.zip.ZipInputStream
+
+class MavenCentralPublishPluginIntegrationTest {
+
+    private lateinit var server: MockWebServer
+    private val recordedRequests = CopyOnWriteArrayList<RecordedRequest>()
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+
+        // Simulate Central Portal: upload returns 201, status returns PUBLISHED immediately
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                recordedRequests.add(request)
+                return when {
+                    request.path?.startsWith("/api/v1/publisher/upload") == true -> {
+                        MockResponse().setResponseCode(201).setBody("test-deployment-id")
+                    }
+                    request.path?.startsWith("/api/v1/publisher/status") == true -> {
+                        MockResponse().setBody("""
+                            {
+                                "deploymentId": "test-deployment-id",
+                                "deploymentState": "PUBLISHED",
+                                "errors": []
+                            }
+                        """.trimIndent())
+                    }
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+
+        server.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `publishes staged artifacts to mock Central Portal`(@TempDir projectDir: File) {
+        setupProject(projectDir)
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("publishToCentralPortal")
+            .build()
+
+        assertThat(result.task(":publishToCentralPortal")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.output).contains("Deployment published successfully!")
+    }
+
+    @Test
+    fun `uploads a valid ZIP bundle containing all modules`(@TempDir projectDir: File) {
+        setupProject(projectDir)
+
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("publishToCentralPortal")
+            .build()
+
+        val uploadRequest = recordedRequests.first { it.path?.contains("/upload") == true }
+
+        // Extract ZIP from multipart body
+        val body = uploadRequest.body.readByteArray()
+        val zipBytes = extractZipFromMultipart(body, uploadRequest.getHeader("Content-Type")!!)
+        val entries = readZipEntries(zipBytes)
+
+        // Should contain POM files for both modules
+        val pomEntries = entries.keys.filter { it.endsWith(".pom") }
+        assertThat(pomEntries).hasSize(2)
+        assertThat(pomEntries).anyMatch { it.contains("module-a") }
+        assertThat(pomEntries).anyMatch { it.contains("module-b") }
+
+        // Should contain JAR files for both modules
+        val jarEntries = entries.keys.filter { it.endsWith(".jar") && !it.contains("sources") && !it.contains("javadoc") }
+        assertThat(jarEntries).hasSize(2)
+    }
+
+    @Test
+    fun `sends correct authentication header`(@TempDir projectDir: File) {
+        setupProject(projectDir)
+
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("publishToCentralPortal")
+            .build()
+
+        val uploadRequest = recordedRequests.first { it.path?.contains("/upload") == true }
+        val expectedToken = Base64.getEncoder()
+            .encodeToString("testUser:testPassword".toByteArray(StandardCharsets.UTF_8))
+        assertThat(uploadRequest.getHeader("Authorization")).isEqualTo("Bearer $expectedToken")
+    }
+
+    @Test
+    fun `sends correct query parameters`(@TempDir projectDir: File) {
+        setupProject(projectDir)
+
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("publishToCentralPortal")
+            .build()
+
+        val uploadRequest = recordedRequests.first { it.path?.contains("/upload") == true }
+        assertThat(uploadRequest.path).contains("publishingType=AUTOMATIC")
+    }
+
+    @Test
+    fun `fails when deployment reaches FAILED state`(@TempDir projectDir: File) {
+        // Override dispatcher to return FAILED
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                return when {
+                    request.path?.startsWith("/api/v1/publisher/upload") == true -> {
+                        MockResponse().setResponseCode(201).setBody("test-deployment-id")
+                    }
+                    request.path?.startsWith("/api/v1/publisher/status") == true -> {
+                        MockResponse().setBody("""
+                            {
+                                "deploymentId": "test-deployment-id",
+                                "deploymentState": "FAILED",
+                                "errors": ["Invalid POM metadata"]
+                            }
+                        """.trimIndent())
+                    }
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+
+        setupProject(projectDir)
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("publishToCentralPortal")
+            .buildAndFail()
+
+        assertThat(result.output).contains("Invalid POM metadata")
+    }
+
+    @Test
+    fun `polls through state transitions until PUBLISHED`(@TempDir projectDir: File) {
+        val states = listOf("PENDING", "VALIDATING", "VALIDATED", "PUBLISHING", "PUBLISHED")
+        val statusCallCount = java.util.concurrent.atomic.AtomicInteger(0)
+
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                recordedRequests.add(request)
+                return when {
+                    request.path?.startsWith("/api/v1/publisher/upload") == true -> {
+                        MockResponse().setResponseCode(201).setBody("test-deployment-id")
+                    }
+                    request.path?.startsWith("/api/v1/publisher/status") == true -> {
+                        val idx = statusCallCount.getAndIncrement().coerceAtMost(states.size - 1)
+                        MockResponse().setBody("""
+                            {
+                                "deploymentId": "test-deployment-id",
+                                "deploymentState": "${states[idx]}",
+                                "errors": []
+                            }
+                        """.trimIndent())
+                    }
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+
+        setupProject(projectDir, retryDelay = 1)
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("publishToCentralPortal")
+            .build()
+
+        assertThat(result.task(":publishToCentralPortal")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.output).contains("Deployment state: PENDING")
+        assertThat(result.output).contains("Deployment state: PUBLISHED")
+        assertThat(result.output).contains("Deployment published successfully!")
+
+        val statusRequests = recordedRequests.filter { it.path?.contains("/status") == true }
+        assertThat(statusRequests.size).isGreaterThanOrEqualTo(states.size)
+    }
+
+    @Test
+    fun `times out when deployment stays in PENDING`(@TempDir projectDir: File) {
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                return when {
+                    request.path?.startsWith("/api/v1/publisher/upload") == true -> {
+                        MockResponse().setResponseCode(201).setBody("test-deployment-id")
+                    }
+                    request.path?.startsWith("/api/v1/publisher/status") == true -> {
+                        MockResponse().setBody("""
+                            {
+                                "deploymentId": "test-deployment-id",
+                                "deploymentState": "PENDING",
+                                "errors": []
+                            }
+                        """.trimIndent())
+                    }
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+
+        setupProject(projectDir, retryDelay = 1, maxRetries = 3)
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("publishToCentralPortal")
+            .buildAndFail()
+
+        assertThat(result.output).contains("did not complete within")
+        assertThat(result.output).contains("Last state: PENDING")
+    }
+
+    private fun setupProject(projectDir: File, retryDelay: Int = 10, maxRetries: Int = 1000) {
+        val serverUrl = server.url("/api/v1/publisher").toString().trimEnd('/')
+
+        writeSettingsFile(projectDir, listOf("module-a", "module-b"))
+        File(projectDir, "build.gradle.kts").writeText("""
+            plugins {
+                id("net.sharplab.maven-central-publish")
+            }
+            group = "com.example"
+            version = "1.0.0"
+            subprojects {
+                group = rootProject.group
+                version = rootProject.version
+            }
+            mavenCentralPublish {
+                targetProjects.addAll(subprojects)
+                username = "testUser"
+                password = "testPassword"
+                apiBaseUrl = "$serverUrl"
+                retryDelay = $retryDelay
+                maxRetries = $maxRetries
+            }
+        """.trimIndent())
+
+        for (module in listOf("module-a", "module-b")) {
+            File(projectDir, module).mkdirs()
+            File(projectDir, "$module/src/main/java").mkdirs()
+            File(projectDir, "$module/src/main/java/Dummy.java").writeText("public class Dummy {}")
+            File(projectDir, "$module/build.gradle.kts").writeText("""
+                plugins {
+                    `java-library`
+                    `maven-publish`
+                }
+                publishing {
+                    publications {
+                        create<MavenPublication>("maven") {
+                            from(components["java"])
+                        }
+                    }
+                }
+            """.trimIndent())
+        }
+    }
+
+    private fun writeSettingsFile(projectDir: File, modules: List<String>) {
+        val includes = modules.joinToString("\n") { "include(\"$it\")" }
+        File(projectDir, "settings.gradle.kts").writeText("""
+            rootProject.name = "test-project"
+            $includes
+        """.trimIndent())
+    }
+
+    private fun extractZipFromMultipart(body: ByteArray, contentType: String): ByteArray {
+        val boundary = contentType.substringAfter("boundary=").trim()
+        val bodyStr = String(body, StandardCharsets.ISO_8859_1)
+
+        // Find the binary content between the headers and the closing boundary
+        val headerEnd = "\r\n\r\n"
+        val headerEndIdx = bodyStr.indexOf(headerEnd)
+        val contentStart = headerEndIdx + headerEnd.length
+        val closingBoundary = "\r\n--$boundary--"
+        val contentEnd = bodyStr.indexOf(closingBoundary, contentStart)
+
+        return body.copyOfRange(contentStart, contentEnd)
+    }
+
+    private fun readZipEntries(zipBytes: ByteArray): Map<String, ByteArray> {
+        val entries = mutableMapOf<String, ByteArray>()
+        ZipInputStream(zipBytes.inputStream()).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                entries[entry.name] = zis.readBytes()
+                zis.closeEntry()
+                entry = zis.nextEntry
+            }
+        }
+        return entries
+    }
+}

--- a/maven-central-publish-plugin/src/test/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishPluginTest.kt
+++ b/maven-central-publish-plugin/src/test/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishPluginTest.kt
@@ -1,0 +1,218 @@
+package net.sharplab.gradle.mavencentral
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class MavenCentralPublishPluginTest {
+
+    @Nested
+    inner class PluginApplicationTest {
+
+        @Test
+        fun `registers publishToCentralPortal task`(@TempDir projectDir: File) {
+            writeSettingsFile(projectDir)
+            File(projectDir, "build.gradle.kts").writeText("""
+                plugins {
+                    id("net.sharplab.maven-central-publish")
+                }
+            """.trimIndent())
+
+            val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withPluginClasspath()
+                .withArguments("tasks", "--group=publishing")
+                .build()
+
+            assertThat(result.output).contains("publishToCentralPortal")
+        }
+
+        @Test
+        fun `registers mavenCentralPublish extension`(@TempDir projectDir: File) {
+            writeSettingsFile(projectDir)
+            File(projectDir, "build.gradle.kts").writeText("""
+                plugins {
+                    id("net.sharplab.maven-central-publish")
+                }
+                mavenCentralPublish {
+                    publishingType.set("USER_MANAGED")
+                }
+            """.trimIndent())
+
+            val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withPluginClasspath()
+                .withArguments("tasks")
+                .build()
+
+            assertThat(result.output).contains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Nested
+    inner class TargetProjectsTest {
+
+        @Test
+        fun `adds mavenCentralStaging repository to subproject`(@TempDir projectDir: File) {
+            setupMultiModuleProject(projectDir)
+
+            val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withPluginClasspath()
+                .withArguments(":module-a:tasks", "--all")
+                .build()
+
+            assertThat(result.output).contains("publishAllPublicationsToMavenCentralStagingRepository")
+        }
+
+        @Test
+        fun `publishToCentralPortal depends on subproject staging tasks`(@TempDir projectDir: File) {
+            setupMultiModuleProject(projectDir)
+
+            val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withPluginClasspath()
+                .withArguments("publishToCentralPortal", "--dry-run")
+                .build()
+
+            assertThat(result.output).contains(":module-a:publishAllPublicationsToMavenCentralStagingRepository")
+            assertThat(result.output).contains(":module-b:publishAllPublicationsToMavenCentralStagingRepository")
+        }
+
+        @Test
+        fun `stages artifacts to maven-central-publish-staging directory`(@TempDir projectDir: File) {
+            setupMultiModuleProject(projectDir)
+
+            val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withPluginClasspath()
+                .withArguments(":module-a:publishAllPublicationsToMavenCentralStagingRepository")
+                .build()
+
+            assertThat(result.task(":module-a:publishAllPublicationsToMavenCentralStagingRepository")?.outcome)
+                .isEqualTo(TaskOutcome.SUCCESS)
+            val stagingDir = File(projectDir, "module-a/build/maven-central-publish-staging")
+            assertThat(stagingDir).isDirectory()
+            assertThat(stagingDir.walkTopDown().filter { it.name.endsWith(".pom") }.toList()).isNotEmpty()
+        }
+
+        @Test
+        fun `does not add repository to subproject without maven-publish`(@TempDir projectDir: File) {
+            writeSettingsFile(projectDir, listOf("module-a", "module-test"))
+            File(projectDir, "build.gradle.kts").writeText("""
+                plugins {
+                    id("net.sharplab.maven-central-publish")
+                }
+                mavenCentralPublish {
+                    targetProjects.addAll(listOf(project(":module-a"), project(":module-test")))
+                }
+            """.trimIndent())
+
+            // module-a has maven-publish
+            File(projectDir, "module-a").mkdirs()
+            File(projectDir, "module-a/build.gradle.kts").writeText("""
+                plugins {
+                    `java-library`
+                    `maven-publish`
+                }
+                publishing {
+                    publications {
+                        create<MavenPublication>("maven") {
+                            from(components["java"])
+                        }
+                    }
+                }
+            """.trimIndent())
+
+            // module-test does NOT have maven-publish
+            File(projectDir, "module-test").mkdirs()
+            File(projectDir, "module-test/build.gradle.kts").writeText("""
+                plugins {
+                    `java-library`
+                }
+            """.trimIndent())
+
+            val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withPluginClasspath()
+                .withArguments(":module-test:tasks", "--all")
+                .build()
+
+            assertThat(result.output).doesNotContain("mavenCentralStaging")
+        }
+    }
+
+    @Nested
+    inner class PublishToCentralPortalTaskTest {
+
+        @Test
+        fun `fails with clear message when credentials are missing`(@TempDir projectDir: File) {
+            setupMultiModuleProject(projectDir)
+
+            // Stage artifacts first
+            GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withPluginClasspath()
+                .withArguments("publishAllPublicationsToMavenCentralStagingRepository")
+                .build()
+
+            // Try to deploy without credentials
+            val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withPluginClasspath()
+                .withArguments("publishToCentralPortal")
+                .buildAndFail()
+
+            assertThat(result.output).contains("username")
+        }
+    }
+
+    private fun setupMultiModuleProject(projectDir: File) {
+        writeSettingsFile(projectDir, listOf("module-a", "module-b"))
+        File(projectDir, "build.gradle.kts").writeText("""
+            plugins {
+                id("net.sharplab.maven-central-publish")
+            }
+            group = "com.example"
+            version = "1.0.0"
+            subprojects {
+                group = rootProject.group
+                version = rootProject.version
+            }
+            mavenCentralPublish {
+                targetProjects.addAll(subprojects)
+            }
+        """.trimIndent())
+
+        for (module in listOf("module-a", "module-b")) {
+            File(projectDir, module).mkdirs()
+            File(projectDir, "$module/src/main/java").mkdirs()
+            File(projectDir, "$module/src/main/java/Dummy.java").writeText("public class Dummy {}")
+            File(projectDir, "$module/build.gradle.kts").writeText("""
+                plugins {
+                    `java-library`
+                    `maven-publish`
+                }
+                publishing {
+                    publications {
+                        create<MavenPublication>("maven") {
+                            from(components["java"])
+                        }
+                    }
+                }
+            """.trimIndent())
+        }
+    }
+
+    private fun writeSettingsFile(projectDir: File, modules: List<String> = emptyList()) {
+        val includes = modules.joinToString("\n") { "include(\"$it\")" }
+        File(projectDir, "settings.gradle.kts").writeText("""
+            rootProject.name = "test-project"
+            $includes
+        """.trimIndent())
+    }
+}

--- a/maven-central-publish-plugin/src/test/kotlin/net/sharplab/gradle/mavencentral/client/CentralPortalClientTest.kt
+++ b/maven-central-publish-plugin/src/test/kotlin/net/sharplab/gradle/mavencentral/client/CentralPortalClientTest.kt
@@ -1,0 +1,178 @@
+package net.sharplab.gradle.mavencentral.client
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+class CentralPortalClientTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: CentralPortalClient
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = CentralPortalClient(
+            apiBaseUrl = server.url("/api/v1/publisher").toString().trimEnd('/'),
+            username = "testUser",
+            password = "testPassword"
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Nested
+    inner class UploadTest {
+
+        @Test
+        fun `uploads bundle and returns deployment ID`() {
+            server.enqueue(MockResponse().setResponseCode(201).setBody("test-deployment-id"))
+
+            val deploymentId = client.upload(
+                zipBytes = "fake-zip".toByteArray(),
+                name = "com.example:mylib:1.0",
+                publishingType = "AUTOMATIC"
+            )
+
+            assertThat(deploymentId).isEqualTo("test-deployment-id")
+        }
+
+        @Test
+        fun `sends correct query parameters`() {
+            server.enqueue(MockResponse().setResponseCode(201).setBody("id"))
+
+            client.upload(
+                zipBytes = "zip".toByteArray(),
+                name = "com.example:mylib:1.0",
+                publishingType = "AUTOMATIC"
+            )
+
+            val request = server.takeRequest()
+            assertThat(request.path).contains("publishingType=AUTOMATIC")
+            assertThat(request.path).contains("name=com.example:mylib:1.0")
+        }
+
+        @Test
+        fun `sends correct authorization header`() {
+            server.enqueue(MockResponse().setResponseCode(201).setBody("id"))
+
+            client.upload(zipBytes = "zip".toByteArray(), name = "test", publishingType = "AUTOMATIC")
+
+            val request = server.takeRequest()
+            val expectedToken = Base64.getEncoder()
+                .encodeToString("testUser:testPassword".toByteArray(StandardCharsets.UTF_8))
+            assertThat(request.getHeader("Authorization")).isEqualTo("Bearer $expectedToken")
+        }
+
+        @Test
+        fun `sends multipart form data with bundle field`() {
+            server.enqueue(MockResponse().setResponseCode(201).setBody("id"))
+
+            client.upload(zipBytes = "zip-data".toByteArray(), name = "test", publishingType = "AUTOMATIC")
+
+            val request = server.takeRequest()
+            assertThat(request.getHeader("Content-Type")).startsWith("multipart/form-data; boundary=")
+            val body = request.body.readUtf8()
+            assertThat(body).contains("Content-Disposition: form-data; name=\"bundle\"")
+            assertThat(body).contains("zip-data")
+        }
+
+        @Test
+        fun `throws CentralPortalApiException on non-201 response`() {
+            server.enqueue(MockResponse().setResponseCode(400).setBody("Bad Request"))
+
+            assertThatThrownBy {
+                client.upload(zipBytes = "zip".toByteArray(), name = "test", publishingType = "AUTOMATIC")
+            }
+                .isInstanceOf(CentralPortalApiException::class.java)
+                .satisfies({ ex ->
+                    ex as CentralPortalApiException
+                    assertThat(ex.statusCode).isEqualTo(400)
+                    assertThat(ex.responseBody).isEqualTo("Bad Request")
+                })
+        }
+    }
+
+    @Nested
+    inner class GetStatusTest {
+
+        @Test
+        fun `parses PUBLISHED state`() {
+            server.enqueue(MockResponse().setBody(statusJson("PUBLISHED")))
+
+            val status = client.getStatus("test-id")
+
+            assertThat(status.deploymentState).isEqualTo("PUBLISHED")
+            assertThat(status.errors).isEmpty()
+        }
+
+        @Test
+        fun `parses PENDING state`() {
+            server.enqueue(MockResponse().setBody(statusJson("PENDING")))
+
+            val status = client.getStatus("test-id")
+
+            assertThat(status.deploymentState).isEqualTo("PENDING")
+        }
+
+        @Test
+        fun `parses FAILED state with errors`() {
+            val json = """
+                {
+                    "deploymentId": "test-id",
+                    "deploymentState": "FAILED",
+                    "errors": ["Invalid POM", "Missing signature"]
+                }
+            """.trimIndent()
+            server.enqueue(MockResponse().setBody(json))
+
+            val status = client.getStatus("test-id")
+
+            assertThat(status.deploymentState).isEqualTo("FAILED")
+            assertThat(status.errors).containsExactly("Invalid POM", "Missing signature")
+        }
+
+        @Test
+        fun `sends correct request`() {
+            server.enqueue(MockResponse().setBody(statusJson("PENDING")))
+
+            client.getStatus("my-deployment-id")
+
+            val request = server.takeRequest()
+            assertThat(request.method).isEqualTo("POST")
+            assertThat(request.path).isEqualTo("/api/v1/publisher/status?id=my-deployment-id")
+        }
+
+        @Test
+        fun `throws CentralPortalApiException on non-200 response`() {
+            server.enqueue(MockResponse().setResponseCode(500).setBody("Internal Server Error"))
+
+            assertThatThrownBy { client.getStatus("test-id") }
+                .isInstanceOf(CentralPortalApiException::class.java)
+                .satisfies({ ex ->
+                    ex as CentralPortalApiException
+                    assertThat(ex.statusCode).isEqualTo(500)
+                })
+        }
+    }
+
+    private fun statusJson(state: String): String = """
+        {
+            "deploymentId": "test-id",
+            "deploymentState": "$state",
+            "errors": []
+        }
+    """.trimIndent()
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+pluginManagement {
+    includeBuild("maven-central-publish-plugin")
+}
+
 include("webauthn4j-core")
 include("webauthn4j-core-async")
 include("webauthn4j-metadata")


### PR DESCRIPTION
## Summary

- Replace jreleaser with a minimal, in-tree Gradle plugin (`maven-central-publish-plugin`) that publishes artifacts to Maven Central via the [Central Portal Publisher API](https://central.sonatype.org/publish/publish-portal-api/)
- Aggregate all subproject artifacts into a single deployment bundle, providing atomic publishing and reducing release time from ~36 minutes to ~5 minutes
- Eliminate the heavyweight jreleaser dependency tree — the plugin has no external runtime dependencies (uses Gradle-bundled Jackson 2 and Java standard library only)

## Motivation

jreleaser uploads each module separately and waits for each to reach `PUBLISHED` before proceeding to the next. With 7 modules, this sequential process took ~36 minutes. The Central Portal API supports uploading multiple modules in a single ZIP
bundle, which jreleaser does not take advantage of.

Additionally, jreleaser brings a large transitive dependency tree for functionality we don't use — we only need the "upload to Central Portal" feature.

## What the new plugin does

The plugin (`net.sharplab.maven-central-publish`) is applied to the root project and configured declaratively:

```kotlin
mavenCentralPublish {
    targetProjects = subprojects.filter { it.name.startsWith("webauthn4j-") }
    username = providers.environmentVariable("MAVEN_CENTRAL_USER")
    password = providers.environmentVariable("MAVEN_CENTRAL_PASSWORD")
}
```

It automatically:
1. Adds a mavenCentralStaging repository to each target subproject's maven-publish configuration
2. Sets up task dependencies so that ./gradlew publishToCentralPortal stages all subprojects first
3. Bundles all staged artifacts into a single ZIP and uploads it to Central Portal
4. Polls for deployment status until PUBLISHED or FAILED

See maven-central-publish-plugin/README.md and maven-central-publish-plugin/ARCHITECTURE.md for details.