### PR TITLE
Hold Parameters objects directly in CoreRegistrationObject / CoreAuthenticationObject

### DIFF
--- a/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAssertionDataVerifier.java
+++ b/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAssertionDataVerifier.java
@@ -16,14 +16,11 @@
 
 package com.webauthn4j.appattest.verifier;
 
-import com.webauthn4j.appattest.authenticator.DCAppleDevice;
-import com.webauthn4j.appattest.authenticator.DCAppleDeviceImpl;
-import com.webauthn4j.authenticator.CoreAuthenticator;
+import com.webauthn4j.appattest.data.DCAssertionParameters;
 import com.webauthn4j.data.CoreAuthenticationData;
 import com.webauthn4j.data.CoreAuthenticationParameters;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
-import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.verifier.CoreAuthenticationDataVerifier;
 import com.webauthn4j.verifier.CoreAuthenticationObject;
@@ -38,7 +35,6 @@ public class DCAssertionDataVerifier extends CoreAuthenticationDataVerifier {
         super(customAuthenticationValidators, new DCAssertionSignatureVerifier());
     }
 
-    @SuppressWarnings("deprecation") // for getAuthenticator()
     @Override
     protected @NotNull CoreAuthenticationObject createCoreAuthenticationObject(@NotNull CoreAuthenticationData authenticationData, @NotNull CoreAuthenticationParameters authenticationParameters) {
 
@@ -50,17 +46,10 @@ public class DCAssertionDataVerifier extends CoreAuthenticationDataVerifier {
         byte[] authenticatorDataBytes = authenticationData.getAuthenticatorDataBytes();
         byte[] clientDataHash = authenticationData.getClientDataHash();
 
-        CoreServerProperty serverProperty = authenticationParameters.getServerProperty();
-        CoreAuthenticator authenticator = authenticationParameters.getAuthenticator();
-        DCAppleDevice dcAppleDevice = new DCAppleDeviceImpl(
-                authenticator.getAttestedCredentialData(),
-                authenticator.getAttestationStatement(),
-                authenticator.getCounter(),
-                authenticator.getAuthenticatorExtensions());
-
+        DCAssertionParameters dcAssertionParameters = (DCAssertionParameters) authenticationParameters;
         //noinspection ConstantConditions null check is already done in caller
         return new DCAuthenticationObject(
-                credentialId, authenticatorData, authenticatorDataBytes, clientDataHash, serverProperty, dcAppleDevice
+                credentialId, authenticatorData, authenticatorDataBytes, clientDataHash, dcAssertionParameters
         );
     }
 

--- a/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAttestationDataVerifier.java
+++ b/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAttestationDataVerifier.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.appattest.verifier;
 
 import com.webauthn4j.appattest.data.DCAttestationData;
+import com.webauthn4j.appattest.data.DCAttestationParameters;
 import com.webauthn4j.appattest.verifier.attestation.statement.appleappattest.AppleAppAttestAttestationStatementVerifier;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.CoreRegistrationData;
@@ -84,13 +85,14 @@ public class DCAttestationDataVerifier extends CoreRegistrationDataVerifier {
         AssertUtil.notNull(registrationParameters, "registrationParameters must not be null");
 
         DCAttestationData dcAttestationData = (DCAttestationData) registrationData;
+        DCAttestationParameters dcAttestationParameters = (DCAttestationParameters) registrationParameters;
         //noinspection ConstantConditions null check is already done in caller
         return new DCRegistrationObject(
                 dcAttestationData.getKeyId(),
                 registrationData.getAttestationObject(),
                 registrationData.getAttestationObjectBytes(),
                 registrationData.getClientDataHash(),
-                registrationParameters.getServerProperty(), Instant.now());
+                dcAttestationParameters, Instant.now());
     }
 
     public boolean isProduction() {

--- a/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAuthenticationObject.java
+++ b/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAuthenticationObject.java
@@ -17,13 +17,30 @@
 package com.webauthn4j.appattest.verifier;
 
 import com.webauthn4j.appattest.authenticator.DCAppleDevice;
+import com.webauthn4j.appattest.data.DCAssertionParameters;
+import com.webauthn4j.data.CoreAuthenticationParameters;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
 import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.verifier.CoreAuthenticationObject;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class DCAuthenticationObject extends CoreAuthenticationObject {
+
+    public DCAuthenticationObject(
+            @NotNull byte[] credentialId,
+            @NotNull AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData,
+            @NotNull byte[] authenticatorDataBytes,
+            @NotNull byte[] clientDataHash,
+            @NotNull DCAssertionParameters dcAssertionParameters) {
+        super(credentialId, authenticatorData, authenticatorDataBytes, clientDataHash, dcAssertionParameters);
+    }
+
+    /**
+     * @deprecated Use {@link #DCAuthenticationObject(byte[], AuthenticatorData, byte[], byte[], DCAssertionParameters)} instead.
+     */
+    @Deprecated
     public DCAuthenticationObject(
             @NotNull byte[] credentialId,
             @NotNull AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData,
@@ -32,5 +49,10 @@ public class DCAuthenticationObject extends CoreAuthenticationObject {
             @NotNull CoreServerProperty serverProperty,
             @NotNull DCAppleDevice dcAppleDevice) {
         super(credentialId, authenticatorData, authenticatorDataBytes, clientDataHash, serverProperty, dcAppleDevice);
+    }
+
+    @Override
+    public @Nullable DCAssertionParameters getAuthenticationParameters() {
+        return (DCAssertionParameters) super.getAuthenticationParameters();
     }
 }

--- a/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCRegistrationObject.java
+++ b/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCRegistrationObject.java
@@ -16,6 +16,8 @@
 
 package com.webauthn4j.appattest.verifier;
 
+import com.webauthn4j.appattest.data.DCAttestationParameters;
+import com.webauthn4j.data.CoreRegistrationParameters;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.util.ArrayUtil;
@@ -31,7 +33,33 @@ public class DCRegistrationObject extends CoreRegistrationObject {
 
     private final byte[] keyId;
 
+    public DCRegistrationObject(
+            @NotNull byte[] keyId,
+            @NotNull AttestationObject attestationObject,
+            @NotNull byte[] attestationObjectBytes,
+            @NotNull byte[] clientDataHash,
+            @NotNull DCAttestationParameters dcAttestationParameters,
+            @NotNull Instant timestamp) {
+        super(attestationObject, attestationObjectBytes, clientDataHash, dcAttestationParameters, timestamp);
 
+        AssertUtil.notNull(keyId, "keyId must not be null");
+
+        this.keyId = ArrayUtil.clone(keyId);
+    }
+
+    public DCRegistrationObject(
+            @NotNull byte[] keyId,
+            @NotNull AttestationObject attestationObject,
+            @NotNull byte[] attestationObjectBytes,
+            @NotNull byte[] clientDataHash,
+            @NotNull DCAttestationParameters dcAttestationParameters) {
+        this(keyId, attestationObject, attestationObjectBytes, clientDataHash, dcAttestationParameters, Instant.now());
+    }
+
+    /**
+     * @deprecated Use {@link #DCRegistrationObject(byte[], AttestationObject, byte[], byte[], DCAttestationParameters, Instant)} instead.
+     */
+    @Deprecated
     public DCRegistrationObject(
             @NotNull byte[] keyId,
             @NotNull AttestationObject attestationObject,
@@ -46,6 +74,10 @@ public class DCRegistrationObject extends CoreRegistrationObject {
         this.keyId = ArrayUtil.clone(keyId);
     }
 
+    /**
+     * @deprecated Use {@link #DCRegistrationObject(byte[], AttestationObject, byte[], byte[], DCAttestationParameters, Instant)} instead.
+     */
+    @Deprecated
     public DCRegistrationObject(
             @NotNull byte[] keyId,
             @NotNull AttestationObject attestationObject,
@@ -61,6 +93,11 @@ public class DCRegistrationObject extends CoreRegistrationObject {
 
     public @NotNull byte[] getKeyId() {
         return ArrayUtil.clone(keyId);
+    }
+
+    @Override
+    public @Nullable DCAttestationParameters getRegistrationParameters() {
+        return (DCAttestationParameters) super.getRegistrationParameters();
     }
 
     @Override

--- a/webauthn4j-appattest/src/test/java/com/webauthn4j/appattest/verifier/DCRegistrationObjectTest.java
+++ b/webauthn4j-appattest/src/test/java/com/webauthn4j/appattest/verifier/DCRegistrationObjectTest.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.appattest.verifier;
 
 import com.webauthn4j.appattest.DeviceCheckManager;
+import com.webauthn4j.appattest.data.DCAttestationParameters;
 import com.webauthn4j.appattest.server.DCServerProperty;
 import com.webauthn4j.converter.AttestationObjectConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
@@ -25,12 +26,10 @@ import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.util.Base64Util;
 import com.webauthn4j.util.MessageDigestUtil;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mockStatic;
 
 class DCRegistrationObjectTest {
 
@@ -47,20 +46,18 @@ class DCRegistrationObjectTest {
         byte[] clientDataHash = MessageDigestUtil.createSHA256().digest(challenge);
 
         DCServerProperty dcServerProperty = new DCServerProperty("8YE23NZS57.com.kayak.travel", new DefaultChallenge(challenge));
+        DCAttestationParameters dcAttestationParameters = new DCAttestationParameters(dcServerProperty);
 
         Instant timestamp = Instant.parse("2020-01-01T00:00:00Z");
-        try (MockedStatic<Instant> mocked = mockStatic(Instant.class)) {
-            mocked.when(Instant::now).thenReturn(timestamp);
 
-            //noinspection ConstantConditions
-            DCRegistrationObject instance = new DCRegistrationObject(keyId, attestationObject, attestationObjectBytes, clientDataHash, dcServerProperty);
-            assertThat(instance.getKeyId()).isEqualTo(keyId);
-            assertThat(instance.getAttestationObjectBytes()).isEqualTo(attestationObjectBytes);
-            assertThat(instance.getAttestationObject()).isEqualTo(attestationObject);
-            assertThat(instance.getClientDataHash()).isEqualTo(clientDataHash);
-            assertThat(instance.getServerProperty()).isEqualTo(dcServerProperty);
-            assertThat(instance.getTimestamp()).isEqualTo(timestamp);
-        }
+        //noinspection ConstantConditions
+        DCRegistrationObject instance = new DCRegistrationObject(keyId, attestationObject, attestationObjectBytes, clientDataHash, dcAttestationParameters, timestamp);
+        assertThat(instance.getKeyId()).isEqualTo(keyId);
+        assertThat(instance.getAttestationObjectBytes()).isEqualTo(attestationObjectBytes);
+        assertThat(instance.getAttestationObject()).isEqualTo(attestationObject);
+        assertThat(instance.getClientDataHash()).isEqualTo(clientDataHash);
+        assertThat(instance.getServerProperty()).isEqualTo(dcServerProperty);
+        assertThat(instance.getTimestamp()).isEqualTo(timestamp);
 
     }
 
@@ -74,11 +71,12 @@ class DCRegistrationObjectTest {
         byte[] clientDataHash = MessageDigestUtil.createSHA256().digest(challenge);
 
         DCServerProperty dcServerProperty = new DCServerProperty("8YE23NZS57.com.kayak.travel", new DefaultChallenge(challenge));
+        DCAttestationParameters dcAttestationParameters = new DCAttestationParameters(dcServerProperty);
         Instant timestamp = Instant.now();
 
         //noinspection ConstantConditions
-        DCRegistrationObject instanceA = new DCRegistrationObject(keyId, attestationObject, attestationObjectBytes, clientDataHash, dcServerProperty, timestamp);
-        DCRegistrationObject instanceB = new DCRegistrationObject(keyId, attestationObject, attestationObjectBytes, clientDataHash, dcServerProperty, timestamp);
+        DCRegistrationObject instanceA = new DCRegistrationObject(keyId, attestationObject, attestationObjectBytes, clientDataHash, dcAttestationParameters, timestamp);
+        DCRegistrationObject instanceB = new DCRegistrationObject(keyId, attestationObject, attestationObjectBytes, clientDataHash, dcAttestationParameters, timestamp);
 
         assertThat(instanceA)
                 .isEqualTo(instanceB)

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationDataVerifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationDataVerifier.java
@@ -151,11 +151,12 @@ public class AuthenticationDataVerifier {
             throw new ConstraintViolationException("attestedCredentialData must be null on authentication");
         }
 
+        @SuppressWarnings("deprecation")
         Authenticator authenticator = authenticationParameters.getAuthenticator();
 
         AuthenticationObject authenticationObject = new AuthenticationObject(
                 credentialId, authenticatorData, aData, collectedClientData, cData, clientExtensions,
-                serverProperty, authenticator
+                authenticationParameters
         );
 
         //spec| Step10

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
@@ -2,6 +2,7 @@ package com.webauthn4j.verifier;
 
 import com.webauthn4j.authenticator.Authenticator;
 import com.webauthn4j.credential.CredentialRecord;
+import com.webauthn4j.data.AuthenticationParameters;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.client.CollectedClientData;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
@@ -37,6 +38,30 @@ public class AuthenticationObject extends CoreAuthenticationObject {
             @NotNull CollectedClientData collectedClientData,
             @NotNull byte[] collectedClientDataBytes,
             @Nullable AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions,
+            @NotNull AuthenticationParameters authenticationParameters) {
+
+        super(credentialId, authenticatorData, authenticatorDataBytes, MessageDigestUtil.createSHA256().digest(collectedClientDataBytes), authenticationParameters);
+
+        AssertUtil.notNull(collectedClientData, "collectedClientData must not be null");
+        AssertUtil.notNull(collectedClientDataBytes, "collectedClientDataBytes must not be null");
+
+        this.collectedClientData = collectedClientData;
+        this.collectedClientDataBytes = ArrayUtil.clone(collectedClientDataBytes);
+        this.clientExtensions = clientExtensions;
+    }
+
+    /**
+     * @deprecated Use {@link #AuthenticationObject(byte[], AuthenticatorData, byte[], CollectedClientData, byte[], AuthenticationExtensionsClientOutputs, AuthenticationParameters)} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("squid:S00107")
+    public AuthenticationObject(
+            @NotNull byte[] credentialId,
+            @NotNull AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData,
+            @NotNull byte[] authenticatorDataBytes,
+            @NotNull CollectedClientData collectedClientData,
+            @NotNull byte[] collectedClientDataBytes,
+            @Nullable AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions,
             @NotNull ServerProperty serverProperty,
             @NotNull Authenticator authenticator) {
 
@@ -62,6 +87,12 @@ public class AuthenticationObject extends CoreAuthenticationObject {
         return this.clientExtensions;
     }
 
+    @Override
+    public @Nullable AuthenticationParameters getAuthenticationParameters() {
+        return (AuthenticationParameters) super.getAuthenticationParameters();
+    }
+
+    @Deprecated
     @Override
     public @NotNull ServerProperty getServerProperty() {
         return (ServerProperty) super.getServerProperty();

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreAuthenticationDataVerifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreAuthenticationDataVerifier.java
@@ -277,20 +277,16 @@ public class CoreAuthenticationDataVerifier {
 
     }
 
-    @SuppressWarnings("deprecation") // for getAuthenticator()
     protected @NotNull CoreAuthenticationObject createCoreAuthenticationObject(@NotNull CoreAuthenticationData authenticationData, @NotNull CoreAuthenticationParameters authenticationParameters) {
         byte[] credentialId = authenticationData.getCredentialId();
         AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData = authenticationData.getAuthenticatorData();
         byte[] authenticatorDataBytes = authenticationData.getAuthenticatorDataBytes();
         byte[] clientDataHash = authenticationData.getClientDataHash();
 
-        CoreServerProperty serverProperty = authenticationParameters.getServerProperty();
-        CoreAuthenticator authenticator = authenticationParameters.getAuthenticator();
-
         AssertUtil.notNull(authenticatorData, "authenticatorData must not be null");
 
         return new CoreAuthenticationObject(
-                credentialId, authenticatorData, authenticatorDataBytes, clientDataHash, serverProperty, authenticator
+                credentialId, authenticatorData, authenticatorDataBytes, clientDataHash, authenticationParameters
         );
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreAuthenticationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreAuthenticationObject.java
@@ -2,6 +2,7 @@ package com.webauthn4j.verifier;
 
 import com.webauthn4j.authenticator.CoreAuthenticator;
 import com.webauthn4j.credential.CoreCredentialRecord;
+import com.webauthn4j.data.CoreAuthenticationParameters;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
 import com.webauthn4j.server.CoreServerProperty;
@@ -25,10 +26,39 @@ public class CoreAuthenticationObject {
     private final AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData;
     private final byte[] authenticatorDataBytes;
     private final byte[] clientDataHash;
+    // Retained for deprecated constructors where coreAuthenticationParameters is null. Remove when deprecated constructors are removed.
     private final CoreServerProperty serverProperty;
-
+    private final CoreAuthenticationParameters coreAuthenticationParameters;
+    // Retained for deprecated constructors where coreAuthenticationParameters is null. Remove when deprecated constructors are removed.
     private final CoreAuthenticator authenticator;
 
+    @SuppressWarnings({"squid:S00107", "deprecation"})
+    public CoreAuthenticationObject(
+            @NotNull byte[] credentialId,
+            @NotNull AuthenticatorData<AuthenticationExtensionAuthenticatorOutput> authenticatorData,
+            @NotNull byte[] authenticatorDataBytes,
+            @NotNull byte[] clientDataHash,
+            @NotNull CoreAuthenticationParameters coreAuthenticationParameters) {
+
+        AssertUtil.notNull(credentialId, "credentialId must not be null");
+        AssertUtil.notNull(authenticatorData, "authenticatorData must not be null");
+        AssertUtil.notNull(authenticatorDataBytes, "authenticatorDataBytes must not be null");
+        AssertUtil.notNull(clientDataHash, "clientDataHash must not be null");
+        AssertUtil.notNull(coreAuthenticationParameters, "coreAuthenticationParameters must not be null");
+
+        this.credentialId = ArrayUtil.clone(credentialId);
+        this.authenticatorData = authenticatorData;
+        this.authenticatorDataBytes = ArrayUtil.clone(authenticatorDataBytes);
+        this.clientDataHash = ArrayUtil.clone(clientDataHash);
+        this.serverProperty = coreAuthenticationParameters.getServerProperty();
+        this.coreAuthenticationParameters = coreAuthenticationParameters;
+        this.authenticator = coreAuthenticationParameters.getAuthenticator();
+    }
+
+    /**
+     * @deprecated Use {@link #CoreAuthenticationObject(byte[], AuthenticatorData, byte[], byte[], CoreAuthenticationParameters)} instead.
+     */
+    @Deprecated
     @SuppressWarnings("squid:S00107")
     public CoreAuthenticationObject(
             @NotNull byte[] credentialId,
@@ -50,6 +80,7 @@ public class CoreAuthenticationObject {
         this.authenticatorDataBytes = ArrayUtil.clone(authenticatorDataBytes);
         this.clientDataHash = ArrayUtil.clone(clientDataHash);
         this.serverProperty = serverProperty;
+        this.coreAuthenticationParameters = null;
         this.authenticator = authenticator;
     }
 
@@ -69,6 +100,14 @@ public class CoreAuthenticationObject {
         return ArrayUtil.clone(clientDataHash);
     }
 
+    public @Nullable CoreAuthenticationParameters getAuthenticationParameters() {
+        return coreAuthenticationParameters;
+    }
+
+    /**
+     * @deprecated Use {@link #getAuthenticationParameters()} instead.
+     */
+    @Deprecated
     public @NotNull CoreServerProperty getServerProperty() {
         return this.serverProperty;
     }
@@ -109,12 +148,13 @@ public class CoreAuthenticationObject {
                 Arrays.equals(authenticatorDataBytes, that.authenticatorDataBytes) &&
                 Arrays.equals(clientDataHash, that.clientDataHash) &&
                 Objects.equals(serverProperty, that.serverProperty) &&
+                Objects.equals(coreAuthenticationParameters, that.coreAuthenticationParameters) &&
                 Objects.equals(authenticator, that.authenticator);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(authenticatorData, serverProperty, authenticator);
+        int result = Objects.hash(authenticatorData, serverProperty, coreAuthenticationParameters, authenticator);
         result = 31 * result + Arrays.hashCode(credentialId);
         result = 31 * result + Arrays.hashCode(authenticatorDataBytes);
         result = 31 * result + Arrays.hashCode(clientDataHash);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreRegistrationDataVerifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreRegistrationDataVerifier.java
@@ -273,7 +273,7 @@ public class CoreRegistrationDataVerifier {
                 registrationData.getAttestationObject(),
                 registrationData.getAttestationObjectBytes(),
                 registrationData.getClientDataHash(),
-                registrationParameters.getServerProperty()
+                registrationParameters
         );
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreRegistrationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreRegistrationObject.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.verifier;
 
 import com.webauthn4j.converter.jackson.JacksonUtil;
+import com.webauthn4j.data.CoreRegistrationParameters;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.util.ArrayUtil;
@@ -36,9 +37,44 @@ public class CoreRegistrationObject {
     private final AttestationObject attestationObject;
     private final byte[] attestationObjectBytes;
     private final byte[] clientDataHash;
+    // Retained for deprecated constructors where coreRegistrationParameters is null. Remove when deprecated constructors are removed.
     private final CoreServerProperty serverProperty;
+    private final CoreRegistrationParameters coreRegistrationParameters;
     private final Instant timestamp;
 
+    public CoreRegistrationObject(
+            @NotNull AttestationObject attestationObject,
+            @NotNull byte[] attestationObjectBytes,
+            @NotNull byte[] clientDataHash,
+            @NotNull CoreRegistrationParameters coreRegistrationParameters,
+            @NotNull Instant timestamp) {
+
+        AssertUtil.notNull(attestationObject, "attestationObject must not be null");
+        AssertUtil.notNull(attestationObjectBytes, "attestationObjectBytes must not be null");
+        AssertUtil.notNull(clientDataHash, "clientDataHash must not be null");
+        AssertUtil.notNull(coreRegistrationParameters, "coreRegistrationParameters must not be null");
+        AssertUtil.notNull(timestamp, "timestamp must not be null");
+
+        this.attestationObject = attestationObject;
+        this.attestationObjectBytes = attestationObjectBytes;
+        this.clientDataHash = clientDataHash;
+        this.serverProperty = coreRegistrationParameters.getServerProperty();
+        this.coreRegistrationParameters = coreRegistrationParameters;
+        this.timestamp = timestamp;
+    }
+
+    public CoreRegistrationObject(
+            @NotNull AttestationObject attestationObject,
+            @NotNull byte[] attestationObjectBytes,
+            @NotNull byte[] clientDataHash,
+            @NotNull CoreRegistrationParameters coreRegistrationParameters) {
+        this(attestationObject, attestationObjectBytes, clientDataHash, coreRegistrationParameters, Instant.now());
+    }
+
+    /**
+     * @deprecated Use {@link #CoreRegistrationObject(AttestationObject, byte[], byte[], CoreRegistrationParameters, Instant)} instead.
+     */
+    @Deprecated
     public CoreRegistrationObject(
             @NotNull AttestationObject attestationObject,
             @NotNull byte[] attestationObjectBytes,
@@ -56,9 +92,14 @@ public class CoreRegistrationObject {
         this.attestationObjectBytes = attestationObjectBytes;
         this.clientDataHash = clientDataHash;
         this.serverProperty = serverProperty;
+        this.coreRegistrationParameters = null;
         this.timestamp = timestamp;
     }
 
+    /**
+     * @deprecated Use {@link #CoreRegistrationObject(AttestationObject, byte[], byte[], CoreRegistrationParameters, Instant)} instead.
+     */
+    @Deprecated
     public CoreRegistrationObject(
             @NotNull AttestationObject attestationObject,
             @NotNull byte[] attestationObjectBytes,
@@ -88,6 +129,14 @@ public class CoreRegistrationObject {
         return clientDataHash;
     }
 
+    public @Nullable CoreRegistrationParameters getRegistrationParameters() {
+        return coreRegistrationParameters;
+    }
+
+    /**
+     * @deprecated Use {@link #getRegistrationParameters()} instead.
+     */
+    @Deprecated
     public @NotNull CoreServerProperty getServerProperty() {
         return serverProperty;
     }
@@ -105,12 +154,13 @@ public class CoreRegistrationObject {
                 Arrays.equals(attestationObjectBytes, that.attestationObjectBytes) &&
                 Arrays.equals(clientDataHash, that.clientDataHash) &&
                 Objects.equals(serverProperty, that.serverProperty) &&
+                Objects.equals(coreRegistrationParameters, that.coreRegistrationParameters) &&
                 Objects.equals(timestamp, that.timestamp);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(attestationObject, serverProperty, timestamp);
+        int result = Objects.hash(attestationObject, serverProperty, coreRegistrationParameters, timestamp);
         result = 31 * result + Arrays.hashCode(attestationObjectBytes);
         result = 31 * result + Arrays.hashCode(clientDataHash);
         return result;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationDataVerifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationDataVerifier.java
@@ -151,7 +151,7 @@ public class RegistrationDataVerifier {
                 clientDataBytes,
                 clientExtensions,
                 transports,
-                serverProperty
+                registrationParameters
         );
 
         AuthenticatorData<RegistrationExtensionAuthenticatorOutput> authenticatorData = attestationObject.getAuthenticatorData();

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationObject.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.verifier;
 
 import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.RegistrationParameters;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.client.CollectedClientData;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
@@ -57,6 +58,43 @@ public class RegistrationObject extends CoreRegistrationObject {
             @NotNull byte[] collectedClientDataBytes,
             @Nullable AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions,
             @Nullable Set<AuthenticatorTransport> transports,
+            @NotNull RegistrationParameters registrationParameters,
+            @NotNull Instant timestamp) {
+
+        super(attestationObject, attestationObjectBytes, MessageDigestUtil.createSHA256().digest(collectedClientDataBytes), registrationParameters, timestamp);
+
+        AssertUtil.notNull(collectedClientData, "collectedClientData must not be null");
+        AssertUtil.notNull(collectedClientDataBytes, "collectedClientDataBytes must not be null");
+
+        this.collectedClientData = collectedClientData;
+        this.collectedClientDataBytes = ArrayUtil.clone(collectedClientDataBytes);
+        this.clientExtensions = clientExtensions;
+        this.transports = CollectionUtil.unmodifiableSet(transports);
+    }
+
+    public RegistrationObject(
+            @NotNull AttestationObject attestationObject,
+            @NotNull byte[] attestationObjectBytes,
+            @NotNull CollectedClientData collectedClientData,
+            @NotNull byte[] collectedClientDataBytes,
+            @Nullable AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions,
+            @Nullable Set<AuthenticatorTransport> transports,
+            @NotNull RegistrationParameters registrationParameters) {
+        this(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, clientExtensions, transports, registrationParameters, Instant.now());
+    }
+
+    /**
+     * @deprecated Use {@link #RegistrationObject(AttestationObject, byte[], CollectedClientData, byte[], AuthenticationExtensionsClientOutputs, Set, RegistrationParameters, Instant)} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("squid:S00107")
+    public RegistrationObject(
+            @NotNull AttestationObject attestationObject,
+            @NotNull byte[] attestationObjectBytes,
+            @NotNull CollectedClientData collectedClientData,
+            @NotNull byte[] collectedClientDataBytes,
+            @Nullable AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions,
+            @Nullable Set<AuthenticatorTransport> transports,
             @NotNull ServerProperty serverProperty,
             @NotNull Instant timestamp) {
 
@@ -71,6 +109,10 @@ public class RegistrationObject extends CoreRegistrationObject {
         this.transports = CollectionUtil.unmodifiableSet(transports);
     }
 
+    /**
+     * @deprecated Use {@link #RegistrationObject(AttestationObject, byte[], CollectedClientData, byte[], AuthenticationExtensionsClientOutputs, Set, RegistrationParameters, Instant)} instead.
+     */
+    @Deprecated
     public RegistrationObject(
             @NotNull AttestationObject attestationObject,
             @NotNull byte[] attestationObjectBytes,
@@ -98,10 +140,16 @@ public class RegistrationObject extends CoreRegistrationObject {
         return clientExtensions;
     }
 
+    @Override
+    public @Nullable RegistrationParameters getRegistrationParameters() {
+        return (RegistrationParameters) super.getRegistrationParameters();
+    }
+
     public @Nullable Set<AuthenticatorTransport> getTransports() {
         return transports;
     }
 
+    @Deprecated
     @Override
     public @NotNull ServerProperty getServerProperty() {
         return (ServerProperty) super.getServerProperty();

--- a/webauthn4j-core/src/test/java/com/webauthn4j/verifier/AuthenticationObjectTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/verifier/AuthenticationObjectTest.java
@@ -21,6 +21,7 @@ import com.webauthn4j.converter.AuthenticatorDataConverter;
 import com.webauthn4j.converter.CollectedClientDataConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.credential.CredentialRecord;
+import com.webauthn4j.data.AuthenticationParameters;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.client.ClientDataType;
 import com.webauthn4j.data.client.CollectedClientData;
@@ -50,7 +51,8 @@ class AuthenticationObjectTest {
         byte[] authenticatorDataBytes = new AuthenticatorDataConverter(objectConverter).convert(authenticatorData);
         AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
-        Authenticator authenticator = TestDataUtil.createCredentialRecord();
+        CredentialRecord credentialRecord = TestDataUtil.createCredentialRecord();
+        AuthenticationParameters authenticationParameters = new AuthenticationParameters(serverProperty, credentialRecord, null, false, true);
         AuthenticationObject authenticationObject = new AuthenticationObject(
                 credentialId,
                 authenticatorData,
@@ -58,8 +60,7 @@ class AuthenticationObjectTest {
                 clientData,
                 clientDataBytes,
                 clientExtensions,
-                serverProperty,
-                authenticator
+                authenticationParameters
         );
 
         assertAll(
@@ -70,7 +71,7 @@ class AuthenticationObjectTest {
                 () -> assertThat(authenticationObject.getAuthenticatorDataBytes()).isEqualTo(authenticatorDataBytes),
                 () -> assertThat(authenticationObject.getClientExtensions()).isEqualTo(clientExtensions),
                 () -> assertThat(authenticationObject.getServerProperty()).isEqualTo(serverProperty),
-                () -> assertThat(authenticationObject.getAuthenticator()).isEqualTo(authenticator)
+                () -> assertThat(authenticationObject.getCredentialRecord()).isEqualTo(credentialRecord)
         );
     }
 
@@ -84,7 +85,8 @@ class AuthenticationObjectTest {
         byte[] authenticatorDataBytes = new AuthenticatorDataConverter(objectConverter).convert(authenticatorData);
         AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
-        Authenticator authenticator = TestDataUtil.createCredentialRecord();
+        CredentialRecord credentialRecord = TestDataUtil.createCredentialRecord();
+        AuthenticationParameters authenticationParameters = new AuthenticationParameters(serverProperty, credentialRecord, null, false, true);
 
         AuthenticationObject instanceA = new AuthenticationObject(
                 credentialId,
@@ -93,8 +95,7 @@ class AuthenticationObjectTest {
                 clientData,
                 clientDataBytes,
                 clientExtensions,
-                serverProperty,
-                authenticator
+                authenticationParameters
         );
 
         AuthenticationObject instanceB = new AuthenticationObject(
@@ -104,8 +105,7 @@ class AuthenticationObjectTest {
                 clientData,
                 clientDataBytes,
                 clientExtensions,
-                serverProperty,
-                authenticator
+                authenticationParameters
         );
 
         assertAll(
@@ -124,6 +124,7 @@ class AuthenticationObjectTest {
         AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
         CredentialRecord credentialRecord = TestDataUtil.createCredentialRecord();
+        AuthenticationParameters authenticationParameters = new AuthenticationParameters(serverProperty, credentialRecord, null, false, true);
 
         AuthenticationObject authenticationObject = new AuthenticationObject(
                 credentialId,
@@ -132,8 +133,7 @@ class AuthenticationObjectTest {
                 clientData,
                 clientDataBytes,
                 clientExtensions,
-                serverProperty,
-                credentialRecord
+                authenticationParameters
         );
 
         assertThat(authenticationObject.getCredentialRecord()).isEqualTo(credentialRecord);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/verifier/RegistrationObjectTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/verifier/RegistrationObjectTest.java
@@ -21,6 +21,7 @@ import com.webauthn4j.converter.AuthenticatorDataConverter;
 import com.webauthn4j.converter.CollectedClientDataConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.RegistrationParameters;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.client.ClientDataType;
@@ -55,6 +56,7 @@ class RegistrationObjectTest {
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
+        RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, null, false, true);
         Instant timestamp = Instant.now();
         RegistrationObject registrationObject = new RegistrationObject(
                 attestationObject,
@@ -63,7 +65,7 @@ class RegistrationObjectTest {
                 clientDataBytes,
                 clientExtensions,
                 transports,
-                serverProperty,
+                registrationParameters,
                 timestamp
         );
 
@@ -89,6 +91,7 @@ class RegistrationObjectTest {
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensions = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = TestDataUtil.createServerProperty();
+        RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, null, false, true);
         Instant timestamp = Instant.now();
         RegistrationObject instanceA = new RegistrationObject(
                 attestationObject,
@@ -97,7 +100,7 @@ class RegistrationObjectTest {
                 clientDataBytes,
                 clientExtensions,
                 transports,
-                serverProperty,
+                registrationParameters,
                 timestamp
         );
 
@@ -108,7 +111,7 @@ class RegistrationObjectTest {
                 clientDataBytes,
                 clientExtensions,
                 transports,
-                serverProperty,
+                registrationParameters,
                 timestamp
         );
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/verifier/attestation/statement/packed/PackedAttestationStatementVerifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/verifier/attestation/statement/packed/PackedAttestationStatementVerifierTest.java
@@ -17,6 +17,7 @@ import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.data.extension.authenticator.ExtensionAuthenticatorOutput;
 import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
+import com.webauthn4j.data.RegistrationParameters;
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientOutputs;
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput;
 import com.webauthn4j.server.ServerProperty;
@@ -222,6 +223,8 @@ class PackedAttestationStatementVerifierTest {
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();
 
+        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, tokenBindingId);
+        RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, null, false, true);
         RegistrationObject registrationObject = new RegistrationObject(
                 attestationObject,
                 attestationObjectBytes,
@@ -229,7 +232,7 @@ class PackedAttestationStatementVerifierTest {
                 clientDataBytes,
                 authenticationExtensionsClientOutputs,
                 transports,
-                new ServerProperty(origin, rpId, challenge, tokenBindingId)
+                registrationParameters
         );
 
         target.verify(registrationObject);

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.test;
 
 import com.webauthn4j.appattest.converter.jackson.DeviceCheckCBORModule;
+import com.webauthn4j.appattest.data.DCAttestationParameters;
 import com.webauthn4j.appattest.server.DCServerProperty;
 import com.webauthn4j.appattest.verifier.DCRegistrationObject;
 import com.webauthn4j.authenticator.Authenticator;
@@ -27,9 +28,7 @@ import com.webauthn4j.converter.CollectedClientDataConverter;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.credential.CredentialRecord;
 import com.webauthn4j.credential.CredentialRecordImpl;
-import com.webauthn4j.data.AuthenticatorAttestationResponse;
-import com.webauthn4j.data.AuthenticatorTransport;
-import com.webauthn4j.data.PublicKeyCredential;
+import com.webauthn4j.data.*;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.data.attestation.authenticator.*;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
@@ -105,7 +104,8 @@ public class TestDataUtil {
         byte[] attestationObjectBytes = attestationObjectConverter.convertToBytes(attestationObject);
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();
-        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, TestDataUtil.createServerProperty());
+        RegistrationParameters registrationParameters = new RegistrationParameters(TestDataUtil.createServerProperty(), null, false, true);
+        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, registrationParameters);
     }
 
     public static RegistrationObject createRegistrationObjectWithAndroidKeyAttestation() {
@@ -116,7 +116,8 @@ public class TestDataUtil {
         AttestationObject attestationObject = attestationObjectConverter.convert(attestationObjectBytes);
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();
-        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, TestDataUtil.createServerProperty());
+        RegistrationParameters registrationParameters = new RegistrationParameters(TestDataUtil.createServerProperty(), null, false, true);
+        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, registrationParameters);
     }
 
     public static RegistrationObject createRegistrationObjectWithAndroidSafetyNetAttestation() {
@@ -127,7 +128,8 @@ public class TestDataUtil {
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();
         Instant timestamp = Instant.parse("2019-02-02T07:01:00.00Z");
-        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, TestDataUtil.createServerProperty(), timestamp);
+        RegistrationParameters registrationParameters = new RegistrationParameters(TestDataUtil.createServerProperty(), null, false, true);
+        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, registrationParameters, timestamp);
     }
 
     public static DCRegistrationObject createRegistrationObjectWithAppleAppAttestAttestation() {
@@ -140,7 +142,8 @@ public class TestDataUtil {
         AttestationObject attestationObject = attestationObjectConverter.convert(attestationObjectBytes);
         Instant timestamp = Instant.parse("2020-08-18T13:37:00Z");
 
-        return new DCRegistrationObject(keyId, attestationObject, attestationObjectBytes, clientDataHash, dcServerProperty, timestamp);
+        DCAttestationParameters dcAttestationParameters = new DCAttestationParameters(dcServerProperty);
+        return new DCRegistrationObject(keyId, attestationObject, attestationObjectBytes, clientDataHash, dcAttestationParameters, timestamp);
     }
 
     public static CoreRegistrationObject createCoreRegistrationObjectWithAppleAppAttestAttestation() {
@@ -151,8 +154,9 @@ public class TestDataUtil {
         AttestationObject attestationObject = attestationObjectConverter.convert(attestationObjectBytes);
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();
-        Instant timestamp = Instant.parse("2020-08-18T13:37:00");
-        return new CoreRegistrationObject(attestationObject, attestationObjectBytes, clientDataHash, TestDataUtil.createServerProperty(), timestamp);
+        Instant timestamp = Instant.parse("2020-08-18T13:37:00Z");
+        CoreRegistrationParameters coreRegistrationParameters = new CoreRegistrationParameters(TestDataUtil.createServerProperty(), null, false, true);
+        return new CoreRegistrationObject(attestationObject, attestationObjectBytes, clientDataHash, coreRegistrationParameters, timestamp);
     }
 
     public static RegistrationObject createRegistrationObjectWithTPMAttestation() {
@@ -162,7 +166,8 @@ public class TestDataUtil {
         AttestationObject attestationObject = attestationObjectConverter.convert(attestationObjectBytes);
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();
-        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, TestDataUtil.createServerProperty());
+        RegistrationParameters registrationParameters = new RegistrationParameters(TestDataUtil.createServerProperty(), null, false, true);
+        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, registrationParameters);
     }
 
     public static RegistrationObject createRegistrationObjectWithAppleAttestation() {
@@ -174,7 +179,8 @@ public class TestDataUtil {
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();
         ServerProperty serverProperty = new ServerProperty(new Origin("https://6cc3c9e7967a.ngrok.io"), "6cc3c9e7967a.ngrok.io", new DefaultChallenge("kOwMvE2mQO6ou0B0jjD0VA"), null);
 
-        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, serverProperty, Instant.parse("2020-10-07T10:00:00Z"));
+        RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, null, false, true);
+        return new RegistrationObject(attestationObject, attestationObjectBytes, collectedClientData, collectedClientDataBytes, authenticationExtensionsClientOutputs, transports, registrationParameters, Instant.parse("2020-10-07T10:00:00Z"));
     }
 
     public static RegistrationObject createRegistrationObject(Function<byte[], AttestationObject> attestationObjectProvider) {
@@ -184,6 +190,7 @@ public class TestDataUtil {
         byte[] attestationObjectBytes = attestationObjectConverter.convertToBytes(attestationObject);
         Set<AuthenticatorTransport> transports = Collections.emptySet();
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> authenticationExtensionsClientOutputs = new AuthenticationExtensionsClientOutputs<>();
+        RegistrationParameters registrationParameters = new RegistrationParameters(TestDataUtil.createServerProperty(), null, false, true);
         return new RegistrationObject(
                 attestationObject,
                 attestationObjectBytes,
@@ -191,7 +198,7 @@ public class TestDataUtil {
                 collectedClientDataBytes,
                 authenticationExtensionsClientOutputs,
                 transports,
-                TestDataUtil.createServerProperty()
+                registrationParameters
         );
     }
 
@@ -203,6 +210,7 @@ public class TestDataUtil {
         AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> clientExtensionResults = publicKeyCredential.getClientExtensionResults();
         Set<AuthenticatorTransport> transports = publicKeyCredential.getResponse().getTransports();
         AttestationObject attestationObject = attestationObjectConverter.convert(attestationObjectBytes);
+        RegistrationParameters registrationParameters = new RegistrationParameters(TestDataUtil.createServerProperty(), null, false, true);
         return new RegistrationObject(
                 attestationObject,
                 attestationObjectBytes,
@@ -210,7 +218,7 @@ public class TestDataUtil {
                 registrationRequest.getClientDataJSON(),
                 clientExtensionResults,
                 transports,
-                TestDataUtil.createServerProperty()
+                registrationParameters
         );
     }
 


### PR DESCRIPTION
Parameters classes aggregate verification expectations and are the natural extension point when introducing new verification requirements. Previously, CoreRegistrationObject and CoreAuthenticationObject extracted individual fields from Parameters (such as serverProperty and authenticator) and held them directly. As a result, expectations added through a Parameters subclass could not reach Verifiers unless these object classes were also extended to carry the new fields.

Holding the Parameters object itself removes this coupling. Extensions to Parameters now propagate to Verifiers transparently, without requiring changes to the object class hierarchy. Enabling this extensibility is the motivation for this change.