### PR TITLE
Clean up repository configuration files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,0 @@
-{
-  "name": "vscode-universal-devcontainer",
-  "image":  "mcr.microsoft.com/vscode/devcontainers/universal:linux"
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         java_version: [17]
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,11 @@ nbdist/
 sample/node_modules
 sample/src/main/resources/application-local-with-services.yml
 
+### Claude Code ###
+.claude/
+
+### Kotlin ###
+.kotlin/
+
 ### Temporary Files ###
 tmp/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,7 +224,7 @@ tasks.register("switchToRelease"){
 asciidoctorj{
     modules{
         diagram.use()
-        diagram.version("2.3.1")
+        diagram.version(libs.versions.asciidoctorj.diagram.get())
     }
     attributes(mapOf("source-highlighter" to "rouge"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,22 +12,36 @@ bouncycastle = "1.84"
 jetbrains-annotations = "26.1.0"
 asciidoctor = "4.0.5"
 
+asciidoctorj-diagram = "2.3.1"
+
 # Test dependencies
 
 spring-boot-bom = "4.0.6"
+
 spring-dependency-management = "1.1.7"
+
 sonarqube = "7.3.0.8198"
 
 quarkus = "3.36.0"
+
 selenium = "4.44.0"
+
 assertj = "3.27.7"
+
+junit-jupiter = "6.1.0"
+
+mockwebserver = "5.3.2"
+
 playwright = "1.60.0"
 
 # fido-integration-bdd dependencies
 
 kotlin = "2.3.21"
+
 kotest = "5.9.1"
+
 kotlinx-coroutines = "1.11.0"
+
 webauthn4j-ctap = "0.2.0.RELEASE"
 
 [libraries]
@@ -50,6 +64,8 @@ spring-boot-bom = { module = "org.springframework.boot:spring-boot-dependencies"
 quarkus-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }
 selenium-java = { module = "org.seleniumhq.selenium:selenium-java", version.ref = "selenium" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 playwright = { module = "com.microsoft.playwright:playwright", version.ref = "playwright" }
 
 # fido-integration-bdd dependencies

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 before_install:
-  - sdk install java 17.0.3-tem
-  - sdk use java 17.0.3-tem
+  - sdk install java 25-tem
+  - sdk use java 25-tem

--- a/maven-central-publish-plugin/build.gradle.kts
+++ b/maven-central-publish-plugin/build.gradle.kts
@@ -7,12 +7,12 @@ repositories {
 }
 
 dependencies {
-    implementation("tools.jackson.core:jackson-databind:3.1.4")
+    implementation(libs.jackson.databind)
 
-    testImplementation("org.junit.jupiter:junit-jupiter:6.1.0")
+    testImplementation(libs.junit.jupiter)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.assertj:assertj-core:3.27.7")
-    testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.mockwebserver)
 }
 
 tasks.test {

--- a/maven-central-publish-plugin/settings.gradle.kts
+++ b/maven-central-publish-plugin/settings.gradle.kts
@@ -1,1 +1,9 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
 rootProject.name = "maven-central-publish-plugin"


### PR DESCRIPTION
- Add .claude/ and .kotlin/ to .gitignore
- Remove unused .devcontainer configuration
- Update JitPack JDK from 17.0.3-tem to 25-tem
- Centralize hardcoded versions in maven-central-publish-plugin to root version catalog via versionCatalogs sharing
- Move asciidoctorj-diagram version to version catalog
- Add spacing between version definitions in libs.versions.toml to reduce Dependabot PR conflicts
- Update CI code-analysis job from ubuntu-22.04 to ubuntu-24.04