### PR TITLE
Add fido-integration-bdd: BDD integration test suite for WebAuthn protocol

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,13 @@ selenium = "4.44.0"
 assertj = "3.27.7"
 playwright = "1.60.0"
 
+# fido-integration-bdd dependencies
+
+kotlin = "2.3.21"
+kotest = "5.9.1"
+kotlinx-coroutines = "1.11.0"
+webauthn4j-ctap = "0.2.0.RELEASE"
+
 [libraries]
 # Third-party libraries
 
@@ -47,6 +54,16 @@ selenium-java = { module = "org.seleniumhq.selenium:selenium-java", version.ref 
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 playwright = { module = "com.microsoft.playwright:playwright", version.ref = "playwright" }
 
+# fido-integration-bdd dependencies
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+jackson-module-kotlin = { module = "tools.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+webauthn4j-ctap-authenticator = { module = "com.webauthn4j:webauthn4j-ctap-authenticator", version.ref = "webauthn4j-ctap" }
+webauthn4j-ctap-client = { module = "com.webauthn4j:webauthn4j-ctap-client", version.ref = "webauthn4j-ctap" }
+
 
 [plugins]
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
@@ -55,3 +72,4 @@ sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot-bom" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }
 quarkus = { id = "io.quarkus", version.ref = "quarkus" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/integration-tests/fido-integration-bdd/README.md
+++ b/integration-tests/fido-integration-bdd/README.md
@@ -1,0 +1,313 @@
+# FIDO Integration BDD Tests
+
+## System Under Test
+
+This test suite verifies the integration of three components across the
+FIDO2/WebAuthn protocol stack:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Server (Relying Party)                                     │
+│  webauthn4j-core: WebAuthnManager                           │
+│  - Verifies registration (attestation, client data)         │
+│  - Verifies authentication (signature, authenticator data)  │
+│  - Stores credentials (credential store)                    │
+└──────────────────────────┬──────────────────────────────────┘
+                           │  RegistrationRequest / AuthenticationRequest
+┌──────────────────────────┴──────────────────────────────────┐
+│  Client Platform                                            │
+│  webauthn4j-ctap: WebAuthnClient                            │
+│  - Filters authenticators by attachment                     │
+│  - Handles attestation conveyance preference                │
+│  - Sets origin in CollectedClientData                       │
+│  - Provides client PIN to authenticator                     │
+│  - Manages credential selection for discoverable credentials│
+└──────────────────────────┬──────────────────────────────────┘
+                           │  CTAP2 protocol (InProcessAdaptor)
+┌──────────────────────────┴──────────────────────────────────┐
+│  Authenticator                                              │
+│  webauthn4j-ctap: CtapAuthenticator                         │
+│  - Generates credentials (makeCredential)                   │
+│  - Signs assertions (getAssertion)                          │
+│  - Manages client PIN, reset                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## DSL
+
+Test environments are set up declaratively. All components (clientPlatform,
+authenticator, relyingParty) must be explicitly declared:
+
+```kotlin
+// Standard: single authenticator with custom settings
+val env = WebAuthnTestEnvironment.create {
+    clientPlatform {
+        authenticator { algorithms = setOf(ES256) }
+    }
+    relyingParty { rpId = "example.com" }
+}
+
+// Multiple authenticators on one client platform
+val env = WebAuthnTestEnvironment.create {
+    clientPlatform {
+        authenticator { attachment = CROSS_PLATFORM }
+        authenticator { attachment = PLATFORM }
+    }
+    relyingParty()
+}
+
+// All defaults (ES256, CROSS_PLATFORM, example.com)
+val env = WebAuthnTestEnvironment.createDefault()
+```
+
+### Protocol flows via step objects
+
+Registration and authentication flows are decomposed into step objects,
+each representing a protocol state:
+
+```kotlin
+// Full chain
+val result = env.scenario
+    .createRegistrationOptions()
+    .createCredential()
+    .verifyOnServer()
+
+// Step-by-step with inspection
+val options = env.scenario.createRegistrationOptions(pubKeyCredParams = listOf(...))
+val credentialCreated = options.createCredential()
+val result = credentialCreated.verifyOnServer(rpId = "...")
+
+// Convenience (all defaults)
+env.scenario.register()
+env.scenario.authenticate()
+```
+
+### Accessing components
+
+```kotlin
+env.relyingParty.webAuthnManager   // Server verification
+env.clientPlatform.webAuthnClient  // Client Platform
+env.clientPlatform.ctapService     // CTAP service (PIN, reset, etc.)
+```
+
+## Test Design
+
+### Component Parameters
+
+Each component has configurable parameters. Tests verify behavior when
+these parameters are varied individually or in combination.
+Server parameters are listed first as webauthn4j is a server-side library.
+
+**Server parameters:**
+
+*PublicKeyCredentialCreationOptions (Registration request):*
+
+| Parameter | Values |
+|-----------|--------|
+| `rp` (rpId, rpName) | RP identifier and display name |
+| `user` (id, name, displayName) | User entity |
+| `challenge` | Random challenge |
+| `pubKeyCredParams` | Algorithm list |
+| `timeout` | Milliseconds (optional) |
+| `excludeCredentials` | Credential ID list |
+| `authenticatorSelection.authenticatorAttachment` | PLATFORM, CROSS_PLATFORM, null |
+| `authenticatorSelection.residentKey` | REQUIRED, PREFERRED, DISCOURAGED |
+| `authenticatorSelection.userVerification` | REQUIRED, PREFERRED, DISCOURAGED |
+| `attestation` | DIRECT, NONE, INDIRECT, ENTERPRISE |
+| `attestationFormats` | Requested attestation format list |
+| `hints` | PUBLIC_KEY, CLIENT_DEVICE, SECURITY_KEY |
+| `extensions` | WebAuthn extensions (credProtect, uvm, credProps, hmacCreateSecret, ...) |
+
+*PublicKeyCredentialRequestOptions (Authentication request):*
+
+| Parameter | Values |
+|-----------|--------|
+| `challenge` | Random challenge |
+| `timeout` | Milliseconds (optional) |
+| `rpId` | RP identifier |
+| `allowCredentials` | Credential ID list |
+| `userVerification` | REQUIRED, PREFERRED, DISCOURAGED |
+| `hints` | PUBLIC_KEY, CLIENT_DEVICE, SECURITY_KEY |
+| `extensions` | WebAuthn extensions (appid, appidExclude, uvm, hmacGetSecret, ...) |
+
+*ServerProperty (Verification):*
+
+| Parameter | Values |
+|-----------|--------|
+| `origin` / `originPredicate` | Expected origin(s) for verification |
+| `topOrigin` / `topOriginPredicate` | Expected top-level origin for cross-origin iframe |
+| `rpId` | RP identifier for rpIdHash verification |
+| `challenge` | Expected challenge |
+
+*RegistrationParameters (Registration verification flags):*
+
+| Parameter | Values |
+|-----------|--------|
+| `userVerificationRequired` | true, false |
+| `userPresenceRequired` | true, false |
+| `pubKeyCredParams` | Allowed algorithms for verification |
+
+*AuthenticationParameters (Authentication verification flags):*
+
+| Parameter | Values |
+|-----------|--------|
+| `userVerificationRequired` | true, false |
+| `userPresenceRequired` | true, false |
+| `allowCredentials` | Allowed credential IDs for verification |
+| `signatureCounter` validation | Counter must increment |
+
+**Client Platform parameters:**
+
+| Parameter | Values |
+|-----------|--------|
+| `origin` | URL (set in CollectedClientData) |
+| `crossOrigin` | true, false (cross-origin iframe context) |
+| `topOrigin` | Top-level origin (set when crossOrigin=true) |
+| Attestation conveyance handling | DIRECT, NONE, INDIRECT processing |
+| Authenticator filtering | Filter by attachment type |
+| Credential selection handler | Select from discoverable credentials |
+| Client PIN provider | Provides PIN value |
+
+**Authenticator parameters:**
+
+| Parameter | Values |
+|-----------|--------|
+| `attestationStatementProvider` | Packed, FIDO U2F, None |
+| `algorithms` | ES256, RS256, ... |
+| `residentKey` | ALWAYS, IF_REQUIRED, NEVER |
+| `userVerification` | READY, NOT_READY, NOT_SUPPORTED |
+| `userPresence` | SUPPORTED, NOT_SUPPORTED |
+| `attachment` | PLATFORM, CROSS_PLATFORM |
+| `aaguid` | Custom UUID |
+| `credentialSelector` | CLIENT_PLATFORM, AUTHENTICATOR |
+| `clientPIN` | ENABLED, DISABLED |
+| `resetProtection` | ENABLED, DISABLED |
+| `transports` | USB, NFC, BLE, INTERNAL, HYBRID |
+
+### Parameter Interaction Map
+
+Not all parameters interact. Tests are needed only for parameters that
+affect each other's behavior. Independent parameters are tested in
+isolation. The map is organized around what the Server requests or
+verifies, since server-side verification is the primary concern.
+
+| Classification | Server | Client Platform | Authenticator | Interaction |
+|---|---|---|---|---|
+| | **— Credential —** | | | |
+| Matrix | `pubKeyCredParams` | — | `algorithms` | Algorithm negotiation |
+| Matrix | `residentKeyRequirement` | — | `residentKey` | Resident key negotiation |
+| Matrix | `excludeCredentials` | — | — | Exclude check |
+| Matrix | — | selection handler | `credentialSelector` | Credential selection |
+| | **— User Verification —** | | | |
+| Matrix | `userVerificationRequirement` | PIN provider | `userVerification`, `clientPIN` | UV negotiation |
+| Matrix | `userPresenceRequired` | — | `userPresence` | UP validation |
+| | **— Authenticator Selection —** | | | |
+| Matrix | `authenticatorAttachment` | **filtering** | `attachment` | Attachment matching |
+| | **— Attestation —** | | | |
+| Matrix | `attestation` preference | **conveyance handling** | `attestationProvider` | Attestation delivery |
+| Matrix | AttestationStatementVerifier, TrustAnchorRepository | — | `attestationProvider` | Attestation trust verification |
+| | **— Server Verification —** | | | |
+| Matrix | `origin` (ServerProperty) | `origin` | — | Origin validation |
+| Matrix | `topOrigin` (ServerProperty) | `crossOrigin`, `topOrigin` | — | Cross-origin validation |
+| Matrix | `rpId` (ServerProperty) | — | — | RP ID validation |
+| Matrix | `challenge` (ServerProperty) | — | — | Challenge validation |
+| Matrix | counter validation | — | — | Signature counter |
+| Single | — | — | `aaguid` | Authenticator identity: propagated as-is, no interaction |
+| Single | — | — | `resetProtection` | Authenticator management: independent setting |
+| Single | — | — | `transports` | Transport hints: propagated to credential record, no negotiation |
+| | **— Out of Scope —** | | | |
+| Out of scope | `timeout` | — | — | Not implemented in webauthn4j-ctap |
+| Out of scope | `hints` | — | — | Advisory only, no behavioral impact |
+| Out of scope | `attestationFormats` | — | — | Not implemented in webauthn4j-ctap |
+| Out of scope | `extensions` | — | — | Per-extension testing; separate effort |
+| Out of scope | `user` (id, name, displayName) | — | — | Passed through; server doesn't verify |
+| Out of scope | `rp.name` | — | — | Display only; server doesn't verify |
+
+## Test Categories
+
+Based on the interaction map, tests are organized into:
+
+### 1. Parameter Tests
+
+Tests that vary one or more parameters and verify their effect on the
+registration/authentication flow. Covers both single-parameter and
+cross-component interaction (matrix) cases.
+
+| Group | Test | Parameters | Spec |
+|-------|------|-----------|------|
+| Credential | Algorithm negotiation (client) | Server.`pubKeyCredParams` × Authenticator.`algorithms` | `AlgorithmSpec` |
+| Credential | Algorithm verification (server) | Authenticator.`algorithms` × Server.`RegistrationParameters.pubKeyCredParams` | `AlgorithmSpec` |
+| Credential | Resident key negotiation | Server.`residentKeyRequirement` × Authenticator.`residentKey` | `ResidentKeySpec` |
+| Credential | Exclude credentials | Server.`excludeCredentials` | `ExcludeCredentialsSpec` |
+| Credential | Allow credentials | Server.`allowCredentials` | `AllowCredentialsSpec` |
+| Credential | Credential selection | Client.selectionHandler × Authenticator.`credentialSelector` | `CredentialSelectorSpec` |
+| User Verification | UV negotiation | Server.`userVerificationRequirement` × Authenticator.`userVerification` × Authenticator.`clientPIN` | `UserVerificationSpec` |
+| User Verification | ClientPIN impact | Authenticator.`clientPIN` × Authenticator.`userVerification` | `ClientPINSpec` |
+| User Verification | UP validation | Server.`userPresenceRequired` × Authenticator.`userPresence` | `UserPresenceSpec` |
+| Authenticator Selection | Attachment matching | Server.`authenticatorAttachment` × Client.filtering × Authenticator.`attachment` | `AttachmentSpec` |
+| Attestation | Attestation delivery | Server.`attestation` × Client.conveyance × Authenticator.`attestationProvider` | `AttestationConveyanceSpec`, `AttestationFormatSpec` |
+| Attestation | Attestation trust | Server.AttestationStatementVerifier, TrustAnchorRepository × Authenticator.`attestationProvider` | `AttestationTrustSpec` |
+| Server Verification | Origin validation | Server.`origin` × Client.`origin` | `OriginSpec` |
+| Server Verification | Cross-origin validation | Server.`topOrigin` × Client.`crossOrigin`, `topOrigin` | `CrossOriginSpec` (@Ignored) |
+| Server Verification | RP ID validation | Server.`rpId` | `RpIdSpec` |
+| Server Verification | Challenge validation | Server.`challenge` | `ChallengeSpec` |
+| Server Verification | Signature counter | Server.counter check | `CounterSpec` |
+| Server Verification | Backup state | BE/BS flag consistency | `BackupStateSpec` |
+| Server Verification | Credential ID | ID length ≤1023, uniqueness | `CredentialIdSpec` |
+| Authenticator | AAGUID propagation | Authenticator.`aaguid` | `AAGUIDSpec` |
+| Authenticator | Reset protection | Authenticator.`resetProtection` | `ResetProtectionSpec` |
+| Authenticator | Transport hints | Authenticator.`transports` | `TransportSpec` |
+
+### 2. Scenario Tests
+
+End-to-end tests that verify complete user journeys spanning multiple
+protocol operations.
+
+| Scenario | Description | Spec |
+|----------|-------------|------|
+| Passwordless flow | Resident key registration → discoverable authentication | `PasswordlessFlowSpec` |
+| Second factor flow | Non-resident registration → allowCredentials authentication | `SecondFactorFlowSpec` |
+| Client PIN management | PIN set, change, retry count | `ClientPINManagementSpec` |
+| Credential deletion | Delete credential → authentication fails | `CredentialDeletionSpec` |
+
+## Architecture
+
+### Package Structure
+
+```
+environment/
+├── Authenticator.kt            — Authenticator.Builder + Authenticator (InternalTransport)
+├── ClientPlatform.kt           — ClientPlatform (WebAuthnClient, CtapService)
+├── RelyingParty.kt             — RelyingParty.Builder + RelyingParty (WebAuthnManager, credential store)
+├── StandardScenario.kt         — Protocol flow orchestration + step objects + result classes
+└── WebAuthnTestEnvironment.kt  — WebAuthnTestEnvironment.create/createDefault + EnvironmentDsl + ClientPlatformDsl
+
+support/
+└── BddHtmlReporter.kt          — Custom single-page BDD HTML report with @Tags grouping
+```
+
+### Step Objects (in StandardScenario)
+
+Registration flow:
+```
+createRegistrationOptions() → RegistrationOptionsCreated
+    .createCredential()     → RegistrationCredentialCreated
+    .verifyOnServer()       → RegistrationResult
+```
+
+Authentication flow:
+```
+createAuthenticationOptions() → AuthenticationOptionsCreated
+    .getAssertion()           → AuthenticationAssertionCreated
+    .verifyOnServer()         → AuthenticationResult
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+./gradlew :integration-tests:fido-integration-bdd:test
+
+# BDD HTML report
+# Generated at: build/reports/bdd/index.html
+```

--- a/integration-tests/fido-integration-bdd/build.gradle.kts
+++ b/integration-tests/fido-integration-bdd/build.gradle.kts
@@ -1,0 +1,44 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+description = "WebAuthn4J FIDO Integration Tests in BDD style"
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    // WebAuthn4J (local project)
+    testImplementation(project(":webauthn4j-core"))
+    testImplementation(project(":webauthn4j-test"))
+
+    // WebAuthn4J CTAP (from Maven Central)
+    testImplementation(libs.webauthn4j.ctap.authenticator)
+    testImplementation(libs.webauthn4j.ctap.client)
+
+    // Kotlin Coroutines
+    testImplementation(libs.kotlinx.coroutines.core)
+    testImplementation(libs.kotlinx.coroutines.test)
+
+    // Kotest
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.framework.datatest)
+    // Jackson (for ObjectConverter)
+    testImplementation(libs.jackson.databind)
+    testImplementation(libs.jackson.dataformat.cbor)
+    testImplementation(libs.jackson.module.kotlin)
+
+    // Logging
+    testImplementation(platform(libs.spring.boot.bom))
+    testImplementation("ch.qos.logback:logback-classic")
+}
+
+sonarqube {
+    isSkipProject = true
+}

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/KotestProjectConfig.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/KotestProjectConfig.kt
@@ -1,0 +1,11 @@
+package com.webauthn4j.test.integration
+
+import com.webauthn4j.test.integration.support.BddHtmlReporter
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+
+class KotestProjectConfig : AbstractProjectConfig() {
+    override fun extensions(): List<Extension> = listOf(
+        BddHtmlReporter(),
+    )
+}

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/Authenticator.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/Authenticator.kt
@@ -1,0 +1,90 @@
+package com.webauthn4j.test.integration.environment
+
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.ctap.authenticator.CredentialSelectionHandler
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.GetAssertionConsentRequest
+import com.webauthn4j.ctap.authenticator.MakeCredentialConsentRequest
+import com.webauthn4j.ctap.authenticator.UserVerificationHandler
+import com.webauthn4j.ctap.authenticator.attestation.AttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FBasicAttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.attestation.PackedBasicAttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.data.credential.Credential
+import com.webauthn4j.ctap.authenticator.data.settings.*
+import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
+import com.webauthn4j.ctap.authenticator.store.InMemoryAuthenticatorPropertyStore
+import com.webauthn4j.ctap.authenticator.transport.internal.InternalTransport
+import com.webauthn4j.ctap.core.data.options.UserVerificationOption
+import com.webauthn4j.data.AuthenticatorTransport
+import com.webauthn4j.data.attestation.authenticator.AAGUID
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
+import java.util.*
+
+/** Runtime representation of a built authenticator. */
+data class Authenticator(
+    val transport: InternalTransport,
+    val propertyStore: AuthenticatorPropertyStore,
+) {
+    class Builder {
+        var attestationStatementProvider: AttestationStatementProvider =
+            PackedBasicAttestationStatementProvider.createWithDemoAttestationKey()
+        var fidoU2FAttestationStatementProvider: FIDOU2FBasicAttestationStatementProvider =
+            FIDOU2FBasicAttestationStatementProvider.createWithDemoAttestationKey()
+        var aaguid: AAGUID = AAGUID(UUID.randomUUID())
+        var algorithms: Set<COSEAlgorithmIdentifier> = setOf(COSEAlgorithmIdentifier.ES256)
+        var residentKey: ResidentKeySetting = ResidentKeySetting.IF_REQUIRED
+        var clientPIN: ClientPINSetting = ClientPINSetting.ENABLED
+        var userVerification: UserVerificationSetting = UserVerificationSetting.READY
+        var userPresence: UserPresenceSetting = UserPresenceSetting.SUPPORTED
+        var attachment: AttachmentSetting = AttachmentSetting.CROSS_PLATFORM
+        var credentialSelector: CredentialSelectorSetting = CredentialSelectorSetting.CLIENT_PLATFORM
+        var resetProtection: ResetProtectionSetting = ResetProtectionSetting.DISABLED
+        var transports: Set<AuthenticatorTransport> = setOf(AuthenticatorTransport.USB)
+        var propertyStore: AuthenticatorPropertyStore? = null
+
+        internal fun build(objectConverter: ObjectConverter): Authenticator {
+            val effectivePropertyStore = (propertyStore ?: InMemoryAuthenticatorPropertyStore()).apply {
+                algorithms = this@Builder.algorithms
+            }
+            val ctapAuthenticator = createCtapAuthenticator(objectConverter, effectivePropertyStore)
+            val uvHandler = createUserVerificationHandler()
+            val transport = InternalTransport(ctapAuthenticator, uvHandler)
+            return Authenticator(transport, effectivePropertyStore)
+        }
+
+        private fun createCtapAuthenticator(
+            objectConverter: ObjectConverter,
+            propertyStore: AuthenticatorPropertyStore,
+        ): CtapAuthenticator {
+            val credSelectionHandler = object : CredentialSelectionHandler {
+                override suspend fun onSelect(list: List<Credential>): Credential = list.first()
+            }
+            return CtapAuthenticator(
+                objectConverter, attestationStatementProvider, fidoU2FAttestationStatementProvider,
+                transports, emptyList(), propertyStore, credentialSelectionHandler = credSelectionHandler
+            ).apply {
+                aaguid = this@Builder.aaguid
+                platform = attachment
+                residentKey = this@Builder.residentKey
+                clientPIN = this@Builder.clientPIN
+                resetProtection = this@Builder.resetProtection
+                userPresence = this@Builder.userPresence
+                userVerification = this@Builder.userVerification
+                credentialSelector = this@Builder.credentialSelector
+            }
+        }
+
+        private fun createUserVerificationHandler(): UserVerificationHandler {
+            val uvSetting = userVerification
+            return object : UserVerificationHandler {
+                override fun getUserVerificationOption(rpId: String?): UserVerificationOption? = when (uvSetting) {
+                    UserVerificationSetting.READY -> UserVerificationOption(true)
+                    UserVerificationSetting.NOT_READY -> UserVerificationOption(false)
+                    UserVerificationSetting.NOT_SUPPORTED -> null
+                }
+                override suspend fun onMakeCredentialConsentRequested(r: MakeCredentialConsentRequest) = true
+                override suspend fun onGetAssertionConsentRequested(r: GetAssertionConsentRequest) = true
+            }
+        }
+    }
+}

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/ClientPlatform.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/ClientPlatform.kt
@@ -1,0 +1,17 @@
+package com.webauthn4j.test.integration.environment
+
+import com.webauthn4j.ctap.client.CtapService
+import com.webauthn4j.ctap.client.WebAuthnClient
+import com.webauthn4j.data.client.Origin
+
+/** Runtime representation of a built client platform. */
+data class ClientPlatform(
+    val webAuthnClient: WebAuthnClient,
+    val ctapServices: List<CtapService>,
+    val authenticators: List<Authenticator>,
+    val origin: Origin,
+    val clientPINValue: String,
+) {
+    /** Shortcut to the first CTAP service. */
+    val ctapService: CtapService get() = ctapServices.first()
+}

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/RelyingParty.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/RelyingParty.kt
@@ -1,0 +1,64 @@
+package com.webauthn4j.test.integration.environment
+
+import com.webauthn4j.WebAuthnManager
+import com.webauthn4j.credential.CredentialRecord
+import com.webauthn4j.data.AttestationConveyancePreference
+import com.webauthn4j.data.ResidentKeyRequirement
+import com.webauthn4j.data.UserVerificationRequirement
+import com.webauthn4j.data.client.Origin
+
+/**
+ * Relying Party: configuration + server-side verification + credential store.
+ * Does not contain any protocol flow logic (that's in [StandardScenario]).
+ */
+class RelyingParty internal constructor(
+    val rpId: String,
+    val rpName: String,
+    val origin: Origin,
+    val attestation: AttestationConveyancePreference,
+    val residentKeyRequirement: ResidentKeyRequirement,
+    val userVerificationRequirement: UserVerificationRequirement,
+    val userVerificationRequired: Boolean,
+    val userPresenceRequired: Boolean,
+    val webAuthnManager: WebAuthnManager,
+) {
+    private val credentialStore = mutableMapOf<CredentialId, CredentialRecord>()
+
+    fun storeCredential(credentialId: ByteArray, record: CredentialRecord) {
+        credentialStore[CredentialId(credentialId)] = record
+    }
+
+    fun lookupCredential(credentialId: ByteArray): CredentialRecord? {
+        return credentialStore[CredentialId(credentialId)]
+    }
+
+    fun deleteCredential(credentialId: ByteArray) {
+        credentialStore.remove(CredentialId(credentialId))
+    }
+
+    private data class CredentialId(val bytes: ByteArray) {
+        override fun equals(other: Any?) = other is CredentialId && bytes.contentEquals(other.bytes)
+        override fun hashCode() = bytes.contentHashCode()
+    }
+
+    class Builder {
+        var rpId: String = "example.com"
+        var rpName: String = "WebAuthn4J Integration Test"
+        var origin: Origin = Origin("https://example.com")
+        var attestation: AttestationConveyancePreference = AttestationConveyancePreference.NONE
+        var residentKeyRequirement: ResidentKeyRequirement = ResidentKeyRequirement.PREFERRED
+        var userVerificationRequirement: UserVerificationRequirement = UserVerificationRequirement.PREFERRED
+        var userVerificationRequired: Boolean = false
+        var userPresenceRequired: Boolean = true
+        var webAuthnManager: WebAuthnManager? = null
+
+        internal fun build(): RelyingParty {
+            val manager = webAuthnManager ?: WebAuthnManager.createNonStrictWebAuthnManager()
+            return RelyingParty(
+                rpId, rpName, origin, attestation,
+                residentKeyRequirement, userVerificationRequirement,
+                userVerificationRequired, userPresenceRequired, manager
+            )
+        }
+    }
+}

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
@@ -1,0 +1,267 @@
+package com.webauthn4j.test.integration.environment
+
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.credential.CredentialRecord
+import com.webauthn4j.credential.CredentialRecordImpl
+import com.webauthn4j.ctap.client.PublicKeyCredentialCreationContext
+import com.webauthn4j.ctap.client.PublicKeyCredentialRequestContext
+import com.webauthn4j.ctap.client.PublicKeyCredentialSelectionHandler
+import com.webauthn4j.data.*
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
+import com.webauthn4j.data.client.Origin
+import com.webauthn4j.data.client.challenge.Challenge
+import com.webauthn4j.data.client.challenge.DefaultChallenge
+import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput
+import com.webauthn4j.server.ServerProperty
+
+/**
+ * Standard WebAuthn scenario that orchestrates the registration/authentication
+ * protocol flow between a [RelyingParty] and a [ClientPlatform].
+ *
+ * Each flow is decomposed into step objects representing protocol states:
+ * - Registration: [RegistrationOptionsCreated] → [RegistrationCredentialCreated] → [RegistrationResult]
+ * - Authentication: [AuthenticationOptionsCreated] → [AuthenticationAssertionCreated] → [AuthenticationResult]
+ */
+class StandardScenario internal constructor(
+    val relyingParty: RelyingParty,
+    val defaultClientPlatform: ClientPlatform,
+    private val objectConverter: ObjectConverter,
+) {
+    // ============================================================
+    // Registration Flow
+    // ============================================================
+
+    fun createRegistrationOptions(
+        pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
+        excludeCredentials: List<PublicKeyCredentialDescriptor>? = null,
+        authenticatorAttachment: AuthenticatorAttachment? = null,
+    ): RegistrationOptionsCreated {
+        val rp = relyingParty
+        val challenge = DefaultChallenge()
+        val options = PublicKeyCredentialCreationOptions(
+            PublicKeyCredentialRpEntity(rp.rpId, rp.rpName),
+            PublicKeyCredentialUserEntity(ByteArray(32), "user@example.com", "Test User"),
+            challenge,
+            pubKeyCredParams ?: listOf(
+                PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256)
+            ),
+            null,
+            excludeCredentials ?: emptyList(),
+            AuthenticatorSelectionCriteria(
+                authenticatorAttachment,
+                rp.residentKeyRequirement == ResidentKeyRequirement.REQUIRED,
+                rp.residentKeyRequirement,
+                rp.userVerificationRequirement
+            ),
+            rp.attestation,
+            null
+        )
+        return RegistrationOptionsCreated(options, challenge, this)
+    }
+
+    /** Convenience: full registration flow with all defaults. */
+    suspend fun register(): RegistrationResult =
+        createRegistrationOptions()
+            .createCredential(defaultClientPlatform)
+            .verifyOnServer()
+
+    // ============================================================
+    // Authentication Flow
+    // ============================================================
+
+    fun createAuthenticationOptions(
+        allowCredentials: List<PublicKeyCredentialDescriptor>? = null,
+        userVerificationRequirement: UserVerificationRequirement? = null,
+    ): AuthenticationOptionsCreated {
+        val rp = relyingParty
+        val challenge = DefaultChallenge()
+        val options = PublicKeyCredentialRequestOptions(
+            challenge, null, rp.rpId, allowCredentials,
+            userVerificationRequirement ?: rp.userVerificationRequirement, null
+        )
+        return AuthenticationOptionsCreated(options, challenge, this)
+    }
+
+    /** Convenience: full authentication flow with all defaults. */
+    suspend fun authenticate(): AuthenticationResult =
+        createAuthenticationOptions()
+            .getAssertion()
+            .verifyOnServer()
+
+    // ============================================================
+    // Step Objects — Registration
+    // ============================================================
+
+    /** RP has created registration options. Ready to send to client platform. */
+    class RegistrationOptionsCreated internal constructor(
+        val publicKeyCredentialCreationOptions: PublicKeyCredentialCreationOptions,
+        internal val challenge: Challenge,
+        internal val scenario: StandardScenario,
+    ) {
+        /**
+         * Send to client platform: calls WebAuthnClient.create().
+         * @param overrideChallenge If set, replaces the challenge (simulates challenge fixation attack).
+         * @param overrideOrigin If set, replaces the origin (simulates cross-origin attack).
+         */
+        suspend fun createCredential(
+            clientPlatform: ClientPlatform = scenario.defaultClientPlatform,
+            overrideChallenge: Challenge? = null,
+            overrideOrigin: Origin? = null,
+        ): RegistrationCredentialCreated {
+            val effectiveOptions = if (overrideChallenge != null) {
+                PublicKeyCredentialCreationOptions(
+                    publicKeyCredentialCreationOptions.rp,
+                    publicKeyCredentialCreationOptions.user,
+                    overrideChallenge,
+                    publicKeyCredentialCreationOptions.pubKeyCredParams,
+                    publicKeyCredentialCreationOptions.timeout,
+                    publicKeyCredentialCreationOptions.excludeCredentials,
+                    publicKeyCredentialCreationOptions.authenticatorSelection,
+                    publicKeyCredentialCreationOptions.attestation,
+                    publicKeyCredentialCreationOptions.extensions
+                )
+            } else {
+                publicKeyCredentialCreationOptions
+            }
+            val context = PublicKeyCredentialCreationContext(
+                overrideOrigin ?: clientPlatform.origin,
+                clientPINProvider = { clientPlatform.clientPINValue.toByteArray() }
+            )
+            val credential = clientPlatform.webAuthnClient.create(effectiveOptions, context)
+            return RegistrationCredentialCreated(credential, challenge, scenario)
+        }
+    }
+
+    /** Client platform has created a credential. Ready for server verification. */
+    class RegistrationCredentialCreated internal constructor(
+        val credential: PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput>,
+        private val challenge: Challenge,
+        private val scenario: StandardScenario,
+    ) {
+        /** Server verifies the registration response. */
+        fun verifyOnServer(
+            rpId: String? = null,
+            pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
+        ): RegistrationResult {
+            val rp = scenario.relyingParty
+            val registrationRequest = RegistrationRequest(
+                credential.response!!.attestationObject,
+                credential.response!!.clientDataJSON,
+                scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
+                credential.response!!.transports.map { it.value }.toSet()
+            )
+            val serverProperty = ServerProperty.builder()
+                .origin(rp.origin)
+                .rpId(rpId ?: rp.rpId)
+                .challenge(this.challenge)
+                .build()
+            val params = RegistrationParameters(
+                serverProperty, pubKeyCredParams, rp.userVerificationRequired, rp.userPresenceRequired
+            )
+            val data = rp.webAuthnManager.verify(registrationRequest, params)
+            val record = CredentialRecordImpl(
+                data.attestationObject!!, data.collectedClientData, data.clientExtensions, data.transports
+            )
+
+            // Store credential in RP for later authentication lookup
+            rp.storeCredential(credential.rawId, record)
+
+            return RegistrationResult(credential, data, record)
+        }
+    }
+
+    // ============================================================
+    // Step Objects — Authentication
+    // ============================================================
+
+    /** RP has created authentication options. Ready to send to client platform. */
+    class AuthenticationOptionsCreated internal constructor(
+        val publicKeyCredentialRequestOptions: PublicKeyCredentialRequestOptions,
+        private val challenge: Challenge,
+        private val scenario: StandardScenario,
+    ) {
+        /**
+         * Send to client platform: calls WebAuthnClient.get().
+         * @param overrideChallenge If set, replaces the challenge (simulates challenge fixation attack).
+         * @param overrideOrigin If set, replaces the origin (simulates cross-origin attack).
+         */
+        suspend fun getAssertion(
+            clientPlatform: ClientPlatform = scenario.defaultClientPlatform,
+            overrideChallenge: Challenge? = null,
+            overrideOrigin: Origin? = null,
+        ): AuthenticationAssertionCreated {
+            val effectiveOptions = if (overrideChallenge != null) {
+                PublicKeyCredentialRequestOptions(
+                    overrideChallenge,
+                    publicKeyCredentialRequestOptions.timeout,
+                    publicKeyCredentialRequestOptions.rpId,
+                    publicKeyCredentialRequestOptions.allowCredentials,
+                    publicKeyCredentialRequestOptions.userVerification,
+                    publicKeyCredentialRequestOptions.extensions
+                )
+            } else {
+                publicKeyCredentialRequestOptions
+            }
+            val context = PublicKeyCredentialRequestContext(
+                overrideOrigin ?: clientPlatform.origin,
+                publicKeyCredentialSelectionHandler = PublicKeyCredentialSelectionHandler { it.first() },
+                clientPINProvider = { clientPlatform.clientPINValue.toByteArray() }
+            )
+            val credential = clientPlatform.webAuthnClient.get(effectiveOptions, context)
+            return AuthenticationAssertionCreated(credential, challenge, scenario)
+        }
+    }
+
+    /** Client platform has produced an assertion. Ready for server verification. */
+    class AuthenticationAssertionCreated internal constructor(
+        val credential: PublicKeyCredential<AuthenticatorAssertionResponse, AuthenticationExtensionClientOutput>,
+        private val challenge: Challenge,
+        private val scenario: StandardScenario,
+    ) {
+        /** Server verifies the authentication response. */
+        fun verifyOnServer(
+            rpId: String? = null,
+            userVerificationRequired: Boolean? = null,
+            allowCredentials: List<ByteArray>? = null,
+        ): AuthenticationResult {
+            val rp = scenario.relyingParty
+            val credentialRecord = rp.lookupCredential(credential.rawId)
+                ?: error("No credential found for ID. Did you register first?")
+
+            val request = AuthenticationRequest(
+                credential.rawId, ByteArray(32),
+                credential.response!!.authenticatorData,
+                credential.response!!.clientDataJSON,
+                scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
+                credential.response!!.signature
+            )
+            val serverProperty = ServerProperty.builder()
+                .origin(rp.origin)
+                .rpId(rpId ?: rp.rpId)
+                .challenge(this.challenge)
+                .build()
+            val params = AuthenticationParameters(
+                serverProperty, credentialRecord, allowCredentials,
+                userVerificationRequired ?: rp.userVerificationRequired, rp.userPresenceRequired
+            )
+            val data = rp.webAuthnManager.verify(request, params)
+            return AuthenticationResult(credential, data)
+        }
+    }
+
+    // ============================================================
+    // Result Classes
+    // ============================================================
+
+    data class RegistrationResult(
+        val credential: PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput>,
+        val registrationData: RegistrationData,
+        val credentialRecord: CredentialRecord,
+    )
+
+    data class AuthenticationResult(
+        val credential: PublicKeyCredential<AuthenticatorAssertionResponse, AuthenticationExtensionClientOutput>,
+        val authenticationData: AuthenticationData,
+    )
+}

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/WebAuthnTestEnvironment.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/WebAuthnTestEnvironment.kt
@@ -1,0 +1,106 @@
+package com.webauthn4j.test.integration.environment
+
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.ctap.client.CtapClient
+import com.webauthn4j.ctap.client.CtapService
+import com.webauthn4j.ctap.client.WebAuthnClient
+import com.webauthn4j.ctap.client.transport.InProcessAdaptor
+import com.webauthn4j.data.client.Origin
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.dataformat.cbor.CBORMapper
+import tools.jackson.module.kotlin.KotlinModule
+
+// ============================================================
+// Test Environment
+// ============================================================
+
+class WebAuthnTestEnvironment internal constructor(
+    val authenticators: List<Authenticator>,
+    val clientPlatforms: List<ClientPlatform>,
+    val relyingParty: RelyingParty,
+    val scenario: StandardScenario,
+) {
+    val authenticator: Authenticator get() = authenticators.first()
+    val clientPlatform: ClientPlatform get() = clientPlatforms.first()
+
+    companion object {
+        fun create(init: EnvironmentDsl.() -> Unit): WebAuthnTestEnvironment {
+            val dsl = EnvironmentDsl().apply(init)
+            return dsl.build()
+        }
+
+        fun createDefault(): WebAuthnTestEnvironment = create {
+            clientPlatform { authenticator() }
+            relyingParty()
+        }
+    }
+}
+
+// ============================================================
+// DSL
+// ============================================================
+
+class EnvironmentDsl {
+    private val clientPlatformDsls = mutableListOf<ClientPlatformDsl>()
+    private var relyingPartyInit: (RelyingParty.Builder.() -> Unit)? = null
+
+    fun clientPlatform(init: ClientPlatformDsl.() -> Unit = {}) {
+        clientPlatformDsls.add(ClientPlatformDsl().apply(init))
+    }
+
+    fun relyingParty(init: RelyingParty.Builder.() -> Unit = {}) {
+        require(relyingPartyInit == null) { "relyingParty must be declared exactly once" }
+        relyingPartyInit = init
+    }
+
+    internal fun build(): WebAuthnTestEnvironment {
+        require(clientPlatformDsls.isNotEmpty()) { "At least one clientPlatform must be declared" }
+        requireNotNull(relyingPartyInit) { "relyingParty must be declared" }
+
+        val objectConverter = createObjectConverter()
+
+        val allAuthenticators = mutableListOf<Authenticator>()
+        val builtClientPlatforms = clientPlatformDsls.map { cpDsl ->
+            cpDsl.build(objectConverter).also { cp ->
+                allAuthenticators.addAll(cp.authenticators)
+            }
+        }
+
+        val relyingParty = RelyingParty.Builder().apply(relyingPartyInit!!).build()
+        val defaultCp = builtClientPlatforms.first()
+        val scenario = StandardScenario(relyingParty, defaultCp, objectConverter)
+
+        return WebAuthnTestEnvironment(
+            authenticators = allAuthenticators,
+            clientPlatforms = builtClientPlatforms,
+            relyingParty = relyingParty,
+            scenario = scenario,
+        )
+    }
+
+    private fun createObjectConverter(): ObjectConverter {
+        val jsonMapper = JsonMapper()
+        val cborMapper = CBORMapper.builder().addModule(KotlinModule.Builder().build()).build()
+        return ObjectConverter(jsonMapper, cborMapper)
+    }
+}
+
+class ClientPlatformDsl {
+    var origin: Origin = Origin("https://example.com")
+    var clientPINValue: String = "clientPIN"
+    private val authenticatorBuilders = mutableListOf<Authenticator.Builder>()
+
+    fun authenticator(init: Authenticator.Builder.() -> Unit = {}) {
+        authenticatorBuilders.add(Authenticator.Builder().apply(init))
+    }
+
+    internal fun build(objectConverter: ObjectConverter): ClientPlatform {
+        require(authenticatorBuilders.isNotEmpty()) { "At least one authenticator must be declared in clientPlatform" }
+
+        val authenticators = authenticatorBuilders.map { it.build(objectConverter) }
+        val ctapClients = authenticators.map { CtapClient(InProcessAdaptor(it.transport)) }
+        val ctapServices = ctapClients.map { CtapService(it) }
+        val webAuthnClient = WebAuthnClient(ctapClients, objectConverter)
+        return ClientPlatform(webAuthnClient, ctapServices, authenticators, origin, clientPINValue)
+    }
+}

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AAGUIDSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AAGUIDSpec.kt
@@ -1,0 +1,31 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.attestation.authenticator.AAGUID
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.util.*
+
+@Tags("Parameter")
+class AAGUIDSpec : BehaviorSpec({
+
+    Given("an authenticator with a custom AAGUID") {
+        val customAaguid = AAGUID(UUID.randomUUID())
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { aaguid = customAaguid }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("the attested credential data should contain the custom AAGUID") {
+                val reg = env.scenario.register()
+                reg.registrationData.attestationObject!!.authenticatorData.attestedCredentialData.shouldNotBeNull()
+                    .aaguid shouldBe customAaguid
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AlgorithmSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AlgorithmSpec.kt
@@ -1,0 +1,131 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.client.exception.CtapErrorException
+import com.webauthn4j.data.PublicKeyCredentialParameters
+import com.webauthn4j.data.PublicKeyCredentialType.PUBLIC_KEY
+import com.webauthn4j.data.attestation.authenticator.COSEKey
+import com.webauthn4j.data.attestation.authenticator.EC2COSEKey
+import com.webauthn4j.data.attestation.authenticator.RSACOSEKey
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier.*
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.NotAllowedAlgorithmException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldContain
+import kotlin.reflect.KClass
+
+@Tags("Parameter")
+class AlgorithmSpec : BehaviorSpec({
+
+    // ============================================================
+    // Client-side: RP requested algorithms × Authenticator supported algorithms
+    // ============================================================
+
+    data class NegotiationCase(
+        val rpRequests: List<com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier>,
+        val authSupports: Set<com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier>,
+        val success: Boolean,
+        val expectedKeyType: KClass<out COSEKey>? = null,
+    )
+
+    listOf(
+        //                RP requests      Auth supports    success  key type
+        NegotiationCase(listOf(ES256),      setOf(ES256),    true,    EC2COSEKey::class),
+        NegotiationCase(listOf(RS256),      setOf(RS256),    true,    RSACOSEKey::class),
+        NegotiationCase(listOf(RS256,ES256),setOf(ES256),    true,    EC2COSEKey::class),
+        NegotiationCase(listOf(ES256),      setOf(ES256,RS256), true, EC2COSEKey::class),
+        NegotiationCase(listOf(ES256),      setOf(RS256),    false),
+        NegotiationCase(listOf(RS256),      setOf(ES256),    false),
+        NegotiationCase(listOf(RS512),      setOf(ES256),    false),
+    ).forEach { case ->
+
+        Given("RP requests ${case.rpRequests} × authenticator supports ${case.authSupports}") {
+            val env = WebAuthnTestEnvironment.create {
+                clientPlatform {
+                    authenticator { algorithms = case.authSupports }
+                }
+                relyingParty()
+            }
+            val pubKeyCredParams = case.rpRequests.map { PublicKeyCredentialParameters(PUBLIC_KEY, it) }
+
+            When("registering a credential") {
+                if (case.success) {
+                    Then("registration should succeed with ${case.expectedKeyType!!.simpleName}") {
+                        val reg = env.scenario.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
+                            .createCredential().verifyOnServer()
+                        val coseKey = reg.registrationData.attestationObject!!.authenticatorData
+                            .attestedCredentialData.shouldNotBeNull().coseKey
+                        coseKey!!::class shouldBe case.expectedKeyType
+                    }
+                } else {
+                    Then("CTAP2_ERR_UNSUPPORTED_ALGORITHM should be thrown") {
+                        val ex = shouldThrow<CtapErrorException> {
+                            env.scenario.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
+                                .createCredential().verifyOnServer()
+                        }
+                        ex.message.shouldContain("CTAP2_ERR_UNSUPPORTED_ALGORITHM")
+                    }
+                }
+            }
+        }
+    }
+
+    // ============================================================
+    // Server-side: pubKeyCredParams verification
+    // ============================================================
+
+    data class ServerVerificationCase(
+        val authenticatorAlgorithm: com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier,
+        val serverPubKeyCredParams: List<com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier>?,
+        val success: Boolean,
+    )
+
+    listOf(
+        //                          authenticator algorithm  server pubKeyCredParams   success
+        // null = accept any
+        ServerVerificationCase(     ES256,          null,                     true),
+        ServerVerificationCase(     RS256,          null,                     true),
+        // exact match
+        ServerVerificationCase(     ES256,          listOf(ES256),            true),
+        ServerVerificationCase(     RS256,          listOf(RS256),            true),
+        // multiple allowed, one matches
+        ServerVerificationCase(     ES256,          listOf(RS256, ES256),     true),
+        // mismatch
+        ServerVerificationCase(     ES256,          listOf(RS256),            false),
+        ServerVerificationCase(     RS256,          listOf(ES256),            false),
+        ServerVerificationCase(     ES256,          listOf(RS512),            false),
+    ).forEach { case ->
+
+        Given("server verification: authenticator=${case.authenticatorAlgorithm}, pubKeyCredParams=${case.serverPubKeyCredParams}") {
+            val env = WebAuthnTestEnvironment.create {
+                clientPlatform {
+                    authenticator { algorithms = setOf(case.authenticatorAlgorithm) }
+                }
+                relyingParty()
+            }
+            val rpPubKeyCredParams = listOf(PublicKeyCredentialParameters(PUBLIC_KEY, case.authenticatorAlgorithm))
+            val serverPubKeyCredParams = case.serverPubKeyCredParams?.map { PublicKeyCredentialParameters(PUBLIC_KEY, it) }
+
+            When("registering and verifying on server") {
+                if (case.success) {
+                    Then("the server should accept the credential") {
+                        env.scenario.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
+                            .createCredential()
+                            .verifyOnServer(pubKeyCredParams = serverPubKeyCredParams)
+                    }
+                } else {
+                    Then("NotAllowedAlgorithmException should be thrown") {
+                        shouldThrow<NotAllowedAlgorithmException> {
+                            env.scenario.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
+                                .createCredential()
+                                .verifyOnServer(pubKeyCredParams = serverPubKeyCredParams)
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AllowCredentialsSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AllowCredentialsSpec.kt
@@ -1,0 +1,59 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.NotAllowedCredentialIdException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Parameter")
+class AllowCredentialsSpec : BehaviorSpec({
+
+    Given("server verification with allowCredentials=null (accept any credential)") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        env.scenario.register()
+
+        When("authenticating") {
+            Then("the server should accept any credential") {
+                env.scenario.createAuthenticationOptions()
+                    .getAssertion()
+                    .verifyOnServer(allowCredentials = null)
+            }
+        }
+    }
+
+    Given("server verification with allowCredentials containing multiple credential IDs") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        val reg1 = env.scenario.register()
+
+        When("authenticating with both IDs in server allowCredentials") {
+            Then("the server should accept when credential is in the list") {
+                val clientAllow = listOf(
+                    PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, reg1.credential.rawId, null)
+                )
+                env.scenario.createAuthenticationOptions(allowCredentials = clientAllow)
+                    .getAssertion()
+                    .verifyOnServer(
+                        allowCredentials = listOf(reg1.credential.rawId, ByteArray(32))
+                    )
+            }
+        }
+    }
+
+    Given("server verification with empty allowCredentials list") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        env.scenario.register()
+
+        When("authenticating with empty list") {
+            Then("NotAllowedCredentialIdException should be thrown") {
+                shouldThrow<NotAllowedCredentialIdException> {
+                    env.scenario.createAuthenticationOptions()
+                        .getAssertion()
+                        .verifyOnServer(allowCredentials = emptyList())
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttachmentSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttachmentSpec.kt
@@ -1,0 +1,104 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.authenticator.data.settings.AttachmentSetting
+import com.webauthn4j.ctap.client.exception.WebAuthnClientException
+import com.webauthn4j.data.AuthenticatorAttachment
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.string.shouldContain
+
+@Tags("Parameter")
+class AttachmentSpec : BehaviorSpec({
+
+    Given("a PLATFORM authenticator and RP requests PLATFORM attachment") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { attachment = AttachmentSetting.PLATFORM }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("registration should succeed") {
+                env.scenario.createRegistrationOptions(
+                    authenticatorAttachment = AuthenticatorAttachment.PLATFORM
+                ).createCredential().verifyOnServer()
+            }
+        }
+    }
+
+    Given("a CROSS_PLATFORM authenticator and RP requests PLATFORM attachment") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { attachment = AttachmentSetting.CROSS_PLATFORM }
+            }
+            relyingParty()
+        }
+
+        When("attempting to register") {
+            Then("WebAuthnClientException should be thrown") {
+                val ex = shouldThrow<WebAuthnClientException> {
+                    env.scenario.createRegistrationOptions(
+                        authenticatorAttachment = AuthenticatorAttachment.PLATFORM
+                    ).createCredential().verifyOnServer()
+                }
+                ex.message.shouldContain("Matching authenticator doesn't exist")
+            }
+        }
+    }
+
+    Given("a PLATFORM authenticator and RP requests CROSS_PLATFORM attachment") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { attachment = AttachmentSetting.PLATFORM }
+            }
+            relyingParty()
+        }
+
+        When("attempting to register") {
+            Then("WebAuthnClientException should be thrown") {
+                val ex = shouldThrow<WebAuthnClientException> {
+                    env.scenario.createRegistrationOptions(
+                        authenticatorAttachment = AuthenticatorAttachment.CROSS_PLATFORM
+                    ).createCredential().verifyOnServer()
+                }
+                ex.message.shouldContain("Matching authenticator doesn't exist")
+            }
+        }
+    }
+
+    Given("a CROSS_PLATFORM authenticator and RP requests CROSS_PLATFORM attachment") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { attachment = AttachmentSetting.CROSS_PLATFORM }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("registration should succeed") {
+                env.scenario.createRegistrationOptions(
+                    authenticatorAttachment = AuthenticatorAttachment.CROSS_PLATFORM
+                ).createCredential().verifyOnServer()
+            }
+        }
+    }
+
+    Given("both PLATFORM and CROSS_PLATFORM authenticators with no attachment preference") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { attachment = AttachmentSetting.PLATFORM }
+                authenticator { attachment = AttachmentSetting.CROSS_PLATFORM }
+            }
+            relyingParty()
+        }
+
+        When("registering without attachment preference") {
+            Then("registration should succeed") {
+                env.scenario.register()
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationConveyanceSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationConveyanceSpec.kt
@@ -1,0 +1,78 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.AttestationConveyancePreference
+import com.webauthn4j.data.attestation.statement.NoneAttestationStatement
+import com.webauthn4j.data.attestation.statement.PackedAttestationStatement
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+@Tags("Parameter")
+class AttestationConveyanceSpec : BehaviorSpec({
+
+    Given("attestation conveyance preference is DIRECT") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform { authenticator() }
+            relyingParty { attestation = AttestationConveyancePreference.DIRECT }
+        }
+
+        When("registering with a Packed authenticator") {
+            Then("the attestation statement should be preserved as PackedAttestationStatement") {
+                val reg = env.scenario.register()
+                reg.registrationData.attestationObject!!.attestationStatement.shouldBeInstanceOf<PackedAttestationStatement>()
+            }
+        }
+    }
+
+    Given("attestation conveyance preference is NONE") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform { authenticator() }
+            relyingParty { attestation = AttestationConveyancePreference.NONE }
+        }
+
+        When("registering with a Packed authenticator") {
+            Then("the attestation statement should be replaced with NoneAttestationStatement") {
+                val reg = env.scenario.register()
+                reg.registrationData.attestationObject!!.attestationStatement.shouldBeInstanceOf<NoneAttestationStatement>()
+            }
+        }
+    }
+
+    // TODO: The current webauthn4j-ctap client does not perform INDIRECT anonymization,
+    //  so the attestation passes through as PackedAttestationStatement.
+    //  If the client implemented INDIRECT handling, this would become NoneAttestationStatement
+    //  or an anonymized statement.
+    Given("attestation conveyance preference is INDIRECT") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform { authenticator() }
+            relyingParty { attestation = AttestationConveyancePreference.INDIRECT }
+        }
+
+        When("registering with a Packed authenticator") {
+            Then("the attestation statement should pass through as PackedAttestationStatement") {
+                val reg = env.scenario.register()
+                reg.registrationData.attestationObject!!.attestationStatement.shouldBeInstanceOf<PackedAttestationStatement>()
+            }
+        }
+    }
+
+    // ENTERPRISE: Per spec, the client should send attestation with uniquely identifying
+    // information for enterprise deployments. The current webauthn4j-ctap client/authenticator
+    // does not implement enterprise attestation, so the attestation passes through as a
+    // regular PackedAttestationStatement. If enterprise attestation were supported, the
+    // attestation statement would contain enterprise-specific identifying information.
+    Given("attestation conveyance preference is ENTERPRISE") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform { authenticator() }
+            relyingParty { attestation = AttestationConveyancePreference.ENTERPRISE }
+        }
+
+        When("registering with a Packed authenticator") {
+            Then("the attestation statement should pass through as PackedAttestationStatement") {
+                val reg = env.scenario.register()
+                reg.registrationData.attestationObject!!.attestationStatement.shouldBeInstanceOf<PackedAttestationStatement>()
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationFormatSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationFormatSpec.kt
@@ -1,0 +1,123 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FBasicAttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.attestation.NoneAttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.attestation.PackedBasicAttestationStatementProvider
+import com.webauthn4j.data.AttestationConveyancePreference
+import com.webauthn4j.data.attestation.authenticator.AAGUID
+import com.webauthn4j.data.attestation.statement.FIDOU2FAttestationStatement
+import com.webauthn4j.data.attestation.statement.NoneAttestationStatement
+import com.webauthn4j.data.attestation.statement.PackedAttestationStatement
+import com.webauthn4j.test.TestAttestationUtil
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+@Tags("Parameter")
+class AttestationFormatSpec : BehaviorSpec({
+
+    Given("a Packed attestation authenticator") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey()
+                }
+            }
+            relyingParty { attestation = AttestationConveyancePreference.DIRECT }
+        }
+
+        When("registering a credential") {
+            Then("the attestation statement should be PackedAttestationStatement with AT flag set") {
+                val reg = env.scenario.register()
+                reg.registrationData.attestationObject!!.attestationStatement.shouldBeInstanceOf<PackedAttestationStatement>()
+                reg.registrationData.attestationObject!!.authenticatorData.isFlagAT shouldBe true
+            }
+
+            Then("authentication should succeed") {
+                shouldNotThrowAny { env.scenario.authenticate() }
+            }
+        }
+    }
+
+    Given("a FIDO U2F attestation authenticator") {
+        val privateKey = TestAttestationUtil.load2tierTestAuthenticatorAttestationPrivateKey()
+        val certificate = TestAttestationUtil.load2tierTestAuthenticatorAttestationCertificate()
+
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = FIDOU2FBasicAttestationStatementProvider(privateKey, certificate)
+                    aaguid = AAGUID.ZERO
+                }
+            }
+            relyingParty { attestation = AttestationConveyancePreference.DIRECT }
+        }
+
+        When("registering a credential") {
+            Then("the attestation statement should be FIDOU2FAttestationStatement") {
+                val reg = env.scenario.register()
+                reg.registrationData.attestationObject!!.attestationStatement.shouldBeInstanceOf<FIDOU2FAttestationStatement>()
+            }
+
+            Then("authentication should succeed") {
+                shouldNotThrowAny { env.scenario.authenticate() }
+            }
+        }
+    }
+
+    Given("a None attestation authenticator") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = NoneAttestationStatementProvider()
+                    aaguid = AAGUID.ZERO
+                }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("the attestation statement should be NoneAttestationStatement") {
+                val reg = env.scenario.register()
+                reg.registrationData.attestationObject!!.attestationStatement.shouldBeInstanceOf<NoneAttestationStatement>()
+            }
+
+            Then("authentication should succeed") {
+                shouldNotThrowAny { env.scenario.authenticate() }
+            }
+        }
+    }
+
+    // --- Formats not yet supported by webauthn4j-ctap authenticator emulator ---
+
+    xGiven("a TPM attestation authenticator") {
+        // TODO: Requires TPM AttestationStatementProvider implementation
+        When("registering a credential") {
+            Then("the attestation statement should be TPMAttestationStatement") {}
+        }
+    }
+
+    xGiven("an Android Key attestation authenticator") {
+        // TODO: Requires AndroidKey AttestationStatementProvider implementation
+        When("registering a credential") {
+            Then("the attestation statement should be AndroidKeyAttestationStatement") {}
+        }
+    }
+
+    xGiven("an Android SafetyNet attestation authenticator") {
+        // TODO: Requires AndroidSafetyNet AttestationStatementProvider implementation
+        When("registering a credential") {
+            Then("the attestation statement should be AndroidSafetyNetAttestationStatement") {}
+        }
+    }
+
+    xGiven("an Apple Anonymous attestation authenticator") {
+        // TODO: Requires AppleAnonymous AttestationStatementProvider implementation
+        When("registering a credential") {
+            Then("the attestation statement should be AppleAnonymousAttestationStatement") {}
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationTrustSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationTrustSpec.kt
@@ -1,0 +1,235 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.WebAuthnManager
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FBasicAttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.attestation.NoneAttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.attestation.PackedBasicAttestationStatementProvider
+import com.webauthn4j.data.AttestationConveyancePreference
+import com.webauthn4j.data.SignatureAlgorithm
+import com.webauthn4j.data.attestation.authenticator.AAGUID
+import com.webauthn4j.test.TestAttestationUtil
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.attestation.statement.none.NoneAttestationStatementVerifier
+import com.webauthn4j.verifier.attestation.statement.packed.PackedAttestationStatementVerifier
+import com.webauthn4j.verifier.attestation.statement.u2f.FIDOU2FAttestationStatementVerifier
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.DefaultCertPathTrustworthinessVerifier
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.NullCertPathTrustworthinessVerifier
+import com.webauthn4j.verifier.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessVerifier
+import com.webauthn4j.verifier.exception.BadAttestationStatementException
+import com.webauthn4j.verifier.exception.CertificateException
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import java.security.KeyPair
+
+@Tags("Parameter")
+class AttestationTrustSpec : BehaviorSpec({
+
+    Given("server configured with trusted root CA and Packed attestation authenticator") {
+        val attestationKeyPair = KeyPair(
+            TestAttestationUtil.load3tierTestAuthenticatorAttestationPublicKey(),
+            TestAttestationUtil.load3tierTestAuthenticatorAttestationPrivateKey()
+        )
+        val intermediateCAPrivateKey = TestAttestationUtil.load3tierTestIntermediateCAPrivateKey()
+        val intermediateCACert = TestAttestationUtil.load3tierTestIntermediateCACertificate()
+        val trustAnchorRepository = TestAttestationUtil.createTrustAnchorRepositoryWith3tierTestRootCACertificate()
+
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = PackedBasicAttestationStatementProvider(
+                        "CN=Test Authenticator, OU=Authenticator Attestation, O=Test, C=US",
+                        attestationKeyPair, intermediateCAPrivateKey,
+                        SignatureAlgorithm.ES256, listOf(intermediateCACert), ObjectConverter()
+                    )
+                }
+            }
+            relyingParty {
+                attestation = AttestationConveyancePreference.DIRECT
+                webAuthnManager = WebAuthnManager(
+                    listOf(PackedAttestationStatementVerifier()),
+                    DefaultCertPathTrustworthinessVerifier(trustAnchorRepository),
+                    DefaultSelfAttestationTrustworthinessVerifier()
+                )
+            }
+        }
+
+        When("registering a credential with a certificate chaining to the trusted root") {
+            Then("the server should accept the attestation") {
+                env.scenario.register()
+            }
+
+            Then("authentication should succeed") {
+                shouldNotThrowAny { env.scenario.authenticate() }
+            }
+        }
+    }
+
+    Given("server configured with a different trust anchor than the authenticator's certificate") {
+        val wrongTrustAnchorRepository = TestAttestationUtil.createTrustAnchorRepositoryWith2tierTestRootCACertificate()
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey()
+                }
+            }
+            relyingParty {
+                attestation = AttestationConveyancePreference.DIRECT
+                webAuthnManager = WebAuthnManager(
+                    listOf(PackedAttestationStatementVerifier()),
+                    DefaultCertPathTrustworthinessVerifier(wrongTrustAnchorRepository),
+                    DefaultSelfAttestationTrustworthinessVerifier()
+                )
+            }
+        }
+
+        When("registering a credential with a certificate NOT chaining to the trusted root") {
+            Then("the server should reject the attestation") {
+                shouldThrow<CertificateException> { env.scenario.register() }
+            }
+        }
+    }
+
+    Given("server configured with trusted root CA and FIDO U2F attestation authenticator") {
+        val privateKey = TestAttestationUtil.load2tierTestAuthenticatorAttestationPrivateKey()
+        val certificate = TestAttestationUtil.load2tierTestAuthenticatorAttestationCertificate()
+        val trustAnchorRepository = TestAttestationUtil.createTrustAnchorRepositoryWith2tierTestRootCACertificate()
+
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = FIDOU2FBasicAttestationStatementProvider(privateKey, certificate)
+                    aaguid = AAGUID.ZERO
+                }
+            }
+            relyingParty {
+                attestation = AttestationConveyancePreference.DIRECT
+                webAuthnManager = WebAuthnManager(
+                    listOf(FIDOU2FAttestationStatementVerifier()),
+                    DefaultCertPathTrustworthinessVerifier(trustAnchorRepository),
+                    DefaultSelfAttestationTrustworthinessVerifier()
+                )
+            }
+        }
+
+        When("registering a credential with a certificate chaining to the trusted root") {
+            Then("the server should accept the attestation") {
+                env.scenario.register()
+            }
+
+            Then("authentication should succeed") {
+                shouldNotThrowAny { env.scenario.authenticate() }
+            }
+        }
+    }
+
+    Given("server configured with wrong trust anchor and FIDO U2F attestation authenticator") {
+        val privateKey = TestAttestationUtil.load2tierTestAuthenticatorAttestationPrivateKey()
+        val certificate = TestAttestationUtil.load2tierTestAuthenticatorAttestationCertificate()
+        val wrongTrustAnchorRepository = TestAttestationUtil.createTrustAnchorRepositoryWith3tierTestRootCACertificate()
+
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = FIDOU2FBasicAttestationStatementProvider(privateKey, certificate)
+                    aaguid = AAGUID.ZERO
+                }
+            }
+            relyingParty {
+                attestation = AttestationConveyancePreference.DIRECT
+                webAuthnManager = WebAuthnManager(
+                    listOf(FIDOU2FAttestationStatementVerifier()),
+                    DefaultCertPathTrustworthinessVerifier(wrongTrustAnchorRepository),
+                    DefaultSelfAttestationTrustworthinessVerifier()
+                )
+            }
+        }
+
+        When("registering a credential with a certificate NOT chaining to the trusted root") {
+            Then("the server should reject the attestation") {
+                shouldThrow<CertificateException> { env.scenario.register() }
+            }
+        }
+    }
+
+    Given("server configured with NoneAttestationStatementVerifier") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = NoneAttestationStatementProvider()
+                    aaguid = AAGUID.ZERO
+                }
+            }
+            relyingParty {
+                attestation = AttestationConveyancePreference.DIRECT
+                webAuthnManager = WebAuthnManager(
+                    listOf(NoneAttestationStatementVerifier()),
+                    NullCertPathTrustworthinessVerifier(),
+                    DefaultSelfAttestationTrustworthinessVerifier()
+                )
+            }
+        }
+
+        When("registering with None attestation") {
+            Then("the server should accept the attestation") {
+                env.scenario.register()
+            }
+
+            Then("authentication should succeed") {
+                shouldNotThrowAny { env.scenario.authenticate() }
+            }
+        }
+    }
+
+    Given("server configured with NoneAttestationStatementVerifier but authenticator sends Packed") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey()
+                }
+            }
+            relyingParty {
+                attestation = AttestationConveyancePreference.DIRECT
+                webAuthnManager = WebAuthnManager(
+                    listOf(NoneAttestationStatementVerifier()),
+                    NullCertPathTrustworthinessVerifier(),
+                    DefaultSelfAttestationTrustworthinessVerifier()
+                )
+            }
+        }
+
+        When("registering with mismatched attestation format") {
+            Then("the server should reject the attestation") {
+                shouldThrow<BadAttestationStatementException> { env.scenario.register() }
+            }
+        }
+    }
+
+    Given("server configured with PackedAttestationStatementVerifier but authenticator sends None") {
+        val trustAnchorRepository = TestAttestationUtil.createTrustAnchorRepositoryWith3tierTestRootCACertificate()
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = NoneAttestationStatementProvider()
+                    aaguid = AAGUID.ZERO
+                }
+            }
+            relyingParty {
+                attestation = AttestationConveyancePreference.DIRECT
+                webAuthnManager = WebAuthnManager(
+                    listOf(PackedAttestationStatementVerifier()),
+                    DefaultCertPathTrustworthinessVerifier(trustAnchorRepository),
+                    DefaultSelfAttestationTrustworthinessVerifier()
+                )
+            }
+        }
+
+        When("registering with mismatched attestation format") {
+            Then("the server should reject the attestation") {
+                shouldThrow<BadAttestationStatementException> { env.scenario.register() }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/BackupStateSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/BackupStateSpec.kt
@@ -1,0 +1,66 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * WebAuthn Spec 7.1 steps 17-19, 7.2 steps 18-20:
+ * - If BE=0 (single-device credential), BS must be 0
+ * - If BE=1 (multi-device credential), BS can be 0 or 1
+ * - BE must not change after registration
+ */
+@Tags("Parameter")
+class BackupStateSpec : BehaviorSpec({
+
+    // --- Single-device credential (BE=0) ---
+
+    Given("a single-device credential (BE=0)") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        val reg = env.scenario.register()
+
+        When("checking flags after registration") {
+            Then("BE should be 0") {
+                reg.registrationData.attestationObject!!.authenticatorData.isFlagBE shouldBe false
+            }
+
+            Then("BS should be 0 (since BE=0, backup is not possible)") {
+                reg.registrationData.attestationObject!!.authenticatorData.isFlagBS shouldBe false
+            }
+        }
+
+        When("authenticating") {
+            val auth = env.scenario.authenticate()
+
+            Then("BE should remain 0 (must not change after registration)") {
+                auth.authenticationData.authenticatorData!!.isFlagBE shouldBe false
+            }
+
+            Then("BS should be 0") {
+                auth.authenticationData.authenticatorData!!.isFlagBS shouldBe false
+            }
+        }
+    }
+
+    // --- Multi-device credential (BE=1) ---
+    // Currently ignored: webauthn4j-ctap authenticator does not support
+    // BackupEligibility setting to generate multi-device credentials.
+
+    xGiven("a multi-device credential (BE=1)") {
+        // TODO: Requires authenticator support for generating backup-eligible credentials
+
+        When("checking flags after registration") {
+            Then("BE should be 1") {
+            }
+
+            Then("BS can be 0 or 1 depending on backup state") {
+            }
+        }
+
+        When("authenticating") {
+            Then("BE should remain 1 (must not change after registration)") {
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
@@ -1,0 +1,47 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.client.challenge.DefaultChallenge
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.BadChallengeException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Parameter")
+class ChallengeSpec : BehaviorSpec({
+
+    // Simulates a challenge fixation attack where the attacker uses a pre-determined
+    // challenge value instead of the one issued by the server.
+    val fixedChallenge = DefaultChallenge(ByteArray(32) { 0x41 })
+
+    Given("a registration with a tampered challenge (challenge fixation attack)") {
+        val env = WebAuthnTestEnvironment.createDefault()
+
+        When("the credential is created with an attacker's fixed challenge instead of the server's") {
+            val credentialCreated = env.scenario.createRegistrationOptions()
+                .createCredential(overrideChallenge = fixedChallenge)
+
+            Then("BadChallengeException should be thrown") {
+                shouldThrow<BadChallengeException> {
+                    credentialCreated.verifyOnServer()
+                }
+            }
+        }
+    }
+
+    Given("an authentication with a tampered challenge (challenge fixation attack)") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        env.scenario.register()
+
+        When("the assertion is created with an attacker's fixed challenge instead of the server's") {
+            val assertionCreated = env.scenario.createAuthenticationOptions()
+                .getAssertion(overrideChallenge = fixedChallenge)
+
+            Then("BadChallengeException should be thrown") {
+                shouldThrow<BadChallengeException> {
+                    assertionCreated.verifyOnServer()
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ClientPINSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ClientPINSpec.kt
@@ -1,0 +1,92 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
+import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
+import com.webauthn4j.data.UserVerificationRequirement
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+@Tags("Parameter")
+class ClientPINSpec : BehaviorSpec({
+
+    Given("clientPIN ENABLED with UV REQUIRED") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    clientPIN = ClientPINSetting.ENABLED
+                    userVerification = UserVerificationSetting.READY
+                }
+            }
+            relyingParty {
+                userVerificationRequirement = UserVerificationRequirement.REQUIRED
+                userVerificationRequired = true
+            }
+        }
+
+        When("registering a credential") {
+            val reg = env.scenario.register()
+
+            Then("registration should succeed with UV flag set") {
+                reg.registrationData.attestationObject!!.authenticatorData.isFlagUV shouldBe true
+            }
+
+            Then("authentication should succeed") {
+                shouldNotThrowAny { env.scenario.authenticate() }
+            }
+        }
+    }
+
+    Given("clientPIN DISABLED with UV READY") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    clientPIN = ClientPINSetting.DISABLED
+                    userVerification = UserVerificationSetting.READY
+                }
+            }
+            relyingParty {
+                userVerificationRequirement = UserVerificationRequirement.REQUIRED
+                userVerificationRequired = true
+            }
+        }
+
+        When("registering a credential") {
+            val reg = env.scenario.register()
+
+            Then("registration should succeed with UV flag set (built-in UV, no PIN needed)") {
+                reg.registrationData.attestationObject!!.authenticatorData.isFlagUV shouldBe true
+            }
+
+            Then("authentication should succeed") {
+                shouldNotThrowAny { env.scenario.authenticate() }
+            }
+        }
+    }
+
+    Given("clientPIN ENABLED with UV NOT_READY") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    clientPIN = ClientPINSetting.ENABLED
+                    userVerification = UserVerificationSetting.NOT_READY
+                }
+            }
+            relyingParty {
+                userVerificationRequirement = UserVerificationRequirement.REQUIRED
+                userVerificationRequired = true
+            }
+        }
+
+        When("setting PIN and registering") {
+            env.clientPlatform.ctapService.setPIN("clientPIN")
+            val reg = env.scenario.register()
+
+            Then("registration should succeed via PIN-based UV fallback") {
+                reg.registrationData.attestationObject!!.authenticatorData.isFlagUV shouldBe true
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CounterSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CounterSpec.kt
@@ -1,0 +1,58 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.credential.CredentialRecordImpl
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.MaliciousCounterValueException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+@Tags("Parameter")
+class CounterSpec : BehaviorSpec({
+
+    Given("a registered credential with counter enabled") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        val registration = env.scenario.register()
+
+        When("authenticating multiple times") {
+            val allowCredentials = listOf(
+                PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, registration.credential.rawId, null)
+            )
+            val auth1 = env.scenario.createAuthenticationOptions(allowCredentials = allowCredentials)
+                .getAssertion()
+                .verifyOnServer()
+            val counter1 = auth1.authenticationData.authenticatorData.shouldNotBeNull().signCount
+
+            val auth2 = env.scenario.createAuthenticationOptions(allowCredentials = allowCredentials)
+                .getAssertion()
+                .verifyOnServer()
+            val counter2 = auth2.authenticationData.authenticatorData.shouldNotBeNull().signCount
+
+            Then("the counter should increment with each authentication") {
+                counter2 shouldBeGreaterThan counter1
+            }
+        }
+    }
+
+    // TODO: Clone detection is simulated by setting the server-side stored counter artificially high.
+    //  A true authenticator clone test would require deep-copying ResidentUserCredential objects
+    //  from the AuthenticatorPropertyStore, which is not supported by the current API.
+    Given("clone detection with counter rollback") {
+        val env = WebAuthnTestEnvironment.createDefault()
+
+        When("the server's stored counter is higher than the authenticator's counter") {
+            val registration = env.scenario.register()
+            (registration.credentialRecord as CredentialRecordImpl).setCounter(999999)
+
+            Then("MaliciousCounterValueException should be thrown") {
+                shouldThrow<MaliciousCounterValueException> {
+                    env.scenario.authenticate()
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialIdSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialIdSpec.kt
@@ -1,0 +1,45 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+
+/**
+ * WebAuthn Spec 7.1 steps 24-25:
+ * - credentialId must be ≤ 1023 bytes
+ * - credentialId must not be already registered for any user
+ */
+@Tags("Parameter")
+class CredentialIdSpec : BehaviorSpec({
+
+    Given("a registered credential") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        val reg = env.scenario.register()
+
+        When("checking the credential ID length") {
+            Then("the credential ID should be ≤ 1023 bytes") {
+                reg.credential.rawId.size shouldBeLessThanOrEqual 1023
+            }
+        }
+    }
+
+    Given("a credential already registered on the server") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        val reg1 = env.scenario.register()
+
+        When("attempting to authenticate with the registered credential") {
+            val allowCredentials = listOf(
+                PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, reg1.credential.rawId, null)
+            )
+
+            Then("the credential should be found in the server's store") {
+                env.scenario.createAuthenticationOptions(allowCredentials = allowCredentials)
+                    .getAssertion()
+                    .verifyOnServer()
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialSelectorSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialSelectorSpec.kt
@@ -1,0 +1,63 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
+import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting.*
+import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
+import com.webauthn4j.ctap.client.PublicKeyCredentialRequestContext
+import com.webauthn4j.ctap.client.PublicKeyCredentialSelectionHandler
+import com.webauthn4j.data.ResidentKeyRequirement
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+@Tags("Parameter")
+class CredentialSelectorSpec : BehaviorSpec({
+
+    listOf(
+        CLIENT_PLATFORM,
+        AUTHENTICATOR,
+    ).forEach { selectorSetting ->
+
+        Given("two discoverable credentials with $selectorSetting credential selector") {
+            val env = WebAuthnTestEnvironment.create {
+                clientPlatform {
+                    authenticator {
+                        residentKey = ResidentKeySetting.ALWAYS
+                        credentialSelector = selectorSetting
+                    }
+                }
+                relyingParty { residentKeyRequirement = ResidentKeyRequirement.REQUIRED }
+            }
+            env.scenario.register()
+            env.scenario.register()
+
+            When("authenticating without allowCredentials (discoverable flow)") {
+                var candidateCount = 0
+                val options = env.scenario.createAuthenticationOptions(allowCredentials = null)
+                val context = PublicKeyCredentialRequestContext(
+                    env.clientPlatform.origin,
+                    publicKeyCredentialSelectionHandler = PublicKeyCredentialSelectionHandler {
+                        candidateCount = it.size
+                        it.first()
+                    },
+                    clientPINProvider = { env.clientPlatform.clientPINValue.toByteArray() }
+                )
+                env.clientPlatform.webAuthnClient.get(options.publicKeyCredentialRequestOptions, context)
+
+                when (selectorSetting) {
+                    CLIENT_PLATFORM -> {
+                        Then("the client-side selector should receive multiple candidates") {
+                            candidateCount shouldBe 2
+                        }
+                    }
+                    AUTHENTICATOR -> {
+                        Then("the authenticator should have already selected (client receives single candidate)") {
+                            candidateCount shouldBe 1
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CrossOriginSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CrossOriginSpec.kt
@@ -1,0 +1,41 @@
+package com.webauthn4j.test.integration.parameter
+
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+/**
+ * WebAuthn Spec 7.1 steps 10-11, 7.2 steps 13-14:
+ * - If crossOrigin is true, RP must expect iframe context
+ * - If topOrigin is present, verify it matches expected top-level origin
+ *
+ * All tests disabled (xGiven): the test DSL does not yet support crossOrigin/topOrigin overrides.
+ */
+@Tags("Parameter")
+class CrossOriginSpec : BehaviorSpec({
+
+    // TODO: Requires DSL support for crossOrigin/topOrigin on ClientPlatform and ServerProperty
+
+    xGiven("a credential created in a cross-origin iframe") {
+        When("the server verifies with matching topOrigin") {
+            Then("registration should succeed") {
+            }
+        }
+
+        When("the server verifies with mismatched topOrigin") {
+            Then("registration should fail") {
+            }
+        }
+    }
+
+    xGiven("an assertion from a cross-origin iframe") {
+        When("the server verifies with matching topOrigin") {
+            Then("authentication should succeed") {
+            }
+        }
+
+        When("the server verifies with mismatched topOrigin") {
+            Then("authentication should fail") {
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ExcludeCredentialsSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ExcludeCredentialsSpec.kt
@@ -1,0 +1,50 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.client.exception.CtapErrorException
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.string.shouldContain
+
+@Tags("Parameter")
+class ExcludeCredentialsSpec : BehaviorSpec({
+
+    Given("an existing registered credential") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        val firstRegistration = env.scenario.register()
+        val existingCredentialId = firstRegistration.credential.rawId
+
+        When("registering with the existing credential in excludeCredentials") {
+            val excludeList = listOf(
+                PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, existingCredentialId, null)
+            )
+
+            Then("CTAP2_ERR_CREDENTIAL_EXCLUDED should be thrown") {
+                val ex = shouldThrow<CtapErrorException> {
+                    env.scenario.createRegistrationOptions(excludeCredentials = excludeList)
+                        .createCredential()
+                        .verifyOnServer()
+                }
+                ex.message.shouldContain("CTAP2_ERR_CREDENTIAL_EXCLUDED")
+            }
+        }
+
+        When("registering with a different credential in excludeCredentials") {
+            val excludeList = listOf(
+                PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, ByteArray(32), null)
+            )
+
+            Then("registration should succeed") {
+                shouldNotThrowAny {
+                    env.scenario.createRegistrationOptions(excludeCredentials = excludeList)
+                        .createCredential()
+                        .verifyOnServer()
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
@@ -1,0 +1,41 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.client.Origin
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.BadOriginException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Parameter")
+class OriginSpec : BehaviorSpec({
+
+    Given("a registration from a malicious origin") {
+        val env = WebAuthnTestEnvironment.createDefault()
+
+        When("the credential is created from a different origin than the server expects") {
+            Then("BadOriginException should be thrown") {
+                shouldThrow<BadOriginException> {
+                    env.scenario.createRegistrationOptions()
+                        .createCredential(overrideOrigin = Origin("https://evil.example.com"))
+                        .verifyOnServer()
+                }
+            }
+        }
+    }
+
+    Given("an authentication from a malicious origin") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        env.scenario.register()
+
+        When("the assertion is created from a different origin than the server expects") {
+            Then("BadOriginException should be thrown") {
+                shouldThrow<BadOriginException> {
+                    env.scenario.createAuthenticationOptions()
+                        .getAssertion(overrideOrigin = Origin("https://evil.example.com"))
+                        .verifyOnServer()
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ResetProtectionSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ResetProtectionSpec.kt
@@ -1,0 +1,47 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.authenticator.data.settings.ResetProtectionSetting
+import com.webauthn4j.ctap.client.exception.CtapErrorException
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.string.shouldContain
+
+@Tags("Parameter")
+class ResetProtectionSpec : BehaviorSpec({
+
+    Given("an authenticator with resetProtection=ENABLED") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { resetProtection = ResetProtectionSetting.ENABLED }
+            }
+            relyingParty()
+        }
+
+        When("attempting to reset the authenticator") {
+            Then("CTAP2_ERR_OPERATION_DENIED should be thrown") {
+                val ex = shouldThrow<CtapErrorException> {
+                    env.clientPlatform.ctapService.reset()
+                }
+                ex.message.shouldContain("CTAP2_ERR_OPERATION_DENIED")
+            }
+        }
+    }
+
+    Given("an authenticator with resetProtection=DISABLED") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { resetProtection = ResetProtectionSetting.DISABLED }
+            }
+            relyingParty()
+        }
+
+        When("resetting the authenticator") {
+            Then("the reset should succeed without error") {
+                shouldNotThrowAny { env.clientPlatform.ctapService.reset() }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ResidentKeySpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ResidentKeySpec.kt
@@ -1,0 +1,111 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
+import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting.*
+import com.webauthn4j.ctap.client.exception.WebAuthnClientException
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.data.ResidentKeyRequirement
+import com.webauthn4j.data.ResidentKeyRequirement.*
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.string.shouldContain
+
+private enum class ResidentKeyResult { DISCOVERABLE, NON_DISCOVERABLE, ERROR }
+
+@Tags("Parameter")
+class ResidentKeySpec : BehaviorSpec({
+
+    // ============================================================
+    // RP requirement × Authenticator setting matrix
+    // ============================================================
+
+    data class MatrixEntry(
+        val rpRequirement: ResidentKeyRequirement,
+        val authSetting: ResidentKeySetting,
+        val expected: ResidentKeyResult,
+    )
+
+    listOf(
+        //          RP requirement  Auth setting    expected result
+        MatrixEntry(REQUIRED,       ALWAYS,         ResidentKeyResult.DISCOVERABLE),
+        MatrixEntry(REQUIRED,       IF_REQUIRED,    ResidentKeyResult.DISCOVERABLE),
+        MatrixEntry(REQUIRED,       NEVER,          ResidentKeyResult.ERROR),
+        MatrixEntry(PREFERRED,      ALWAYS,         ResidentKeyResult.DISCOVERABLE),
+        MatrixEntry(PREFERRED,      IF_REQUIRED,    ResidentKeyResult.NON_DISCOVERABLE),
+        MatrixEntry(DISCOURAGED,    ALWAYS,         ResidentKeyResult.DISCOVERABLE),
+    ).forEach { (rpRequirement, authSetting, expected) ->
+
+        Given("RP $rpRequirement × authenticator $authSetting") {
+            val env = WebAuthnTestEnvironment.create {
+                clientPlatform {
+                    authenticator { residentKey = authSetting }
+                }
+                relyingParty { residentKeyRequirement = rpRequirement }
+            }
+
+            when (expected) {
+                ResidentKeyResult.DISCOVERABLE -> {
+                    When("registering a credential") {
+                        Then("a discoverable credential should be created (no allowCredentials needed)") {
+                            env.scenario.register()
+                            shouldNotThrowAny { env.scenario.authenticate() }
+                        }
+                    }
+                }
+                ResidentKeyResult.NON_DISCOVERABLE -> {
+                    When("registering a credential") {
+                        Then("a non-discoverable credential should be created (requires allowCredentials)") {
+                            val reg = env.scenario.register()
+                            val allowCredentials = listOf(
+                                PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, reg.credential.rawId, null)
+                            )
+                            shouldNotThrowAny {
+                                env.scenario.createAuthenticationOptions(allowCredentials = allowCredentials)
+                                    .getAssertion()
+                                    .verifyOnServer()
+                            }
+                        }
+                    }
+                }
+                ResidentKeyResult.ERROR -> {
+                    When("attempting to register") {
+                        Then("WebAuthnClientException should be thrown") {
+                            val ex = shouldThrow<WebAuthnClientException> { env.scenario.register() }
+                            ex.message.shouldContain("Matching authenticator doesn't exist")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // --- Cases not yet supported by webauthn4j-ctap authenticator emulator (CTAP1_ERR_OTHER) ---
+
+    xGiven("RP PREFERRED × authenticator NEVER → NON_DISCOVERABLE") {
+        // TODO: Authenticator emulator fails with CTAP1_ERR_OTHER for NEVER setting with non-required rk
+        When("registering a credential") {
+            Then("a non-discoverable credential should be created") {}
+        }
+    }
+
+    xGiven("RP DISCOURAGED × authenticator IF_REQUIRED → NON_DISCOVERABLE") {
+        // TODO: Authenticator emulator fails with CTAP1_ERR_OTHER for DISCOURAGED requirement
+        When("registering a credential") {
+            Then("a non-discoverable credential should be created") {}
+        }
+    }
+
+    xGiven("RP DISCOURAGED × authenticator NEVER → NON_DISCOVERABLE") {
+        // TODO: Authenticator emulator fails with CTAP1_ERR_OTHER for NEVER setting with DISCOURAGED
+        When("registering a credential") {
+            Then("a non-discoverable credential should be created") {}
+        }
+    }
+
+    // TODO: RP null (unspecified) x authenticator IF_REQUIRED
+    //  The test client (webauthn4j-ctap WebAuthnClient) does not accept null residentKeyRequirement.
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/RpIdSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/RpIdSpec.kt
@@ -1,0 +1,40 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.BadRpIdException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Parameter")
+class RpIdSpec : BehaviorSpec({
+
+    Given("a credential presented to a different RP during registration") {
+        val env = WebAuthnTestEnvironment.createDefault()
+
+        When("the server verifies with a different rpId") {
+            Then("BadRpIdException should be thrown") {
+                shouldThrow<BadRpIdException> {
+                    env.scenario.createRegistrationOptions()
+                        .createCredential()
+                        .verifyOnServer(rpId = "another.site.example.net")
+                }
+            }
+        }
+    }
+
+    Given("a credential presented to a different RP during authentication") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        env.scenario.register()
+
+        When("the server verifies with a different rpId") {
+            Then("BadRpIdException should be thrown") {
+                shouldThrow<BadRpIdException> {
+                    env.scenario.createAuthenticationOptions()
+                        .getAssertion()
+                        .verifyOnServer(rpId = "another.site.example.net")
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/TransportSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/TransportSpec.kt
@@ -1,0 +1,121 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.AuthenticatorTransport
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+
+@Tags("Parameter")
+class TransportSpec : BehaviorSpec({
+
+    Given("an authenticator with transports={INTERNAL}") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { transports = setOf(AuthenticatorTransport.INTERNAL) }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("the registration response should contain INTERNAL transport") {
+                val reg = env.scenario.register()
+                reg.credential.response!!.transports.shouldContainExactlyInAnyOrder(
+                    AuthenticatorTransport.INTERNAL
+                )
+            }
+
+            Then("the credential record should store the transport") {
+                val reg = env.scenario.register()
+                reg.credentialRecord.transports!!.shouldContainExactlyInAnyOrder(
+                    AuthenticatorTransport.INTERNAL
+                )
+            }
+        }
+    }
+
+    Given("an authenticator with transports={USB, NFC}") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { transports = setOf(AuthenticatorTransport.USB, AuthenticatorTransport.NFC) }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("the registration response should contain both transports") {
+                val reg = env.scenario.register()
+                reg.credential.response!!.transports.shouldContainExactlyInAnyOrder(
+                    AuthenticatorTransport.USB, AuthenticatorTransport.NFC
+                )
+            }
+        }
+    }
+
+    Given("an authenticator with transports={BLE}") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { transports = setOf(AuthenticatorTransport.BLE) }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("the registration response should contain BLE transport") {
+                val reg = env.scenario.register()
+                reg.credential.response!!.transports.shouldContainExactlyInAnyOrder(
+                    AuthenticatorTransport.BLE
+                )
+            }
+        }
+    }
+
+    Given("an authenticator with transports={HYBRID}") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { transports = setOf(AuthenticatorTransport.HYBRID) }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("the registration response should contain HYBRID transport") {
+                val reg = env.scenario.register()
+                reg.credential.response!!.transports.shouldContainExactlyInAnyOrder(
+                    AuthenticatorTransport.HYBRID
+                )
+            }
+        }
+    }
+
+    Given("an authenticator with transports={SMART_CARD}") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { transports = setOf(AuthenticatorTransport.SMART_CARD) }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("the registration response should contain SMART_CARD transport") {
+                val reg = env.scenario.register()
+                reg.credential.response!!.transports.shouldContainExactlyInAnyOrder(
+                    AuthenticatorTransport.SMART_CARD
+                )
+            }
+        }
+    }
+
+    Given("an authenticator with default transports (USB)") {
+        val env = WebAuthnTestEnvironment.createDefault()
+
+        When("registering a credential") {
+            Then("the registration response should contain USB transport") {
+                val reg = env.scenario.register()
+                reg.credential.response!!.transports.shouldContainExactlyInAnyOrder(
+                    AuthenticatorTransport.USB
+                )
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserPresenceSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserPresenceSpec.kt
@@ -1,0 +1,63 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
+import com.webauthn4j.ctap.client.exception.UPNotSupportedException
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+@Tags("Parameter")
+class UserPresenceSpec : BehaviorSpec({
+
+    Given("an authenticator with userPresence=SUPPORTED") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { userPresence = UserPresenceSetting.SUPPORTED }
+            }
+            relyingParty()
+        }
+
+        When("registering a credential") {
+            Then("the UP flag should be set in authenticator data") {
+                val reg = env.scenario.register()
+                reg.registrationData.attestationObject!!.authenticatorData.isFlagUP shouldBe true
+            }
+
+            Then("authentication should succeed with UP flag set") {
+                val auth = env.scenario.authenticate()
+                auth.authenticationData.authenticatorData.shouldNotBeNull()
+                    .isFlagUP shouldBe true
+            }
+        }
+    }
+
+    Given("an authenticator with userPresence=NOT_SUPPORTED") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { userPresence = UserPresenceSetting.NOT_SUPPORTED }
+            }
+            relyingParty()
+        }
+
+        When("attempting to register") {
+            Then("an exception should be thrown") {
+                shouldThrow<UPNotSupportedException> {
+                    env.scenario.register()
+                }
+            }
+        }
+    }
+
+    // TODO: Conditional mediation requires the client to skip UP and the authenticator to
+    //  return UP=false. The current webauthn4j-ctap client always requires UP support
+    //  (throws UPNotSupportedException otherwise), so a true conditional mediation flow
+    //  (authenticator UP=NOT_SUPPORTED + server userPresenceRequired=false) cannot be tested.
+    xGiven("conditional mediation: authenticator UP=false, server accepts without UP") {
+        When("registering and authenticating without user presence") {
+            Then("server should accept despite UP flag being false") {}
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserVerificationSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserVerificationSpec.kt
@@ -1,0 +1,148 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
+import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting.DISABLED
+import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting.ENABLED
+import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
+import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting.*
+import com.webauthn4j.data.UserVerificationRequirement
+import com.webauthn4j.data.UserVerificationRequirement.*
+import com.webauthn4j.ctap.client.exception.WebAuthnClientException
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.UserNotVerifiedException
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+@Tags("Parameter")
+class UserVerificationSpec : BehaviorSpec({
+
+    // ============================================================
+    // Registration: RP requirement × Authenticator state matrix
+    // ============================================================
+
+    // --- Axis 1: RP requirement + server verification condition ---
+
+    data class RPConfig(
+        val requirement: UserVerificationRequirement,
+        val uvRequired: Boolean,
+    ) {
+        override fun toString() = requirement.toString()
+    }
+
+    val REQUIRE_UV    = RPConfig(REQUIRED,    uvRequired = true)
+    val PREFER_UV     = RPConfig(PREFERRED,   uvRequired = false)
+    val DISCOURAGE_UV = RPConfig(DISCOURAGED, uvRequired = false)
+
+    // --- Axis 2: Authenticator UV capability + ClientPIN state ---
+
+    data class AuthenticatorState(
+        val uv: UserVerificationSetting,
+        val pin: ClientPINSetting,
+        val setPIN: Boolean = false,
+    ) {
+        override fun toString() = if (setPIN) "$uv, PIN $pin (+setPIN)" else "$uv, PIN $pin"
+    }
+
+    val READY_WITH_PIN    = AuthenticatorState(READY,         ENABLED)
+    val READY_NO_PIN      = AuthenticatorState(READY,         DISABLED)
+    val NOT_READY_SET_PIN = AuthenticatorState(NOT_READY,     ENABLED,  setPIN = true)
+    val NOT_READY_NO_PIN  = AuthenticatorState(NOT_READY,     DISABLED)
+    val NO_UV_NO_PIN      = AuthenticatorState(NOT_SUPPORTED, DISABLED)
+
+    // --- Matrix: RP × Authenticator → expected result ---
+
+    data class MatrixEntry(
+        val rp: RPConfig,
+        val auth: AuthenticatorState,
+        val success: Boolean,
+        val uvFlag: Boolean? = null,
+    )
+
+    listOf(
+        //          RP               Authenticator          success  UV flag
+        MatrixEntry(REQUIRE_UV,      READY_WITH_PIN,        true,    true),
+        MatrixEntry(REQUIRE_UV,      READY_NO_PIN,          true,    true),
+        MatrixEntry(REQUIRE_UV,      NOT_READY_SET_PIN,     true,    true),
+        MatrixEntry(REQUIRE_UV,      NOT_READY_NO_PIN,      false),
+        MatrixEntry(REQUIRE_UV,      NO_UV_NO_PIN,          false),
+        MatrixEntry(PREFER_UV,       READY_WITH_PIN,        true,    true),
+        MatrixEntry(PREFER_UV,       READY_NO_PIN,          true,    true),
+        MatrixEntry(PREFER_UV,       NOT_READY_SET_PIN,     true,    true),
+        MatrixEntry(PREFER_UV,       NOT_READY_NO_PIN,      true,    false),
+        MatrixEntry(PREFER_UV,       NO_UV_NO_PIN,          true,    false),
+        MatrixEntry(DISCOURAGE_UV,   READY_WITH_PIN,        true,    false),
+        MatrixEntry(DISCOURAGE_UV,   READY_NO_PIN,          true,    false),
+        MatrixEntry(DISCOURAGE_UV,   NOT_READY_SET_PIN,     true,    false),
+        MatrixEntry(DISCOURAGE_UV,   NOT_READY_NO_PIN,      true,    false),
+        MatrixEntry(DISCOURAGE_UV,   NO_UV_NO_PIN,          true,    false),
+    ).forEach { (rp, auth, success, uvFlag) ->
+
+        Given("RP $rp × authenticator $auth") {
+            val env = WebAuthnTestEnvironment.create {
+                clientPlatform {
+                    authenticator { userVerification = auth.uv; clientPIN = auth.pin }
+                }
+                relyingParty { userVerificationRequirement = rp.requirement; userVerificationRequired = rp.uvRequired }
+            }
+            if (auth.setPIN) env.clientPlatform.ctapService.setPIN("clientPIN")
+
+            When("registering a credential") {
+                if (success) {
+                    Then("registration should succeed") {
+                        val reg = env.scenario.register()
+                        if (uvFlag != null) {
+                            reg.registrationData.attestationObject!!.authenticatorData.isFlagUV shouldBe uvFlag
+                        }
+                    }
+                } else {
+                    Then("an error should be thrown") {
+                        shouldThrow<WebAuthnClientException> { env.scenario.register() }
+                    }
+                }
+            }
+        }
+    }
+
+    // ============================================================
+    // Authentication: server UV requirement vs client UV behavior
+    // ============================================================
+
+    Given("server requires UV but client authenticates with DISCOURAGED") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform { authenticator() }
+            relyingParty { userVerificationRequirement = REQUIRED; userVerificationRequired = true }
+        }
+        env.scenario.register()
+
+        When("authenticating without UV while server requires it") {
+            Then("UserNotVerifiedException should be thrown") {
+                shouldThrow<UserNotVerifiedException> {
+                    env.scenario.createAuthenticationOptions(userVerificationRequirement = DISCOURAGED)
+                        .getAssertion()
+                        .verifyOnServer(userVerificationRequired = true)
+                }
+            }
+        }
+    }
+
+    Given("server does not require UV and client authenticates with DISCOURAGED") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform { authenticator() }
+            relyingParty { userVerificationRequirement = DISCOURAGED; userVerificationRequired = false }
+        }
+        env.scenario.register()
+
+        When("authenticating without UV") {
+            Then("the server should accept the authentication") {
+                shouldNotThrowAny {
+                    env.scenario.createAuthenticationOptions(userVerificationRequirement = DISCOURAGED)
+                        .getAssertion()
+                        .verifyOnServer(userVerificationRequired = false)
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/ClientPINManagementSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/ClientPINManagementSpec.kt
@@ -1,0 +1,68 @@
+package com.webauthn4j.test.integration.scenario
+
+import com.webauthn4j.ctap.client.exception.CtapErrorException
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+@Tags("Scenario")
+class ClientPINManagementSpec : BehaviorSpec({
+
+    Given("an authenticator with clientPIN already set") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        // Explicitly set the initial PIN
+        env.clientPlatform.ctapService.setPIN("clientPIN")
+
+        When("attempting to set a new PIN without resetting") {
+            Then("CTAP2_ERR_PIN_AUTH_INVALID should be thrown") {
+                val ex = shouldThrow<CtapErrorException> {
+                    env.clientPlatform.ctapService.setPIN("new-PIN")
+                }
+                ex.message.shouldContain("CTAP2_ERR_PIN_AUTH_INVALID")
+            }
+        }
+    }
+
+    Given("an authenticator with clientPIN set for PIN change") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        // Explicitly set the initial PIN
+        env.clientPlatform.ctapService.setPIN("clientPIN")
+
+        When("changing the PIN with the correct current PIN") {
+            Then("the PIN change should succeed") {
+                shouldNotThrowAny { env.clientPlatform.ctapService.changePIN("clientPIN", "new-PIN") }
+            }
+        }
+    }
+
+    Given("a registered credential and then PIN is changed") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        // Explicitly set the initial PIN before registration
+        env.clientPlatform.ctapService.setPIN("clientPIN")
+        env.scenario.register()
+
+        When("changing the PIN and then authenticating") {
+            env.clientPlatform.ctapService.changePIN("clientPIN", "new-PIN")
+
+            Then("authentication should still succeed with the existing credential") {
+                shouldNotThrowAny { env.scenario.authenticate() }
+            }
+        }
+    }
+
+    Given("an authenticator for retry count verification") {
+        val env = WebAuthnTestEnvironment.createDefault()
+
+        When("checking the initial retry count") {
+            val retries = env.clientPlatform.ctapService.getRetries()
+
+            Then("the retry count should be the maximum") {
+                retries shouldBe 8u
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/CredentialDeletionSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/CredentialDeletionSpec.kt
@@ -1,0 +1,24 @@
+package com.webauthn4j.test.integration.scenario
+
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Scenario")
+class CredentialDeletionSpec : BehaviorSpec({
+
+    Given("a registered credential that is then deleted from the server") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        val registration = env.scenario.register()
+        env.relyingParty.deleteCredential(registration.credential.rawId)
+
+        When("attempting to authenticate") {
+            Then("credential not found error should be thrown") {
+                shouldThrow<IllegalStateException> {
+                    env.scenario.authenticate()
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/PasswordlessFlowSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/PasswordlessFlowSpec.kt
@@ -1,0 +1,31 @@
+package com.webauthn4j.test.integration.scenario
+
+import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
+import com.webauthn4j.data.ResidentKeyRequirement
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Scenario")
+class PasswordlessFlowSpec : BehaviorSpec({
+
+    Given("a relying party requiring resident key") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator { residentKey = ResidentKeySetting.ALWAYS }
+            }
+            relyingParty { residentKeyRequirement = ResidentKeyRequirement.REQUIRED }
+        }
+
+        When("a user registers a credential") {
+            env.scenario.register()
+
+            And("the user authenticates without providing credential ID") {
+                Then("the authentication should succeed") {
+                    shouldNotThrowAny { env.scenario.authenticate() }
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/SecondFactorFlowSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/SecondFactorFlowSpec.kt
@@ -1,0 +1,46 @@
+package com.webauthn4j.test.integration.scenario
+
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.data.ResidentKeyRequirement
+import com.webauthn4j.data.UserVerificationRequirement
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Scenario")
+class SecondFactorFlowSpec : BehaviorSpec({
+
+    Given("a relying party with resident key not required and UV preferred") {
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform { authenticator() }
+            relyingParty {
+                residentKeyRequirement = ResidentKeyRequirement.PREFERRED
+                userVerificationRequirement = UserVerificationRequirement.PREFERRED
+                userVerificationRequired = false
+            }
+        }
+
+        When("a user registers and authenticates with credential ID in allowCredentials") {
+            val registration = env.scenario.register()
+            val allowCredentials = listOf(
+                PublicKeyCredentialDescriptor(
+                    PublicKeyCredentialType.PUBLIC_KEY,
+                    registration.credential.rawId,
+                    null
+                )
+            )
+            Then("the authentication should succeed") {
+                shouldNotThrowAny {
+                    env.scenario.createAuthenticationOptions(
+                        allowCredentials = allowCredentials,
+                        userVerificationRequirement = UserVerificationRequirement.DISCOURAGED
+                    )
+                        .getAssertion()
+                        .verifyOnServer(userVerificationRequired = false)
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/support/BddHtmlReporter.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/support/BddHtmlReporter.kt
@@ -1,0 +1,253 @@
+package com.webauthn4j.test.integration.support
+
+import io.kotest.core.listeners.AfterProjectListener
+import io.kotest.core.listeners.AfterTestListener
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.core.test.TestType
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.reflect.KClass
+
+/**
+ * A custom Kotest listener that generates a single-page BDD HTML report
+ * with the full Given/When/Then hierarchy displayed as a tree.
+ *
+ * Output: {buildDir}/reports/bdd/index.html
+ */
+class BddHtmlReporter : AfterTestListener, AfterProjectListener {
+
+    private data class TestEntry(
+        val testCase: TestCase,
+        val result: TestResult,
+    )
+
+    private val entries = mutableListOf<TestEntry>()
+
+    override suspend fun afterAny(testCase: TestCase, result: TestResult) {
+        synchronized(entries) {
+            entries.add(TestEntry(testCase, result))
+        }
+    }
+
+    override suspend fun afterProject() {
+        if (entries.isEmpty()) return
+
+        val buildDir = System.getProperty("gradle.build.dir") ?: "build"
+        val outputDir = File(buildDir, "reports/bdd")
+        outputDir.mkdirs()
+
+        val html = generateHtml()
+        File(outputDir, "index.html").writeText(html)
+    }
+
+    private fun generateHtml(): String {
+        // Group entries by spec class, then by @Tags category
+        val specGroups = entries.groupBy { it.testCase.spec::class }
+        val categoryGroups = specGroups.entries.groupBy { (specClass, _) ->
+            specClass.java.getAnnotation(Tags::class.java)?.values?.firstOrNull() ?: "Uncategorized"
+        }
+
+        // Count results
+        val leafTests = entries.filter { it.testCase.type == TestType.Test }
+        val totalTests = leafTests.size
+        val passed = leafTests.count { it.result is TestResult.Success }
+        val failed = leafTests.count { it.result is TestResult.Failure || it.result is TestResult.Error }
+        val skipped = leafTests.count { it.result is TestResult.Ignored }
+
+        val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+
+        return buildString {
+            appendLine("<!DOCTYPE html>")
+            appendLine("<html lang=\"en\">")
+            appendLine("<head>")
+            appendLine("<meta charset=\"UTF-8\">")
+            appendLine("<title>BDD Specification Report</title>")
+            appendLine("<style>")
+            appendLine(CSS)
+            appendLine("</style>")
+            appendLine("</head>")
+            appendLine("<body>")
+            appendLine("<div class=\"container\">")
+            appendLine("<h1>BDD Specification Report</h1>")
+            appendLine("<p class=\"timestamp\">Generated: $timestamp</p>")
+            appendLine("<div class=\"summary\">")
+            appendLine("<span class=\"total\">$totalTests tests</span>")
+            if (passed > 0) appendLine("<span class=\"pass-count\">$passed passed</span>")
+            if (failed > 0) appendLine("<span class=\"fail-count\">$failed failed</span>")
+            if (skipped > 0) appendLine("<span class=\"skip-count\">$skipped skipped</span>")
+            appendLine("</div>")
+
+            for ((category, specs) in categoryGroups.entries.sortedBy { it.key }) {
+                appendLine("<section class=\"category\">")
+                appendLine("<h2 class=\"category-header\">${escapeHtml(category)}</h2>")
+                for ((specClass, specEntries) in specs) {
+                    renderSpec(specClass, specEntries)
+                }
+                appendLine("</section>")
+            }
+
+            appendLine("</div>")
+            appendLine("</body>")
+            appendLine("</html>")
+        }
+    }
+
+    private fun StringBuilder.renderSpec(specClass: KClass<out Spec>, specEntries: List<TestEntry>) {
+        val specName = specClass.simpleName ?: "Unknown"
+        val leafTests = specEntries.filter { it.testCase.type == TestType.Test }
+        val allSkipped = specEntries.isNotEmpty() && specEntries.all { it.result is TestResult.Ignored }
+        val allPassed = !allSkipped && leafTests.all { it.result is TestResult.Success }
+        val statusClass = when {
+            allSkipped -> "skip"
+            allPassed -> "pass"
+            else -> "fail"
+        }
+
+        appendLine("<div class=\"spec\">")
+        appendLine("<h3 class=\"$statusClass\">$specName</h3>")
+
+        // Build tree from entries
+        val roots = buildTree(specEntries)
+        for (node in roots) {
+            renderNode(node)
+        }
+
+        appendLine("</div>")
+    }
+
+    private data class TreeNode(
+        val entry: TestEntry,
+        val children: MutableList<TreeNode> = mutableListOf(),
+    )
+
+    private fun buildTree(specEntries: List<TestEntry>): List<TreeNode> {
+        // Map descriptor path to TreeNode
+        val nodeMap = linkedMapOf<String, TreeNode>()
+        for (entry in specEntries) {
+            val path = entry.testCase.descriptor.path().value
+            nodeMap[path] = TreeNode(entry)
+        }
+
+        // Link parent-child
+        val roots = mutableListOf<TreeNode>()
+        for ((path, node) in nodeMap) {
+            val parent = node.entry.testCase.parent
+            if (parent != null) {
+                val parentPath = parent.descriptor.path().value
+                val parentNode = nodeMap[parentPath]
+                if (parentNode != null) {
+                    parentNode.children.add(node)
+                    continue
+                }
+            }
+            roots.add(node)
+        }
+        return roots
+    }
+
+    private fun StringBuilder.renderNode(node: TreeNode) {
+        val testCase = node.entry.testCase
+        val result = node.entry.result
+        val isLeaf = testCase.type == TestType.Test
+        val description = testCase.name.testName
+        val keyword = testCase.name.prefix?.trim()?.trimEnd(':')?.trim() ?: ""
+        val keywordLower = keyword.lowercase()
+
+        // Skipped container (e.g., xGiven) with no children
+        if (!isLeaf && node.children.isEmpty() && result is TestResult.Ignored) {
+            appendLine("<div class=\"test-leaf skip\">")
+            appendLine("<span class=\"icon\">\u25CB</span>")
+            if (keyword.isNotEmpty()) {
+                appendLine("<span class=\"keyword keyword-$keywordLower\">$keyword</span>")
+            }
+            appendLine("${escapeHtml(description)} <em>(skipped)</em>")
+            appendLine("</div>")
+            return
+        }
+
+        if (isLeaf) {
+            val (icon, statusClass) = when (result) {
+                is TestResult.Success -> "\u2713" to "pass"
+                is TestResult.Failure -> "\u2717" to "fail"
+                is TestResult.Error -> "\u2717" to "fail"
+                is TestResult.Ignored -> "\u25CB" to "skip"
+            }
+            appendLine("<div class=\"test-leaf $statusClass\">")
+            appendLine("<span class=\"icon\">$icon</span>")
+            if (keyword.isNotEmpty()) {
+                appendLine("<span class=\"keyword keyword-$keywordLower\">$keyword</span>")
+            }
+            appendLine(escapeHtml(description))
+            if (result is TestResult.Failure) {
+                appendLine("<pre class=\"error\">${escapeHtml(result.errorOrNull?.message ?: "")}</pre>")
+            }
+            if (result is TestResult.Error) {
+                appendLine("<pre class=\"error\">${escapeHtml(result.errorOrNull?.message ?: "")}</pre>")
+            }
+            appendLine("</div>")
+        } else {
+            appendLine("<details open>")
+            append("<summary class=\"test-container\">")
+            if (keyword.isNotEmpty()) {
+                append("<span class=\"keyword keyword-$keywordLower\">$keyword</span> ")
+            }
+            append(escapeHtml(description))
+            appendLine("</summary>")
+            appendLine("<div class=\"children\">")
+            for (child in node.children) {
+                renderNode(child)
+            }
+            appendLine("</div>")
+            appendLine("</details>")
+        }
+    }
+
+    private fun escapeHtml(text: String): String {
+        return text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+    }
+
+    companion object {
+        private val CSS = """
+            * { margin: 0; padding: 0; box-sizing: border-box; }
+            body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f8f9fa; color: #212529; line-height: 1.6; }
+            .container { max-width: 960px; margin: 2rem auto; padding: 0 1rem; }
+            h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+            .timestamp { color: #6c757d; font-size: 0.85rem; margin-bottom: 1rem; }
+            .summary { margin-bottom: 1.5rem; font-size: 0.9rem; }
+            .summary span { margin-right: 1rem; padding: 0.2rem 0.6rem; border-radius: 4px; }
+            .total { background: #e9ecef; }
+            .pass-count { background: #d4edda; color: #155724; }
+            .fail-count { background: #f8d7da; color: #721c24; }
+            .skip-count { background: #fff3cd; color: #856404; }
+            .category { margin-bottom: 2rem; }
+            .category-header { font-size: 1.2rem; color: #495057; margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 2px solid #adb5bd; }
+            .spec { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 1rem; padding: 1rem 1.25rem; }
+            .spec h3 { font-size: 1rem; margin-bottom: 0.5rem; padding-bottom: 0.5rem; border-bottom: 1px solid #eee; }
+            .spec h3.pass { color: #155724; }
+            .spec h3.fail { color: #721c24; }
+            .spec h3.skip { color: #856404; }
+            details { margin-left: 1rem; }
+            summary.test-container { cursor: pointer; font-weight: 500; padding: 0.2rem 0; color: #495057; }
+            summary.test-container:hover { color: #212529; }
+            .children { margin-left: 0.5rem; border-left: 2px solid #e9ecef; padding-left: 0.75rem; }
+            .test-leaf { padding: 0.15rem 0; margin-left: 1rem; }
+            .test-leaf.pass { color: #155724; }
+            .test-leaf.fail { color: #721c24; }
+            .test-leaf.skip { color: #856404; }
+            .icon { font-weight: bold; margin-right: 0.25rem; }
+            .keyword { display: inline-block; font-weight: 700; font-size: 0.8rem; padding: 0.05rem 0.4rem; border-radius: 3px; margin-right: 0.3rem; text-transform: uppercase; letter-spacing: 0.03em; }
+            .keyword-given { background: #cce5ff; color: #004085; }
+            .keyword-when { background: #d4edda; color: #155724; }
+            .keyword-then { background: #fff3cd; color: #856404; }
+            .keyword-and { background: #e2e3e5; color: #383d41; }
+            .error { margin: 0.25rem 0 0.5rem 1.5rem; padding: 0.5rem; background: #fff5f5; border: 1px solid #f8d7da; border-radius: 4px; font-size: 0.8rem; color: #721c24; white-space: pre-wrap; word-break: break-word; }
+        """.trimIndent()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,5 +24,6 @@ include("webauthn4j-util")
 include("integration-tests:spring-security-passkeys")
 include("integration-tests:quarkus-security-webauthn")
 include("integration-tests:fido-mds-integration")
+include("integration-tests:fido-integration-bdd")
 
 rootProject.name = "webauthn4j"


### PR DESCRIPTION
Comprehensive BDD integration tests using Kotest BehaviorSpec that verify the interaction between Authenticator (webauthn4j-ctap-authenticator), Client Platform(webauthn4j-ctap-client), and Server/Relying Party (webauthn4j-core), based on W3C WebAuthn Level 3 specification sections 7.1 and 7.2.

- DSL-based test environment (webAuthnEnv) for configuring authenticators, client platforms, and relying parties
- Step objects pattern for protocol flow decomposition
- Table-driven matrix tests for parameter combinations (UserVerification, Algorithm, ResidentKey, CredentialSelector)
- 22 parameter test specs: algorithm, attestation (format/trust/conveyance), attachment, backup state, challenge, client PIN, counter, credential ID, credential selector, cross-origin, exclude/allow credentials, origin, reset protection, resident key, RP ID, transport, user presence, user verification, AAGUID
- 4 scenario test specs: passwordless, second factor, credential deletion, client PIN management
- Custom BDD HTML reporter with tag-based grouping
- 95 tests passing, 3 tests skipped (pending DSL/authenticator support)