### PR TITLE
Fix incorrect target type in InvalidFormatException across deserializers

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/CredentialProtectionPolicyDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/CredentialProtectionPolicyDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.converter.jackson.deserializer.cbor;
 
-import com.webauthn4j.data.AuthenticatorAttachment;
 import com.webauthn4j.data.extension.CredentialProtectionPolicy;
 import org.jetbrains.annotations.NotNull;
 import tools.jackson.core.JsonParser;
@@ -36,7 +35,7 @@ public class CredentialProtectionPolicyDeserializer extends StdDeserializer<Cred
         try {
             return CredentialProtectionPolicy.create(value);
         } catch (IllegalArgumentException e) {
-            throw new InvalidFormatException(p, "value is out of range", value, AuthenticatorAttachment.class);
+            throw new InvalidFormatException(p, "value is out of range", value, CredentialProtectionPolicy.class);
         }
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticatorAttestationTypeFromIntDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticatorAttestationTypeFromIntDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.converter.jackson.deserializer.json;
 
-import com.webauthn4j.data.AttachmentHint;
 import com.webauthn4j.data.AuthenticatorAttestationType;
 import org.jetbrains.annotations.NotNull;
 import tools.jackson.core.JsonParser;
@@ -36,7 +35,7 @@ public class AuthenticatorAttestationTypeFromIntDeserializer extends StdDeserial
         try {
             return AuthenticatorAttestationType.create(value);
         } catch (IllegalArgumentException e) {
-            throw new InvalidFormatException(p, "value is out of range", value, AttachmentHint.class);
+            throw new InvalidFormatException(p, "value is out of range", value, AuthenticatorAttestationType.class);
         }
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticatorAttestationTypeFromStringDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticatorAttestationTypeFromStringDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.converter.jackson.deserializer.json;
 
-import com.webauthn4j.data.AttachmentHint;
 import com.webauthn4j.data.AuthenticatorAttestationType;
 import org.jetbrains.annotations.NotNull;
 import tools.jackson.core.JsonParser;
@@ -36,7 +35,7 @@ public class AuthenticatorAttestationTypeFromStringDeserializer extends StdDeser
         try {
             return AuthenticatorAttestationType.create(value);
         } catch (IllegalArgumentException e) {
-            throw new InvalidFormatException(p, "value is out of range", value, AttachmentHint.class);
+            throw new InvalidFormatException(p, "value is out of range", value, AuthenticatorAttestationType.class);
         }
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/CredentialProtectionPolicyDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/CredentialProtectionPolicyDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.converter.jackson.deserializer.json;
 
-import com.webauthn4j.data.AuthenticatorAttachment;
 import com.webauthn4j.data.extension.CredentialProtectionPolicy;
 import org.jetbrains.annotations.NotNull;
 import tools.jackson.core.JsonParser;
@@ -35,7 +34,7 @@ public class CredentialProtectionPolicyDeserializer extends StdDeserializer<Cred
         try {
             return CredentialProtectionPolicy.create(value);
         } catch (IllegalArgumentException e) {
-            throw new InvalidFormatException(p, "value is out of range", value, AuthenticatorAttachment.class);
+            throw new InvalidFormatException(p, "value is out of range", value, CredentialProtectionPolicy.class);
         }
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/KeyProtectionTypeFromIntDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/KeyProtectionTypeFromIntDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.converter.jackson.deserializer.json;
 
-import com.webauthn4j.data.AttachmentHint;
 import com.webauthn4j.data.KeyProtectionType;
 import org.jetbrains.annotations.NotNull;
 import tools.jackson.core.JsonParser;
@@ -36,7 +35,7 @@ public class KeyProtectionTypeFromIntDeserializer extends StdDeserializer<KeyPro
         try {
             return KeyProtectionType.create(value);
         } catch (IllegalArgumentException e) {
-            throw new InvalidFormatException(p, "value is out of range", value, AttachmentHint.class);
+            throw new InvalidFormatException(p, "value is out of range", value, KeyProtectionType.class);
         }
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/KeyProtectionTypeFromStringDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/KeyProtectionTypeFromStringDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.converter.jackson.deserializer.json;
 
-import com.webauthn4j.data.AttachmentHint;
 import com.webauthn4j.data.KeyProtectionType;
 import org.jetbrains.annotations.NotNull;
 import tools.jackson.core.JsonParser;
@@ -36,7 +35,7 @@ public class KeyProtectionTypeFromStringDeserializer extends StdDeserializer<Key
         try {
             return KeyProtectionType.create(value);
         } catch (IllegalArgumentException e) {
-            throw new InvalidFormatException(p, "value is out of range", value, AttachmentHint.class);
+            throw new InvalidFormatException(p, "value is out of range", value, KeyProtectionType.class);
         }
     }
 }


### PR DESCRIPTION
Several deserializers were passing the wrong class as the target type to InvalidFormatException, causing misleading error messages.