### PR TITLE
Add CTAP 2.1-2.3 top-level fields to AuthenticatorGetInfo

### DIFF
--- a/integration-tests/fido-mds-integration/src/test/java/com/webauthn4j/metadata/FidoMDS3MetadataBLOBIntegrationTest.java
+++ b/integration-tests/fido-mds-integration/src/test/java/com/webauthn4j/metadata/FidoMDS3MetadataBLOBIntegrationTest.java
@@ -4,18 +4,24 @@ import com.webauthn4j.async.metadata.FidoMDS3MetadataBLOBAsyncProvider;
 import com.webauthn4j.async.metadata.HttpAsyncClient;
 import com.webauthn4j.async.util.internal.FileAsyncUtil;
 import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule;
 import com.webauthn4j.metadata.data.MetadataBLOB;
+import com.webauthn4j.metadata.data.MetadataBLOBPayload;
 import com.webauthn4j.util.Base64Util;
 import com.webauthn4j.util.CertificateUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -74,6 +80,23 @@ class FidoMDS3MetadataBLOBIntegrationTest {
                 Collections.singleton(new TrustAnchor(ROOT_CERTIFICATE, null)));
         MetadataBLOB metadataBLOB = target.provide();
         assertThat(metadataBLOB).isNotNull();
+    }
+
+    @Test
+    void metadata_blob_payload_should_cover_all_fields() {
+        String blobJwt = new String(blobBytes, StandardCharsets.UTF_8).trim();
+
+        JsonMapper strictMapper = new ObjectConverter()
+                .rebuildWithJSONModule(new WebAuthnMetadataJSONModule())
+                .getJsonMapper().rebuild()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+                .build();
+
+        String[] parts = blobJwt.split("\\.");
+        String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+
+        assertThatCode(() -> strictMapper.readValue(payloadJson, MetadataBLOBPayload.class))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/UserVerificationMethodSetFromLongDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/UserVerificationMethodSetFromLongDeserializer.java
@@ -1,0 +1,30 @@
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.webauthn4j.data.UserVerificationMethod;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public class UserVerificationMethodSetFromLongDeserializer extends StdDeserializer<Set<UserVerificationMethod>> {
+
+    public UserVerificationMethodSetFromLongDeserializer() {
+        super(Set.class);
+    }
+
+    @Override
+    public @Nullable Set<UserVerificationMethod> deserialize(@NotNull JsonParser p, @NotNull DeserializationContext ctxt) {
+        long bitmask = p.getLongValue();
+        EnumSet<UserVerificationMethod> result = EnumSet.noneOf(UserVerificationMethod.class);
+        for (UserVerificationMethod method : UserVerificationMethod.values()) {
+            if ((bitmask & method.getValue()) != 0) {
+                result.add(method);
+            }
+        }
+        return result;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/UserVerificationMethodSetToLongSerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/UserVerificationMethodSetToLongSerializer.java
@@ -1,0 +1,25 @@
+package com.webauthn4j.converter.jackson.serializer.json;
+
+import com.webauthn4j.data.UserVerificationMethod;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+import java.util.Set;
+
+public class UserVerificationMethodSetToLongSerializer extends StdSerializer<Set<UserVerificationMethod>> {
+
+    public UserVerificationMethodSetToLongSerializer() {
+        super(Set.class);
+    }
+
+    @Override
+    public void serialize(@NotNull Set<UserVerificationMethod> value, @NotNull JsonGenerator gen, @NotNull SerializationContext ctxt) {
+        long bitmask = 0;
+        for (UserVerificationMethod method : value) {
+            bitmask |= method.getValue();
+        }
+        gen.writeNumber(bitmask);
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/json/UserVerificationMethodSetFromLongDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/json/UserVerificationMethodSetFromLongDeserializerTest.java
@@ -1,0 +1,54 @@
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.webauthn4j.data.UserVerificationMethod;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UserVerificationMethodSetFromLongDeserializerTest {
+
+    private final UserVerificationMethodSetFromLongDeserializer deserializer = new UserVerificationMethodSetFromLongDeserializer();
+
+    @Test
+    void single_value_test() {
+        Set<UserVerificationMethod> result = deserialize(2L);
+        assertThat(result).containsExactly(UserVerificationMethod.FINGERPRINT_INTERNAL);
+    }
+
+    @Test
+    void multiple_values_bitmask_test() {
+        Set<UserVerificationMethod> result = deserialize(3L);
+        assertThat(result).containsExactlyInAnyOrder(
+                UserVerificationMethod.PRESENCE_INTERNAL,
+                UserVerificationMethod.FINGERPRINT_INTERNAL
+        );
+    }
+
+    @Test
+    void zero_test() {
+        Set<UserVerificationMethod> result = deserialize(0L);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void all_values_test() {
+        long allBits = 0;
+        for (UserVerificationMethod m : UserVerificationMethod.values()) {
+            allBits |= m.getValue();
+        }
+        Set<UserVerificationMethod> result = deserialize(allBits);
+        assertThat(result).containsExactlyInAnyOrder(UserVerificationMethod.values());
+    }
+
+    private Set<UserVerificationMethod> deserialize(long bitmask) {
+        JsonParser parser = mock(JsonParser.class);
+        when(parser.getLongValue()).thenReturn(bitmask);
+        return deserializer.deserialize(parser, mock(DeserializationContext.class));
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/json/UserVerificationMethodSetToLongSerializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/json/UserVerificationMethodSetToLongSerializerTest.java
@@ -1,0 +1,43 @@
+package com.webauthn4j.converter.jackson.serializer.json;
+
+import com.webauthn4j.data.UserVerificationMethod;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+class UserVerificationMethodSetToLongSerializerTest {
+
+    private final UserVerificationMethodSetToLongSerializer serializer = new UserVerificationMethodSetToLongSerializer();
+
+    @Test
+    void single_value_test() throws Exception {
+        JsonGenerator gen = mock(JsonGenerator.class);
+        Set<UserVerificationMethod> set = EnumSet.of(UserVerificationMethod.FINGERPRINT_INTERNAL);
+        serializer.serialize(set, gen, mock(SerializationContext.class));
+        verify(gen).writeNumber(2L);
+    }
+
+    @Test
+    void multiple_values_test() throws Exception {
+        JsonGenerator gen = mock(JsonGenerator.class);
+        Set<UserVerificationMethod> set = EnumSet.of(
+                UserVerificationMethod.PRESENCE_INTERNAL,
+                UserVerificationMethod.FINGERPRINT_INTERNAL
+        );
+        serializer.serialize(set, gen, mock(SerializationContext.class));
+        verify(gen).writeNumber(3L);
+    }
+
+    @Test
+    void empty_set_test() throws Exception {
+        JsonGenerator gen = mock(JsonGenerator.class);
+        Set<UserVerificationMethod> set = EnumSet.noneOf(UserVerificationMethod.class);
+        serializer.serialize(set, gen, mock(SerializationContext.class));
+        verify(gen).writeNumber(0L);
+    }
+}

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/MetadataCodecFallbackRegistrar.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/MetadataCodecFallbackRegistrar.java
@@ -3,7 +3,10 @@ package com.webauthn4j.metadata;
 import com.webauthn4j.converter.jackson.ModuleNotRegisteredGuardClearingMixin;
 import com.webauthn4j.converter.jackson.ModuleNotRegisteredGuardDeserializer;
 import com.webauthn4j.converter.jackson.ModuleNotRegisteredGuardSerializer;
+import com.webauthn4j.converter.jackson.deserializer.json.UserVerificationMethodSetFromLongDeserializer;
+import com.webauthn4j.converter.jackson.serializer.json.UserVerificationMethodSetToLongSerializer;
 import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.UserVerificationMethod;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.metadata.converter.jackson.deserializer.AAIDDeserializer;
 import com.webauthn4j.metadata.converter.jackson.deserializer.AuthenticatorStatusDeserializer;
@@ -16,10 +19,16 @@ import com.webauthn4j.metadata.data.uaf.AAID;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import tools.jackson.databind.JavaType;
+import tools.jackson.databind.*;
+import tools.jackson.databind.deser.Deserializers;
 import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.jsontype.TypeDeserializer;
 import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.Serializers;
 import tools.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.databind.type.CollectionType;
+
+import java.util.Set;
 
 public class MetadataCodecFallbackRegistrar {
 
@@ -34,6 +43,11 @@ public class MetadataCodecFallbackRegistrar {
                 super.setupModule(context);
                 ModuleNotRegisteredGuardClearingMixin.setIfAbsent(context, AAID.class);
                 ModuleNotRegisteredGuardClearingMixin.setIfAbsent(context, AuthenticatorStatus.class);
+
+                addCollectionSerializer(context, Set.class, UserVerificationMethod.class,
+                        new UserVerificationMethodSetToLongSerializer());
+                addCollectionDeserializer(context, Set.class, UserVerificationMethod.class,
+                        new UserVerificationMethodSetFromLongDeserializer());
             }
         };
         boolean needsFallback = false;
@@ -80,5 +94,45 @@ public class MetadataCodecFallbackRegistrar {
             return true;
         }
         return false;
+    }
+
+    private static void addCollectionSerializer(SimpleModule.SetupContext context,
+            Class<?> collectionType, Class<?> elementType, ValueSerializer<?> serializer) {
+        context.addSerializers(new Serializers.Base() {
+            @Override
+            public ValueSerializer<?> findCollectionSerializer(SerializationConfig config,
+                    CollectionType type, BeanDescription.Supplier beanDescRef,
+                    com.fasterxml.jackson.annotation.JsonFormat.Value formatOverrides,
+                    tools.jackson.databind.jsontype.TypeSerializer elementTypeSerializer,
+                    ValueSerializer<Object> elementValueSerializer) {
+                if (collectionType.isAssignableFrom(type.getRawClass())
+                        && type.getContentType().getRawClass() == elementType) {
+                    return serializer;
+                }
+                return null;
+            }
+        });
+    }
+
+    private static void addCollectionDeserializer(SimpleModule.SetupContext context,
+            Class<?> collectionType, Class<?> elementType, ValueDeserializer<?> deserializer) {
+        context.addDeserializers(new Deserializers.Base() {
+            @Override
+            public ValueDeserializer<?> findCollectionDeserializer(CollectionType type,
+                    DeserializationConfig config, BeanDescription.Supplier beanDescRef,
+                    TypeDeserializer elementTypeDeserializer,
+                    ValueDeserializer<?> elementDeserializer) {
+                if (collectionType.isAssignableFrom(type.getRawClass())
+                        && type.getContentType().getRawClass() == elementType) {
+                    return deserializer;
+                }
+                return null;
+            }
+
+            @Override
+            public boolean hasDeserializerFor(DeserializationConfig config, Class<?> valueType) {
+                return collectionType.isAssignableFrom(valueType);
+            }
+        });
     }
 }

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/converter/jackson/WebAuthnMetadataJSONModule.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/converter/jackson/WebAuthnMetadataJSONModule.java
@@ -17,6 +17,9 @@
 package com.webauthn4j.metadata.converter.jackson;
 
 import com.webauthn4j.converter.jackson.ModuleNotRegisteredGuardClearingMixin;
+import com.webauthn4j.converter.jackson.deserializer.json.UserVerificationMethodSetFromLongDeserializer;
+import com.webauthn4j.converter.jackson.serializer.json.UserVerificationMethodSetToLongSerializer;
+import com.webauthn4j.data.UserVerificationMethod;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.metadata.converter.jackson.deserializer.AAIDDeserializer;
 import com.webauthn4j.metadata.converter.jackson.deserializer.AuthenticatorStatusDeserializer;
@@ -26,7 +29,14 @@ import com.webauthn4j.metadata.converter.jackson.serializer.AuthenticatorStatusS
 import com.webauthn4j.metadata.converter.jackson.serializer.MetadataAAGUIDSerializer;
 import com.webauthn4j.metadata.data.toc.AuthenticatorStatus;
 import com.webauthn4j.metadata.data.uaf.AAID;
+import tools.jackson.databind.*;
+import tools.jackson.databind.deser.Deserializers;
+import tools.jackson.databind.jsontype.TypeDeserializer;
 import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.Serializers;
+import tools.jackson.databind.type.CollectionType;
+
+import java.util.Set;
 
 public class WebAuthnMetadataJSONModule extends SimpleModule {
 
@@ -47,14 +57,53 @@ public class WebAuthnMetadataJSONModule extends SimpleModule {
     @Override
     public void setupModule(SetupContext context) {
         super.setupModule(context);
-        // These classes have @JsonSerialize(using = ModuleNotRegisteredGuardSerializer.class) /
-        // @JsonDeserialize(using = ModuleNotRegisteredGuardDeserializer.class) annotations that throw
-        // if no module is registered. Clear them so that the serializers/deserializers registered above
-        // via addSerializer/addDeserializer take effect instead.
-        // This is necessary because Jackson resolves annotation-based serializers before module-registered ones.
-        // Only set the clearing MixIn if the user hasn't already provided their own MixIn for the type.
         ModuleNotRegisteredGuardClearingMixin.setIfAbsent(context, AAID.class);
         ModuleNotRegisteredGuardClearingMixin.setIfAbsent(context, AuthenticatorStatus.class);
+
+        addCollectionSerializer(context, Set.class, UserVerificationMethod.class,
+                new UserVerificationMethodSetToLongSerializer());
+        addCollectionDeserializer(context, Set.class, UserVerificationMethod.class,
+                new UserVerificationMethodSetFromLongDeserializer());
+    }
+
+    private static void addCollectionSerializer(SetupContext context,
+            Class<?> collectionType, Class<?> elementType, ValueSerializer<?> serializer) {
+        context.addSerializers(new Serializers.Base() {
+            @Override
+            public ValueSerializer<?> findCollectionSerializer(SerializationConfig config,
+                    CollectionType type, BeanDescription.Supplier beanDescRef,
+                    com.fasterxml.jackson.annotation.JsonFormat.Value formatOverrides,
+                    tools.jackson.databind.jsontype.TypeSerializer elementTypeSerializer,
+                    ValueSerializer<Object> elementValueSerializer) {
+                if (collectionType.isAssignableFrom(type.getRawClass())
+                        && type.getContentType().getRawClass() == elementType) {
+                    return serializer;
+                }
+                return null;
+            }
+        });
+    }
+
+    private static void addCollectionDeserializer(SetupContext context,
+            Class<?> collectionType, Class<?> elementType, ValueDeserializer<?> deserializer) {
+        context.addDeserializers(new Deserializers.Base() {
+            @Override
+            public ValueDeserializer<?> findCollectionDeserializer(CollectionType type,
+                    DeserializationConfig config, BeanDescription.Supplier beanDescRef,
+                    TypeDeserializer elementTypeDeserializer,
+                    ValueDeserializer<?> elementDeserializer) {
+                if (collectionType.isAssignableFrom(type.getRawClass())
+                        && type.getContentType().getRawClass() == elementType) {
+                    return deserializer;
+                }
+                return null;
+            }
+
+            @Override
+            public boolean hasDeserializerFor(DeserializationConfig config, Class<?> valueType) {
+                return collectionType.isAssignableFrom(valueType);
+            }
+        });
     }
 
 }

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AlternativeDescriptions.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AlternativeDescriptions.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 /**
  * This descriptor contains description in alternative languages.
+ *
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dom-metadatastatement-alternativedescriptions">§4. MetadataStatement - alternativeDescriptions</a>
  */
 public class AlternativeDescriptions extends AbstractImmutableMap<String, String> {
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.webauthn4j.data.PinProtocolVersion;
+import com.webauthn4j.data.PublicKeyCredentialParameters;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.metadata.converter.jackson.deserializer.MetadataAAGUIDRelaxedDeserializer;
 import org.jetbrains.annotations.NotNull;
@@ -29,9 +30,10 @@ import org.jetbrains.annotations.Nullable;
 import tools.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
-//TODO: support CTAP 2.1
+@SuppressWarnings("java:S107")
 public class AuthenticatorGetInfo {
 
     @JsonProperty("versions")
@@ -59,6 +61,106 @@ public class AuthenticatorGetInfo {
     @Nullable
     private final List<PinProtocolVersion> pinUvAuthProtocols;
 
+    @JsonProperty("maxCredentialCountInList")
+    @Nullable
+    private final Integer maxCredentialCountInList;
+
+    @JsonProperty("maxCredentialIdLength")
+    @Nullable
+    private final Integer maxCredentialIdLength;
+
+    @JsonProperty("transports")
+    @Nullable
+    private final List<String> transports;
+
+    @JsonProperty("algorithms")
+    @Nullable
+    private final List<PublicKeyCredentialParameters> algorithms;
+
+    @JsonProperty("maxSerializedLargeBlobArray")
+    @Nullable
+    private final Integer maxSerializedLargeBlobArray;
+
+    @JsonProperty("forcePINChange")
+    @Nullable
+    private final Boolean forcePINChange;
+
+    @JsonProperty("minPINLength")
+    @Nullable
+    private final Integer minPINLength;
+
+    @JsonProperty("firmwareVersion")
+    @Nullable
+    private final Integer firmwareVersion;
+
+    @JsonProperty("maxCredBlobLength")
+    @Nullable
+    private final Integer maxCredBlobLength;
+
+    @JsonProperty("maxRPIDsForSetMinPINLength")
+    @Nullable
+    private final Integer maxRPIDsForSetMinPINLength;
+
+    @JsonProperty("preferredPlatformUvAttempts")
+    @Nullable
+    private final Integer preferredPlatformUvAttempts;
+
+    @JsonProperty("uvModality")
+    @Nullable
+    private final Integer uvModality;
+
+    @JsonProperty("certifications")
+    @Nullable
+    private final Map<String, Object> certifications;
+
+    @JsonProperty("remainingDiscoverableCredentials")
+    @Nullable
+    private final Integer remainingDiscoverableCredentials;
+
+    @JsonProperty("vendorPrototypeConfigCommands")
+    @Nullable
+    private final List<Integer> vendorPrototypeConfigCommands;
+
+    @JsonProperty("attestationFormats")
+    @Nullable
+    private final List<String> attestationFormats;
+
+    @JsonProperty("uvCountSinceLastPinEntry")
+    @Nullable
+    private final Integer uvCountSinceLastPinEntry;
+
+    @JsonProperty("longTouchForReset")
+    @Nullable
+    private final Boolean longTouchForReset;
+
+    @JsonProperty("encIdentifier")
+    @Nullable
+    private final String encIdentifier;
+
+    @JsonProperty("transportsForReset")
+    @Nullable
+    private final List<String> transportsForReset;
+
+    @JsonProperty("pinComplexityPolicy")
+    @Nullable
+    private final Boolean pinComplexityPolicy;
+
+    @JsonProperty("pinComplexityPolicyURL")
+    @Nullable
+    private final String pinComplexityPolicyURL;
+
+    @JsonProperty("maxPINLength")
+    @Nullable
+    private final Integer maxPINLength;
+
+    @JsonProperty("encCredStoreState")
+    @Nullable
+    private final String encCredStoreState;
+
+    @JsonProperty("authenticatorConfigCommands")
+    @Nullable
+    private final List<Integer> authenticatorConfigCommands;
+
     @JsonCreator
     public AuthenticatorGetInfo(
             @JsonProperty("versions") @NotNull List<String> versions,
@@ -66,37 +168,201 @@ public class AuthenticatorGetInfo {
             @JsonProperty("aaguid") @NotNull AAGUID aaguid,
             @JsonProperty("options") @Nullable Options options,
             @JsonProperty("maxMsgSize") @Nullable Integer maxMsgSize,
-            @JsonProperty("pinUvAuthProtocols") @Nullable List<PinProtocolVersion> pinUvAuthProtocols) {
+            @JsonProperty("pinUvAuthProtocols") @Nullable List<PinProtocolVersion> pinUvAuthProtocols,
+            @JsonProperty("maxCredentialCountInList") @Nullable Integer maxCredentialCountInList,
+            @JsonProperty("maxCredentialIdLength") @Nullable Integer maxCredentialIdLength,
+            @JsonProperty("transports") @Nullable List<String> transports,
+            @JsonProperty("algorithms") @Nullable List<PublicKeyCredentialParameters> algorithms,
+            @JsonProperty("maxSerializedLargeBlobArray") @Nullable Integer maxSerializedLargeBlobArray,
+            @JsonProperty("forcePINChange") @Nullable Boolean forcePINChange,
+            @JsonProperty("minPINLength") @Nullable Integer minPINLength,
+            @JsonProperty("firmwareVersion") @Nullable Integer firmwareVersion,
+            @JsonProperty("maxCredBlobLength") @Nullable Integer maxCredBlobLength,
+            @JsonProperty("maxRPIDsForSetMinPINLength") @Nullable Integer maxRPIDsForSetMinPINLength,
+            @JsonProperty("preferredPlatformUvAttempts") @Nullable Integer preferredPlatformUvAttempts,
+            @JsonProperty("uvModality") @Nullable Integer uvModality,
+            @JsonProperty("certifications") @Nullable Map<String, Object> certifications,
+            @JsonProperty("remainingDiscoverableCredentials") @Nullable Integer remainingDiscoverableCredentials,
+            @JsonProperty("vendorPrototypeConfigCommands") @Nullable List<Integer> vendorPrototypeConfigCommands,
+            @JsonProperty("attestationFormats") @Nullable List<String> attestationFormats,
+            @JsonProperty("uvCountSinceLastPinEntry") @Nullable Integer uvCountSinceLastPinEntry,
+            @JsonProperty("longTouchForReset") @Nullable Boolean longTouchForReset,
+            @JsonProperty("encIdentifier") @Nullable String encIdentifier,
+            @JsonProperty("transportsForReset") @Nullable List<String> transportsForReset,
+            @JsonProperty("pinComplexityPolicy") @Nullable Boolean pinComplexityPolicy,
+            @JsonProperty("pinComplexityPolicyURL") @Nullable String pinComplexityPolicyURL,
+            @JsonProperty("maxPINLength") @Nullable Integer maxPINLength,
+            @JsonProperty("encCredStoreState") @Nullable String encCredStoreState,
+            @JsonProperty("authenticatorConfigCommands") @Nullable List<Integer> authenticatorConfigCommands) {
         this.versions = versions;
         this.extensions = extensions;
         this.aaguid = aaguid;
         this.options = options;
         this.maxMsgSize = maxMsgSize;
         this.pinUvAuthProtocols = pinUvAuthProtocols;
+        this.maxCredentialCountInList = maxCredentialCountInList;
+        this.maxCredentialIdLength = maxCredentialIdLength;
+        this.transports = transports;
+        this.algorithms = algorithms;
+        this.maxSerializedLargeBlobArray = maxSerializedLargeBlobArray;
+        this.forcePINChange = forcePINChange;
+        this.minPINLength = minPINLength;
+        this.firmwareVersion = firmwareVersion;
+        this.maxCredBlobLength = maxCredBlobLength;
+        this.maxRPIDsForSetMinPINLength = maxRPIDsForSetMinPINLength;
+        this.preferredPlatformUvAttempts = preferredPlatformUvAttempts;
+        this.uvModality = uvModality;
+        this.certifications = certifications;
+        this.remainingDiscoverableCredentials = remainingDiscoverableCredentials;
+        this.vendorPrototypeConfigCommands = vendorPrototypeConfigCommands;
+        this.attestationFormats = attestationFormats;
+        this.uvCountSinceLastPinEntry = uvCountSinceLastPinEntry;
+        this.longTouchForReset = longTouchForReset;
+        this.encIdentifier = encIdentifier;
+        this.transportsForReset = transportsForReset;
+        this.pinComplexityPolicy = pinComplexityPolicy;
+        this.pinComplexityPolicyURL = pinComplexityPolicyURL;
+        this.maxPINLength = maxPINLength;
+        this.encCredStoreState = encCredStoreState;
+        this.authenticatorConfigCommands = authenticatorConfigCommands;
     }
 
-    public List<String> getVersions() {
+    @Deprecated
+    public AuthenticatorGetInfo(
+            @NotNull List<String> versions,
+            @Nullable List<String> extensions,
+            @NotNull AAGUID aaguid,
+            @Nullable Options options,
+            @Nullable Integer maxMsgSize,
+            @Nullable List<PinProtocolVersion> pinUvAuthProtocols) {
+        this(versions, extensions, aaguid, options, maxMsgSize, pinUvAuthProtocols,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null);
+    }
+
+    public @NotNull List<String> getVersions() {
         return versions;
     }
 
-    public List<String> getExtensions() {
+    public @Nullable List<String> getExtensions() {
         return extensions;
     }
 
-    public AAGUID getAaguid() {
+    public @NotNull AAGUID getAaguid() {
         return aaguid;
     }
 
-    public Options getOptions() {
+    public @Nullable Options getOptions() {
         return options;
     }
 
-    public Integer getMaxMsgSize() {
+    public @Nullable Integer getMaxMsgSize() {
         return maxMsgSize;
     }
 
-    public List<PinProtocolVersion> getPinUvAuthProtocols() {
+    public @Nullable List<PinProtocolVersion> getPinUvAuthProtocols() {
         return pinUvAuthProtocols;
+    }
+
+    public @Nullable Integer getMaxCredentialCountInList() {
+        return maxCredentialCountInList;
+    }
+
+    public @Nullable Integer getMaxCredentialIdLength() {
+        return maxCredentialIdLength;
+    }
+
+    public @Nullable List<String> getTransports() {
+        return transports;
+    }
+
+    public @Nullable List<PublicKeyCredentialParameters> getAlgorithms() {
+        return algorithms;
+    }
+
+    public @Nullable Integer getMaxSerializedLargeBlobArray() {
+        return maxSerializedLargeBlobArray;
+    }
+
+    public @Nullable Boolean getForcePINChange() {
+        return forcePINChange;
+    }
+
+    public @Nullable Integer getMinPINLength() {
+        return minPINLength;
+    }
+
+    public @Nullable Integer getFirmwareVersion() {
+        return firmwareVersion;
+    }
+
+    public @Nullable Integer getMaxCredBlobLength() {
+        return maxCredBlobLength;
+    }
+
+    public @Nullable Integer getMaxRPIDsForSetMinPINLength() {
+        return maxRPIDsForSetMinPINLength;
+    }
+
+    public @Nullable Integer getPreferredPlatformUvAttempts() {
+        return preferredPlatformUvAttempts;
+    }
+
+    public @Nullable Integer getUvModality() {
+        return uvModality;
+    }
+
+    public @Nullable Map<String, Object> getCertifications() {
+        return certifications;
+    }
+
+    public @Nullable Integer getRemainingDiscoverableCredentials() {
+        return remainingDiscoverableCredentials;
+    }
+
+    public @Nullable List<Integer> getVendorPrototypeConfigCommands() {
+        return vendorPrototypeConfigCommands;
+    }
+
+    public @Nullable List<String> getAttestationFormats() {
+        return attestationFormats;
+    }
+
+    public @Nullable Integer getUvCountSinceLastPinEntry() {
+        return uvCountSinceLastPinEntry;
+    }
+
+    public @Nullable Boolean getLongTouchForReset() {
+        return longTouchForReset;
+    }
+
+    public @Nullable String getEncIdentifier() {
+        return encIdentifier;
+    }
+
+    public @Nullable List<String> getTransportsForReset() {
+        return transportsForReset;
+    }
+
+    public @Nullable Boolean getPinComplexityPolicy() {
+        return pinComplexityPolicy;
+    }
+
+    public @Nullable String getPinComplexityPolicyURL() {
+        return pinComplexityPolicyURL;
+    }
+
+    public @Nullable Integer getMaxPINLength() {
+        return maxPINLength;
+    }
+
+    public @Nullable String getEncCredStoreState() {
+        return encCredStoreState;
+    }
+
+    public @Nullable List<Integer> getAuthenticatorConfigCommands() {
+        return authenticatorConfigCommands;
     }
 
     @Override
@@ -104,12 +370,49 @@ public class AuthenticatorGetInfo {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AuthenticatorGetInfo that = (AuthenticatorGetInfo) o;
-        return versions.equals(that.versions) && Objects.equals(extensions, that.extensions) && aaguid.equals(that.aaguid) && Objects.equals(options, that.options) && Objects.equals(maxMsgSize, that.maxMsgSize) && Objects.equals(pinUvAuthProtocols, that.pinUvAuthProtocols);
+        return versions.equals(that.versions) &&
+                Objects.equals(extensions, that.extensions) &&
+                aaguid.equals(that.aaguid) &&
+                Objects.equals(options, that.options) &&
+                Objects.equals(maxMsgSize, that.maxMsgSize) &&
+                Objects.equals(pinUvAuthProtocols, that.pinUvAuthProtocols) &&
+                Objects.equals(maxCredentialCountInList, that.maxCredentialCountInList) &&
+                Objects.equals(maxCredentialIdLength, that.maxCredentialIdLength) &&
+                Objects.equals(transports, that.transports) &&
+                Objects.equals(algorithms, that.algorithms) &&
+                Objects.equals(maxSerializedLargeBlobArray, that.maxSerializedLargeBlobArray) &&
+                Objects.equals(forcePINChange, that.forcePINChange) &&
+                Objects.equals(minPINLength, that.minPINLength) &&
+                Objects.equals(firmwareVersion, that.firmwareVersion) &&
+                Objects.equals(maxCredBlobLength, that.maxCredBlobLength) &&
+                Objects.equals(maxRPIDsForSetMinPINLength, that.maxRPIDsForSetMinPINLength) &&
+                Objects.equals(preferredPlatformUvAttempts, that.preferredPlatformUvAttempts) &&
+                Objects.equals(uvModality, that.uvModality) &&
+                Objects.equals(certifications, that.certifications) &&
+                Objects.equals(remainingDiscoverableCredentials, that.remainingDiscoverableCredentials) &&
+                Objects.equals(vendorPrototypeConfigCommands, that.vendorPrototypeConfigCommands) &&
+                Objects.equals(attestationFormats, that.attestationFormats) &&
+                Objects.equals(uvCountSinceLastPinEntry, that.uvCountSinceLastPinEntry) &&
+                Objects.equals(longTouchForReset, that.longTouchForReset) &&
+                Objects.equals(encIdentifier, that.encIdentifier) &&
+                Objects.equals(transportsForReset, that.transportsForReset) &&
+                Objects.equals(pinComplexityPolicy, that.pinComplexityPolicy) &&
+                Objects.equals(pinComplexityPolicyURL, that.pinComplexityPolicyURL) &&
+                Objects.equals(maxPINLength, that.maxPINLength) &&
+                Objects.equals(encCredStoreState, that.encCredStoreState) &&
+                Objects.equals(authenticatorConfigCommands, that.authenticatorConfigCommands);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(versions, extensions, aaguid, options, maxMsgSize, pinUvAuthProtocols);
+        return Objects.hash(versions, extensions, aaguid, options, maxMsgSize, pinUvAuthProtocols,
+                maxCredentialCountInList, maxCredentialIdLength, transports, algorithms,
+                maxSerializedLargeBlobArray, forcePINChange, minPINLength, firmwareVersion,
+                maxCredBlobLength, maxRPIDsForSetMinPINLength, preferredPlatformUvAttempts,
+                uvModality, certifications, remainingDiscoverableCredentials,
+                vendorPrototypeConfigCommands, attestationFormats, uvCountSinceLastPinEntry,
+                longTouchForReset, encIdentifier, transportsForReset, pinComplexityPolicy,
+                pinComplexityPolicyURL, maxPINLength, encCredStoreState, authenticatorConfigCommands);
     }
 
     /**

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
@@ -21,17 +21,21 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.PinProtocolVersion;
 import com.webauthn4j.data.PublicKeyCredentialParameters;
+import com.webauthn4j.data.UserVerificationMethod;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.metadata.converter.jackson.deserializer.MetadataAAGUIDRelaxedDeserializer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tools.jackson.databind.annotation.JsonDeserialize;
 
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 @SuppressWarnings("java:S107")
 public class AuthenticatorGetInfo {
@@ -71,7 +75,7 @@ public class AuthenticatorGetInfo {
 
     @JsonProperty("transports")
     @Nullable
-    private final List<String> transports;
+    private final List<AuthenticatorTransport> transports;
 
     @JsonProperty("algorithms")
     @Nullable
@@ -107,7 +111,7 @@ public class AuthenticatorGetInfo {
 
     @JsonProperty("uvModality")
     @Nullable
-    private final Integer uvModality;
+    private final Set<UserVerificationMethod> uvModality;
 
     @JsonProperty("certifications")
     @Nullable
@@ -139,7 +143,7 @@ public class AuthenticatorGetInfo {
 
     @JsonProperty("transportsForReset")
     @Nullable
-    private final List<String> transportsForReset;
+    private final List<AuthenticatorTransport> transportsForReset;
 
     @JsonProperty("pinComplexityPolicy")
     @Nullable
@@ -171,7 +175,7 @@ public class AuthenticatorGetInfo {
             @JsonProperty("pinUvAuthProtocols") @Nullable List<PinProtocolVersion> pinUvAuthProtocols,
             @JsonProperty("maxCredentialCountInList") @Nullable Integer maxCredentialCountInList,
             @JsonProperty("maxCredentialIdLength") @Nullable Integer maxCredentialIdLength,
-            @JsonProperty("transports") @Nullable List<String> transports,
+            @JsonProperty("transports") @Nullable List<AuthenticatorTransport> transports,
             @JsonProperty("algorithms") @Nullable List<PublicKeyCredentialParameters> algorithms,
             @JsonProperty("maxSerializedLargeBlobArray") @Nullable Integer maxSerializedLargeBlobArray,
             @JsonProperty("forcePINChange") @Nullable Boolean forcePINChange,
@@ -180,7 +184,7 @@ public class AuthenticatorGetInfo {
             @JsonProperty("maxCredBlobLength") @Nullable Integer maxCredBlobLength,
             @JsonProperty("maxRPIDsForSetMinPINLength") @Nullable Integer maxRPIDsForSetMinPINLength,
             @JsonProperty("preferredPlatformUvAttempts") @Nullable Integer preferredPlatformUvAttempts,
-            @JsonProperty("uvModality") @Nullable Integer uvModality,
+            @JsonProperty("uvModality") @Nullable Set<UserVerificationMethod> uvModality,
             @JsonProperty("certifications") @Nullable Map<String, Object> certifications,
             @JsonProperty("remainingDiscoverableCredentials") @Nullable Integer remainingDiscoverableCredentials,
             @JsonProperty("vendorPrototypeConfigCommands") @Nullable List<Integer> vendorPrototypeConfigCommands,
@@ -188,7 +192,7 @@ public class AuthenticatorGetInfo {
             @JsonProperty("uvCountSinceLastPinEntry") @Nullable Integer uvCountSinceLastPinEntry,
             @JsonProperty("longTouchForReset") @Nullable Boolean longTouchForReset,
             @JsonProperty("encIdentifier") @Nullable String encIdentifier,
-            @JsonProperty("transportsForReset") @Nullable List<String> transportsForReset,
+            @JsonProperty("transportsForReset") @Nullable List<AuthenticatorTransport> transportsForReset,
             @JsonProperty("pinComplexityPolicy") @Nullable Boolean pinComplexityPolicy,
             @JsonProperty("pinComplexityPolicyURL") @Nullable String pinComplexityPolicyURL,
             @JsonProperty("maxPINLength") @Nullable Integer maxPINLength,
@@ -273,7 +277,7 @@ public class AuthenticatorGetInfo {
         return maxCredentialIdLength;
     }
 
-    public @Nullable List<String> getTransports() {
+    public @Nullable List<AuthenticatorTransport> getTransports() {
         return transports;
     }
 
@@ -309,7 +313,7 @@ public class AuthenticatorGetInfo {
         return preferredPlatformUvAttempts;
     }
 
-    public @Nullable Integer getUvModality() {
+    public @Nullable Set<UserVerificationMethod> getUvModality() {
         return uvModality;
     }
 
@@ -341,7 +345,7 @@ public class AuthenticatorGetInfo {
         return encIdentifier;
     }
 
-    public @Nullable List<String> getTransportsForReset() {
+    public @Nullable List<AuthenticatorTransport> getTransportsForReset() {
         return transportsForReset;
     }
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/BiometricAccuracyDescriptor.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/BiometricAccuracyDescriptor.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * Describes the relevant accuracy/complexity aspects of an authenticator's biometric user verification methods.
  *
- * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-rd-20251016.html#dictdef-biometricaccuracydescriptor">
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-biometricaccuracydescriptor">
  * §3.3. BiometricAccuracyDescriptor dictionary</a>
  */
 @SuppressWarnings("squid:S00116")

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/CodeAccuracyDescriptor.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/CodeAccuracyDescriptor.java
@@ -25,6 +25,9 @@ import java.util.Objects;
 
 /**
  * The CodeAccuracyDescriptor describes the relevant accuracy/complexity aspects of passcode user verification methods.
+ *
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-codeaccuracydescriptor">
+ * §3.2. CodeAccuracyDescriptor dictionary</a>
  */
 public class CodeAccuracyDescriptor {
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/DisplayPNGCharacteristicsDescriptor.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/DisplayPNGCharacteristicsDescriptor.java
@@ -28,6 +28,8 @@ import java.util.Objects;
 
 /**
  * The DisplayPNGCharacteristicsDescriptor describes a PNG image characteristics as defined in the PNG spec for IHDR (image header) and PLTE (palette table)
+ *
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-displaypngcharacteristicsdescriptor">§3.8. DisplayPNGCharacteristicsDescriptor dictionary</a>
  */
 public class DisplayPNGCharacteristicsDescriptor {
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/EcdaaTrustAnchor.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/EcdaaTrustAnchor.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 
 /**
  * In the case of ECDAA attestation, the ECDAA-Issuer's trust anchor must be specified in this field.
+ *
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-ecdaatrustanchor">§3.9. EcdaaTrustAnchor dictionary</a>
  */
 public class EcdaaTrustAnchor {
     @NotNull private final String x;

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/ExtensionDescriptor.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/ExtensionDescriptor.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 
 /**
  * This descriptor contains an extension supported by the authenticator.
+ *
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-extensiondescriptor">§3.10. ExtensionDescriptor dictionary</a>
  */
 public class ExtensionDescriptor {
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/FriendlyNames.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/FriendlyNames.java
@@ -26,7 +26,7 @@ import java.util.Map;
 /**
  * Represents a map of friendly names for an authenticator, keyed by language tag.
  *
- * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-rd-20251016.html#dictdef-friendlynames">FriendlyNames in Metadata Statement v3.1.1</a>
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-friendlynames">FriendlyNames in Metadata Statement v3.1.1</a>
  */
 public class FriendlyNames extends AbstractImmutableMap<String, String> {
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/MetadataStatement.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/MetadataStatement.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 /**
  * This metadata statement contains a subset of verifiable information for authenticators certified by the FIDO Alliance.
  *
- * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-rd-20251016.html#dictdef-metadatastatement">Metadata Statement v3.1.1</a>
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-metadatastatement">Metadata Statement v3.1.1</a>
  */
 public class MetadataStatement {
     @Nullable private final String legalHeader;

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/MultiDeviceCredentialSupport.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/MultiDeviceCredentialSupport.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 /**
  * Indicates whether the authenticator supports multi-device credentials.
  *
- * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-rd-20251016.html#dom-metadatastatement-multidevicecredentialsupport">
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dom-metadatastatement-multidevicecredentialsupport">
  * §4. MetadataStatement - multiDeviceCredentialSupport</a>
  */
 public class MultiDeviceCredentialSupport {

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/PatternAccuracyDescriptor.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/PatternAccuracyDescriptor.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 
 /**
  * The PatternAccuracyDescriptor describes relevant accuracy/complexity aspects in the case that a pattern is used as the user verification method.
+ *
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-patternaccuracydescriptor">§3.4. PatternAccuracyDescriptor dictionary</a>
  */
 public class PatternAccuracyDescriptor {
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/RGBPaletteEntry.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/RGBPaletteEntry.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 
 /**
  * The RGBPaletteEntry is an RGB three-sample tuple palette entry
+ *
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-rgbpaletteentry">§3.7. rgbPaletteEntry dictionary</a>
  */
 public class RGBPaletteEntry {
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/VerificationMethodANDCombinations.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/VerificationMethodANDCombinations.java
@@ -23,6 +23,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
+/**
+ * Represents a combination of verification method descriptors that must all be satisfied.
+ *
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#typedefdef-verificationmethodandcombinations">
+ * §3.6. VerificationMethodANDCombinations typedef</a>
+ */
 public class VerificationMethodANDCombinations extends AbstractList<VerificationMethodDescriptor> {
 
     private final int size;

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/VerificationMethodDescriptor.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/VerificationMethodDescriptor.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 
 /**
  * A descriptor for a specific base user verification method as implemented by the authenticator.
+ *
+ * @see <a href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-ps-20260105.html#dictdef-verificationmethoddescriptor">§3.5. VerificationMethodDescriptor dictionary</a>
  */
 public class VerificationMethodDescriptor {
 

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
@@ -42,6 +42,31 @@ class AuthenticatorGetInfoTest {
         assertThat(info.getOptions()).isNotNull();
         assertThat(info.getMaxMsgSize()).isEqualTo(1200);
         assertThat(info.getPinUvAuthProtocols()).containsExactly(PinProtocolVersion.VERSION_1);
+        assertThat(info.getMaxCredentialCountInList()).isEqualTo(16);
+        assertThat(info.getMaxCredentialIdLength()).isEqualTo(128);
+        assertThat(info.getTransports()).containsExactly("usb", "nfc");
+        assertThat(info.getAlgorithms()).hasSize(2);
+        assertThat(info.getFirmwareVersion()).isEqualTo(5);
+        assertThat(info.getMaxSerializedLargeBlobArray()).isEqualTo(4096);
+        assertThat(info.getForcePINChange()).isFalse();
+        assertThat(info.getMinPINLength()).isEqualTo(4);
+        assertThat(info.getMaxCredBlobLength()).isEqualTo(32);
+        assertThat(info.getMaxRPIDsForSetMinPINLength()).isEqualTo(3);
+        assertThat(info.getPreferredPlatformUvAttempts()).isEqualTo(5);
+        assertThat(info.getUvModality()).isEqualTo(2);
+        assertThat(info.getCertifications()).containsKey("FIDO");
+        assertThat(info.getRemainingDiscoverableCredentials()).isEqualTo(25);
+        assertThat(info.getVendorPrototypeConfigCommands()).containsExactly(1, 2);
+        assertThat(info.getAttestationFormats()).containsExactly("packed", "fido-u2f");
+        assertThat(info.getUvCountSinceLastPinEntry()).isEqualTo(3);
+        assertThat(info.getLongTouchForReset()).isTrue();
+        assertThat(info.getEncIdentifier()).isEqualTo("abc123");
+        assertThat(info.getTransportsForReset()).containsExactly("usb");
+        assertThat(info.getPinComplexityPolicy()).isTrue();
+        assertThat(info.getPinComplexityPolicyURL()).isEqualTo("https://example.com/policy");
+        assertThat(info.getMaxPINLength()).isEqualTo(64);
+        assertThat(info.getEncCredStoreState()).isEqualTo("state123");
+        assertThat(info.getAuthenticatorConfigCommands()).containsExactly(3, 4);
     }
 
     @Test
@@ -342,9 +367,27 @@ class AuthenticatorGetInfoTest {
                     {"type": "public-key", "alg": -7},
                     {"type": "public-key", "alg": -257}
                 ],
-                "maxAuthenticatorConfigLength": 1024,
-                "defaultCredProtect": 2,
-                "firmwareVersion": 5
+                "maxSerializedLargeBlobArray": 4096,
+                "forcePINChange": false,
+                "minPINLength": 4,
+                "firmwareVersion": 5,
+                "maxCredBlobLength": 32,
+                "maxRPIDsForSetMinPINLength": 3,
+                "preferredPlatformUvAttempts": 5,
+                "uvModality": 2,
+                "certifications": {"FIDO": 1},
+                "remainingDiscoverableCredentials": 25,
+                "vendorPrototypeConfigCommands": [1, 2],
+                "attestationFormats": ["packed", "fido-u2f"],
+                "uvCountSinceLastPinEntry": 3,
+                "longTouchForReset": true,
+                "encIdentifier": "abc123",
+                "transportsForReset": ["usb"],
+                "pinComplexityPolicy": true,
+                "pinComplexityPolicyURL": "https://example.com/policy",
+                "maxPINLength": 64,
+                "encCredStoreState": "state123",
+                "authenticatorConfigCommands": [3, 4]
             }
             """;
 }

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
@@ -17,7 +17,9 @@
 package com.webauthn4j.metadata.data.statement;
 
 import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.PinProtocolVersion;
+import com.webauthn4j.data.UserVerificationMethod;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule;
 import org.junit.jupiter.api.Test;
@@ -44,7 +46,7 @@ class AuthenticatorGetInfoTest {
         assertThat(info.getPinUvAuthProtocols()).containsExactly(PinProtocolVersion.VERSION_1);
         assertThat(info.getMaxCredentialCountInList()).isEqualTo(16);
         assertThat(info.getMaxCredentialIdLength()).isEqualTo(128);
-        assertThat(info.getTransports()).containsExactly("usb", "nfc");
+        assertThat(info.getTransports()).containsExactly(AuthenticatorTransport.USB, AuthenticatorTransport.NFC);
         assertThat(info.getAlgorithms()).hasSize(2);
         assertThat(info.getFirmwareVersion()).isEqualTo(5);
         assertThat(info.getMaxSerializedLargeBlobArray()).isEqualTo(4096);
@@ -53,7 +55,7 @@ class AuthenticatorGetInfoTest {
         assertThat(info.getMaxCredBlobLength()).isEqualTo(32);
         assertThat(info.getMaxRPIDsForSetMinPINLength()).isEqualTo(3);
         assertThat(info.getPreferredPlatformUvAttempts()).isEqualTo(5);
-        assertThat(info.getUvModality()).isEqualTo(2);
+        assertThat(info.getUvModality()).containsExactly(UserVerificationMethod.FINGERPRINT_INTERNAL);
         assertThat(info.getCertifications()).containsKey("FIDO");
         assertThat(info.getRemainingDiscoverableCredentials()).isEqualTo(25);
         assertThat(info.getVendorPrototypeConfigCommands()).containsExactly(1, 2);
@@ -61,7 +63,7 @@ class AuthenticatorGetInfoTest {
         assertThat(info.getUvCountSinceLastPinEntry()).isEqualTo(3);
         assertThat(info.getLongTouchForReset()).isTrue();
         assertThat(info.getEncIdentifier()).isEqualTo("abc123");
-        assertThat(info.getTransportsForReset()).containsExactly("usb");
+        assertThat(info.getTransportsForReset()).containsExactly(AuthenticatorTransport.USB);
         assertThat(info.getPinComplexityPolicy()).isTrue();
         assertThat(info.getPinComplexityPolicyURL()).isEqualTo("https://example.com/policy");
         assertThat(info.getMaxPINLength()).isEqualTo(64);

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MetadataStatementTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MetadataStatementTest.java
@@ -19,6 +19,7 @@ package com.webauthn4j.metadata.data.statement;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.*;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
+import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -26,7 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MetadataStatementTest {
 
-    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+    private final JsonMapper jsonMapper = new ObjectConverter()
+            .rebuildWithJSONModule(new WebAuthnMetadataJSONModule())
+            .getJsonMapper();
 
     @SuppressWarnings("java:S5961")
     @Test


### PR DESCRIPTION
Add 25 top-level response fields to AuthenticatorGetInfo covering CTAP 2.1 through 2.3 specifications.

- Use `AuthenticatorTransport` type for `transports` and `transportsForReset` fields
- Use `Set<UserVerificationMethod>` with bitmask serialization for `uvModality` field, registered via `Serializers`/`Deserializers` SPI in both `WebAuthnMetadataJSONModule` and `MetadataCodecFallbackRegistrar`
- Add Javadoc with spec links to all metadata statement data types (updated to PS version: fido-metadata-statement-v3.1.1-ps-20260105)
- Add integration test that deserializes the live FIDO MDS BLOB with `FAIL_ON_UNKNOWN_PROPERTIES` enabled to detect any unhandled fields