### PR TITLE
Add JSON serializer/deserializer for AAGUID and @JsonValue to Options

### DIFF
--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/converter/jackson/WebAuthnMetadataJSONModule.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/converter/jackson/WebAuthnMetadataJSONModule.java
@@ -16,6 +16,9 @@
 
 package com.webauthn4j.metadata.converter.jackson;
 
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
+import com.webauthn4j.metadata.converter.jackson.deserializer.MetadataAAGUIDRelaxedDeserializer;
+import com.webauthn4j.metadata.converter.jackson.serializer.MetadataAAGUIDSerializer;
 import tools.jackson.databind.module.SimpleModule;
 
 public class WebAuthnMetadataJSONModule extends SimpleModule {
@@ -23,6 +26,9 @@ public class WebAuthnMetadataJSONModule extends SimpleModule {
     @SuppressWarnings("deprecation")
     public WebAuthnMetadataJSONModule() {
         super("WebAuthnMetadataJSONModule");
+
+        this.addSerializer(AAGUID.class, new MetadataAAGUIDSerializer());
+        this.addDeserializer(AAGUID.class, new MetadataAAGUIDRelaxedDeserializer());
     }
 
 }

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/converter/jackson/serializer/MetadataAAGUIDSerializer.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/converter/jackson/serializer/MetadataAAGUIDSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.metadata.converter.jackson.serializer;
+
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
+import com.webauthn4j.util.AssertUtil;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Jackson Serializer for {@link AAGUID} in Metadata JSON format.
+ * Serializes AAGUID as a UUID string (e.g. "33c1642b-b5e9-423d-9add-5a0119c2a8b8").
+ */
+public class MetadataAAGUIDSerializer extends StdSerializer<AAGUID> {
+
+    public MetadataAAGUIDSerializer() {
+        super(AAGUID.class);
+    }
+
+    @Override
+    public void serialize(@NotNull AAGUID value, @NotNull JsonGenerator gen, @NotNull SerializationContext provider) {
+        AssertUtil.notNull(value, "value is null");
+        gen.writeString(value.toString());
+    }
+}

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
@@ -18,6 +18,7 @@ package com.webauthn4j.metadata.data.statement;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.webauthn4j.data.PinProtocolVersion;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.metadata.converter.jackson.deserializer.MetadataAAGUIDRelaxedDeserializer;
@@ -212,6 +213,7 @@ public class AuthenticatorGetInfo {
                 this.value = value;
             }
 
+            @JsonValue
             public boolean getValue() {
                 return value;
             }
@@ -243,6 +245,7 @@ public class AuthenticatorGetInfo {
                 this.value = value;
             }
 
+            @JsonValue
             public boolean getValue() {
                 return value;
             }
@@ -274,6 +277,7 @@ public class AuthenticatorGetInfo {
                 this.value = value;
             }
 
+            @JsonValue
             public boolean getValue() {
                 return value;
             }
@@ -305,6 +309,7 @@ public class AuthenticatorGetInfo {
                 this.value = value;
             }
 
+            @JsonValue
             public boolean getValue() {
                 return value;
             }
@@ -336,6 +341,7 @@ public class AuthenticatorGetInfo {
                 this.value = value;
             }
 
+            @JsonValue
             public boolean getValue() {
                 return value;
             }
@@ -367,6 +373,7 @@ public class AuthenticatorGetInfo {
                 this.value = value;
             }
 
+            @JsonValue
             public boolean getValue() {
                 return value;
             }
@@ -398,6 +405,7 @@ public class AuthenticatorGetInfo {
                 this.value = value;
             }
 
+            @JsonValue
             public boolean getValue() {
                 return value;
             }

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/converter/jackson/deserializer/MetadataAAGUIDRelaxedDeserializerTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/converter/jackson/deserializer/MetadataAAGUIDRelaxedDeserializerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.metadata.converter.jackson.deserializer;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
+import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetadataAAGUIDRelaxedDeserializerTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper().rebuild()
+            .addModule(new WebAuthnMetadataJSONModule())
+            .build();
+
+    @Test
+    void deserialize_shouldReadUUIDStringWithHyphens() {
+        AAGUID aaguid = jsonMapper.readValue(
+                "\"33c1642b-b5e9-423d-9add-5a0119c2a8b8\"", AAGUID.class);
+        assertThat(aaguid).isEqualTo(new AAGUID("33c1642b-b5e9-423d-9add-5a0119c2a8b8"));
+    }
+
+    @Test
+    void deserialize_shouldReadUUIDStringWithoutHyphens() {
+        AAGUID aaguid = jsonMapper.readValue(
+                "\"33c1642bb5e9423d9add5a0119c2a8b8\"", AAGUID.class);
+        assertThat(aaguid).isEqualTo(new AAGUID("33c1642b-b5e9-423d-9add-5a0119c2a8b8"));
+    }
+
+    @Test
+    void deserialize_shouldHandleZeroUUID() {
+        AAGUID aaguid = jsonMapper.readValue(
+                "\"00000000-0000-0000-0000-000000000000\"", AAGUID.class);
+        assertThat(aaguid).isEqualTo(AAGUID.ZERO);
+    }
+}

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/converter/jackson/serializer/MetadataAAGUIDSerializerTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/converter/jackson/serializer/MetadataAAGUIDSerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.metadata.converter.jackson.serializer;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
+import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MetadataAAGUIDSerializerTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper().rebuild()
+            .addModule(new WebAuthnMetadataJSONModule())
+            .build();
+
+    @Test
+    void serialize_shouldWriteUUIDString() {
+        AAGUID aaguid = new AAGUID("33c1642b-b5e9-423d-9add-5a0119c2a8b8");
+        String json = jsonMapper.writeValueAsString(aaguid);
+        assertThat(json).isEqualTo("\"33c1642b-b5e9-423d-9add-5a0119c2a8b8\"");
+    }
+
+    @Test
+    void serialize_shouldRoundTrip() {
+        AAGUID original = new AAGUID("33c1642b-b5e9-423d-9add-5a0119c2a8b8");
+        String json = jsonMapper.writeValueAsString(original);
+        AAGUID deserialized = jsonMapper.readValue(json, AAGUID.class);
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void serialize_shouldThrowForNull() {
+        MetadataAAGUIDSerializer serializer = new MetadataAAGUIDSerializer();
+        assertThatThrownBy(() -> serializer.serialize(null, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
@@ -19,6 +19,7 @@ package com.webauthn4j.metadata.data.statement;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.PinProtocolVersion;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
+import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -26,7 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthenticatorGetInfoTest {
 
-    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper().rebuild()
+            .addModule(new WebAuthnMetadataJSONModule())
+            .build();
 
 
     @Test
@@ -47,6 +50,57 @@ class AuthenticatorGetInfoTest {
         );
         assertThat(authenticatorGetInfo.getMaxMsgSize()).isEqualTo(1200);
         assertThat(authenticatorGetInfo.getPinUvAuthProtocols()).containsExactly(PinProtocolVersion.VERSION_1);
+    }
+
+    @Test
+    void options_shouldSerializeAsPlainBooleans() {
+        AuthenticatorGetInfo.Options options = new AuthenticatorGetInfo.Options(
+                AuthenticatorGetInfo.Options.PlatformOption.CROSS_PLATFORM,
+                AuthenticatorGetInfo.Options.ResidentKeyOption.SUPPORTED,
+                AuthenticatorGetInfo.Options.ClientPINOption.SET,
+                AuthenticatorGetInfo.Options.UserPresenceOption.SUPPORTED,
+                AuthenticatorGetInfo.Options.UserVerificationOption.READY,
+                null,
+                null
+        );
+        String json = jsonMapper.writeValueAsString(options);
+        assertThat(json).contains("\"plat\":false");
+        assertThat(json).contains("\"rk\":true");
+        assertThat(json).contains("\"clientPin\":true");
+        assertThat(json).contains("\"up\":true");
+        assertThat(json).contains("\"uv\":true");
+        // Should NOT contain nested objects
+        assertThat(json).doesNotContain("\"value\"");
+    }
+
+    @Test
+    void options_shouldRoundTrip() {
+        AuthenticatorGetInfo.Options original = new AuthenticatorGetInfo.Options(
+                AuthenticatorGetInfo.Options.PlatformOption.CROSS_PLATFORM,
+                AuthenticatorGetInfo.Options.ResidentKeyOption.SUPPORTED,
+                AuthenticatorGetInfo.Options.ClientPINOption.SET,
+                AuthenticatorGetInfo.Options.UserPresenceOption.SUPPORTED,
+                AuthenticatorGetInfo.Options.UserVerificationOption.READY,
+                AuthenticatorGetInfo.Options.UVTokenOption.NOT_SUPPORTED,
+                AuthenticatorGetInfo.Options.ConfigOption.NOT_SUPPORTED
+        );
+        String json = jsonMapper.writeValueAsString(original);
+        AuthenticatorGetInfo.Options deserialized = jsonMapper.readValue(json, AuthenticatorGetInfo.Options.class);
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void authenticatorGetInfo_aaguid_shouldSerializeAsString() {
+        AuthenticatorGetInfo info = new AuthenticatorGetInfo(
+                java.util.List.of("FIDO_2_0"),
+                null,
+                new AAGUID("33c1642b-b5e9-423d-9add-5a0119c2a8b8"),
+                null,
+                null,
+                null
+        );
+        String json = jsonMapper.writeValueAsString(info);
+        assertThat(json).contains("\"aaguid\":\"33c1642b-b5e9-423d-9add-5a0119c2a8b8\"");
     }
 
     private AuthenticatorGetInfo createAuthenticatorGetInfo(){


### PR DESCRIPTION
Add custom JSON serializer/deserializer for AAGUID that serializes to/from UUID string format ("33c1642b-...") instead of the default object format. Registered in WebAuthnJSONModule.

Add @JsonValue to AuthenticatorGetInfo.Options inner classes (PlatformOption, ResidentKeyOption, etc.) so they serialize as plain boolean values instead of objects with a value field.