### PR TITLE
Add Large Blob Storage extension (largeBlob) support

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
@@ -25,6 +25,7 @@ import com.webauthn4j.data.attestation.statement.*;
 import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.data.client.challenge.Challenge;
 import com.webauthn4j.data.extension.CredentialProtectionPolicy;
+import com.webauthn4j.data.extension.LargeBlobSupport;
 import com.webauthn4j.data.extension.client.*;
 import com.webauthn4j.data.jws.JWAIdentifier;
 import com.webauthn4j.data.jws.JWSHeader;
@@ -49,6 +50,7 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(AuthenticationAlgorithm.class, new AuthenticationAlgorithmFromIntDeserializer());
         this.addDeserializer(Challenge.class, new ChallengeDeserializer());
         this.addDeserializer(CredentialProtectionPolicy.class, new CredentialProtectionPolicyDeserializer());
+        this.addDeserializer(LargeBlobSupport.class, new LargeBlobSupportDeserializer());
         this.addDeserializer(JWSHeader.class, new JWSHeaderDeserializer());
         this.addDeserializer(KeyProtectionType.class, new KeyProtectionTypeFromIntDeserializer());
         this.addDeserializer(MatcherProtectionType.class, new MatcherProtectionTypeFromIntDeserializer());
@@ -87,6 +89,7 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(CredentialProtectionExtensionClientInput.class, new CredentialProtectionExtensionClientInputDeserializer());
         this.addDeserializer(HMACSecretRegistrationExtensionClientInput.class, new HMACSecretRegistrationExtensionClientInputDeserializer());
         this.addDeserializer(HMACSecretAuthenticationExtensionClientInput.class, new HMACSecretAuthenticationExtensionClientInputDeserializer());
+        this.addDeserializer(LargeBlobExtensionClientInput.class, new LargeBlobExtensionClientInputDeserializer());
 
         // Extension output deserializers
         this.addDeserializer(FIDOAppIDExtensionClientOutput.class, new FIDOAppIDExtensionClientOutputDeserializer());
@@ -95,12 +98,14 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(CredentialPropertiesExtensionClientOutput.class, new CredentialPropertiesExtensionClientOutputDeserializer());
         this.addDeserializer(HMACSecretRegistrationExtensionClientOutput.class, new HMACSecretRegistrationExtensionClientOutputDeserializer());
         this.addDeserializer(HMACSecretAuthenticationExtensionClientOutput.class, new HMACSecretAuthenticationExtensionClientOutputDeserializer());
+        this.addDeserializer(LargeBlobExtensionClientOutput.class, new LargeBlobExtensionClientOutputDeserializer());
 
         this.addSerializer(AttachmentHint.class, new AttachmentHintToLongSerializer());
         this.addSerializer(AuthenticatorAttestationType.class, new AuthenticatorAttestationTypeToIntSerializer());
         this.addSerializer(AuthenticationAlgorithm.class, new AuthenticationAlgorithmToIntSerializer());
         this.addSerializer(new ChallengeSerializer());
         this.addSerializer(new CredentialProtectionPolicySerializer());
+        this.addSerializer(new LargeBlobSupportSerializer());
         this.addSerializer(new JWSHeaderSerializer());
         this.addSerializer(new KeyProtectionTypeToIntSerializer());
         this.addSerializer(new MatcherProtectionTypeToIntSerializer());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobExtensionClientInputDeserializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsLargeBlobInputs;
+import com.webauthn4j.data.extension.client.LargeBlobExtensionClientInput;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.Set;
+
+public class LargeBlobExtensionClientInputDeserializer extends ExtensionClientInputDeserializer<LargeBlobExtensionClientInput> {
+
+    public LargeBlobExtensionClientInputDeserializer() {
+        super(LargeBlobExtensionClientInput.class);
+    }
+
+    @Override
+    public @NotNull Set<String> getKeys() {
+        return Set.of(LargeBlobExtensionClientInput.KEY_LARGE_BLOB);
+    }
+
+    @Override
+    public LargeBlobExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
+        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        JsonNode largeBlobNode = node.get(LargeBlobExtensionClientInput.KEY_LARGE_BLOB);
+        if (largeBlobNode == null || largeBlobNode.isNull() || !largeBlobNode.isObject()) return null;
+        AuthenticationExtensionsLargeBlobInputs inputs = ctxt.readTreeAsValue(largeBlobNode, AuthenticationExtensionsLargeBlobInputs.class);
+        return new LargeBlobExtensionClientInput(inputs);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobExtensionClientOutputDeserializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsLargeBlobOutputs;
+import com.webauthn4j.data.extension.client.LargeBlobExtensionClientOutput;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.Set;
+
+public class LargeBlobExtensionClientOutputDeserializer extends ExtensionClientOutputDeserializer<LargeBlobExtensionClientOutput> {
+
+    public LargeBlobExtensionClientOutputDeserializer() {
+        super(LargeBlobExtensionClientOutput.class);
+    }
+
+    @Override
+    public @NotNull Set<String> getKeys() {
+        return Set.of(LargeBlobExtensionClientOutput.KEY_LARGE_BLOB);
+    }
+
+    @Override
+    public LargeBlobExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) {
+        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        JsonNode largeBlobNode = node.get(LargeBlobExtensionClientOutput.KEY_LARGE_BLOB);
+        if (largeBlobNode == null || largeBlobNode.isNull() || !largeBlobNode.isObject()) return null;
+        AuthenticationExtensionsLargeBlobOutputs outputs = ctxt.readTreeAsValue(largeBlobNode, AuthenticationExtensionsLargeBlobOutputs.class);
+        return new LargeBlobExtensionClientOutput(outputs);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobSupportDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobSupportDeserializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.webauthn4j.data.extension.LargeBlobSupport;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.exc.InvalidFormatException;
+
+public class LargeBlobSupportDeserializer extends StdDeserializer<LargeBlobSupport> {
+    public LargeBlobSupportDeserializer() {
+        super(LargeBlobSupport.class);
+    }
+
+    @Override
+    public @NotNull LargeBlobSupport deserialize(@NotNull JsonParser p, @NotNull DeserializationContext ctxt) {
+        String value = p.getValueAsString();
+        try {
+            return LargeBlobSupport.create(value);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidFormatException(p, "value is out of range", value, LargeBlobSupport.class);
+        }
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/LargeBlobSupportSerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/LargeBlobSupportSerializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.serializer.json;
+
+import com.webauthn4j.data.extension.LargeBlobSupport;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+public class LargeBlobSupportSerializer extends StdSerializer<LargeBlobSupport> {
+
+    public LargeBlobSupportSerializer() {
+        super(LargeBlobSupport.class);
+    }
+
+    @Override
+    public void serialize(@NotNull LargeBlobSupport value, @NotNull JsonGenerator gen, @NotNull SerializationContext provider) {
+        gen.writeString(value.toString());
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/LargeBlobSupport.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/LargeBlobSupport.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum LargeBlobSupport {
+
+    PREFERRED("preferred"),
+    REQUIRED("required");
+
+    final String string;
+
+    LargeBlobSupport(@NotNull String string) {
+        this.string = string;
+    }
+
+    public static LargeBlobSupport create(@NotNull String string) {
+        switch (string) {
+            case "preferred":
+                return PREFERRED;
+            case "required":
+                return REQUIRED;
+            default:
+                throw new IllegalArgumentException("string '" + string + "' is out of range");
+        }
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return string;
+    }
+
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputs.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputs.java
@@ -47,7 +47,8 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
             CredentialPropertiesExtensionClientInput.class,
             CredentialProtectionExtensionClientInput.class,
             HMACSecretRegistrationExtensionClientInput.class,
-            HMACSecretAuthenticationExtensionClientInput.class
+            HMACSecretAuthenticationExtensionClientInput.class,
+            LargeBlobExtensionClientInput.class
     );
 
     private static final Set<String> KNOWN_KEYS = Set.of(
@@ -58,7 +59,8 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
             CredentialProtectionExtensionClientInput.KEY_CREDENTIAL_PROTECTION_POLICY,
             CredentialProtectionExtensionClientInput.KEY_ENFORCE_CREDENTIAL_PROTECTION_POLICY,
             HMACSecretRegistrationExtensionClientInput.KEY_HMAC_CREATE_SECRET,
-            HMACSecretAuthenticationExtensionClientInput.KEY_HMAC_GET_SECRET
+            HMACSecretAuthenticationExtensionClientInput.KEY_HMAC_GET_SECRET,
+            LargeBlobExtensionClientInput.KEY_LARGE_BLOB
     );
 
     @JsonIgnore
@@ -136,6 +138,8 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
                 return getHMACCreateSecret();
             case HMACSecretAuthenticationExtensionClientInput.KEY_HMAC_GET_SECRET:
                 return getHMACGetSecret();
+            case LargeBlobExtensionClientInput.KEY_LARGE_BLOB:
+                return getLargeBlob();
             default:
                 JsonNode node = rawData.get(key);
                 if (node == null || node.isNull()) return null;
@@ -197,6 +201,14 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
         HMACSecretAuthenticationExtensionClientInput ext = lookupExtension(HMACSecretAuthenticationExtensionClientInput.class);
         return ext != null ? ext.getValue() : null;
     }
+
+    @JsonIgnore
+    public @Nullable AuthenticationExtensionsLargeBlobInputs getLargeBlob() {
+        LargeBlobExtensionClientInput ext = lookupExtension(LargeBlobExtensionClientInput.class);
+        return ext != null ? ext.getValue() : null;
+    }
+
+
 
     @SuppressWarnings("unchecked")
     public @Nullable <E extends T> E getExtension(Class<E> tClass) {
@@ -300,6 +312,11 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
             return this;
         }
 
+        public @NotNull BuilderForRegistration setLargeBlob(@Nullable AuthenticationExtensionsLargeBlobInputs largeBlob) {
+            if (largeBlob != null) values.put("largeBlob", largeBlob);
+            return this;
+        }
+
         public @NotNull BuilderForRegistration set(@NotNull String key, @Nullable Object value) {
             AssertUtil.notNull(key, "key must not be null.");
             AssertUtil.notNull(value, "value must not be null.");
@@ -340,6 +357,11 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
 
         public @NotNull BuilderForAuthentication setHMACGetSecret(@Nullable HMACGetSecretInput hmacGetSecret) {
             if (hmacGetSecret != null) values.put("hmacGetSecret", hmacGetSecret);
+            return this;
+        }
+
+        public @NotNull BuilderForAuthentication setLargeBlob(@Nullable AuthenticationExtensionsLargeBlobInputs largeBlob) {
+            if (largeBlob != null) values.put("largeBlob", largeBlob);
             return this;
         }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputs.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputs.java
@@ -29,7 +29,8 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
             UserVerificationMethodExtensionClientOutput.class,
             CredentialPropertiesExtensionClientOutput.class,
             HMACSecretRegistrationExtensionClientOutput.class,
-            HMACSecretAuthenticationExtensionClientOutput.class
+            HMACSecretAuthenticationExtensionClientOutput.class,
+            LargeBlobExtensionClientOutput.class
     );
 
     private static final Set<String> KNOWN_KEYS = Set.of(
@@ -38,7 +39,8 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
             UserVerificationMethodExtensionClientOutput.KEY_UVM,
             CredentialPropertiesExtensionClientOutput.KEY_CRED_PROPS,
             HMACSecretRegistrationExtensionClientOutput.KEY_HMAC_CREATE_SECRET,
-            HMACSecretAuthenticationExtensionClientOutput.KEY_HMAC_GET_SECRET
+            HMACSecretAuthenticationExtensionClientOutput.KEY_HMAC_GET_SECRET,
+            LargeBlobExtensionClientOutput.KEY_LARGE_BLOB
     );
 
     @JsonIgnore
@@ -111,6 +113,8 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
                 return getHMACCreateSecret();
             case HMACSecretAuthenticationExtensionClientOutput.KEY_HMAC_GET_SECRET:
                 return getHMACGetSecret();
+            case LargeBlobExtensionClientOutput.KEY_LARGE_BLOB:
+                return getLargeBlob();
             default:
                 JsonNode node = rawData.get(key);
                 if (node == null || node.isNull()) return null;
@@ -158,6 +162,14 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
         CredentialPropertiesExtensionClientOutput ext = lookupExtension(CredentialPropertiesExtensionClientOutput.class);
         return ext != null ? ext.getValue() : null;
     }
+
+    @JsonIgnore
+    public @Nullable AuthenticationExtensionsLargeBlobOutputs getLargeBlob() {
+        LargeBlobExtensionClientOutput ext = lookupExtension(LargeBlobExtensionClientOutput.class);
+        return ext != null ? ext.getValue() : null;
+    }
+
+
 
     @SuppressWarnings("unchecked")
     public @Nullable <E extends T> E getExtension(@NotNull Class<E> tClass) {
@@ -253,6 +265,11 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
             return this;
         }
 
+        public @NotNull BuilderForRegistration setLargeBlob(@Nullable AuthenticationExtensionsLargeBlobOutputs largeBlob) {
+            if (largeBlob != null) values.put("largeBlob", largeBlob);
+            return this;
+        }
+
         public @NotNull BuilderForRegistration set(@NotNull String key, @Nullable Object value) {
             AssertUtil.notNull(key, "key must not be null.");
             AssertUtil.notNull(value, "value must not be null.");
@@ -293,6 +310,11 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
 
         public @NotNull BuilderForAuthentication setHMACGetSecret(@Nullable HMACGetSecretOutput hmacGetSecret) {
             if (hmacGetSecret != null) values.put("hmacGetSecret", hmacGetSecret);
+            return this;
+        }
+
+        public @NotNull BuilderForAuthentication setLargeBlob(@Nullable AuthenticationExtensionsLargeBlobOutputs largeBlob) {
+            if (largeBlob != null) values.put("largeBlob", largeBlob);
             return this;
         }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobInputs.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobInputs.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.webauthn4j.data.extension.LargeBlobSupport;
+import com.webauthn4j.util.ArrayUtil;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Data class representing the WebIDL AuthenticationExtensionsLargeBlobInputs dictionary.
+ *
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#dictdef-authenticationextensionslargeblobinputs">
+ * §10.5. Large blob storage extension (largeBlob)</a>
+ */
+public class AuthenticationExtensionsLargeBlobInputs {
+
+    private final LargeBlobSupport support;
+    private final Boolean read;
+    private final byte[] write;
+
+    @JsonCreator
+    public AuthenticationExtensionsLargeBlobInputs(
+            @Nullable @JsonProperty("support") LargeBlobSupport support,
+            @Nullable @JsonProperty("read") Boolean read,
+            @Nullable @JsonProperty("write") byte[] write) {
+        this.support = support;
+        this.read = read;
+        this.write = ArrayUtil.clone(write);
+    }
+
+    public @Nullable LargeBlobSupport getSupport() {
+        return support;
+    }
+
+    public @Nullable Boolean getRead() {
+        return read;
+    }
+
+    public @Nullable byte[] getWrite() {
+        return ArrayUtil.clone(write);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationExtensionsLargeBlobInputs that = (AuthenticationExtensionsLargeBlobInputs) o;
+        return support == that.support && Objects.equals(read, that.read) && Arrays.equals(write, that.write);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(support, read);
+        result = 31 * result + Arrays.hashCode(write);
+        return result;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobOutputs.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobOutputs.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.webauthn4j.util.ArrayUtil;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Data class representing the WebIDL AuthenticationExtensionsLargeBlobOutputs dictionary.
+ *
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#dictdef-authenticationextensionslargebloboutputs">
+ * §10.5. Large blob storage extension (largeBlob)</a>
+ */
+public class AuthenticationExtensionsLargeBlobOutputs {
+
+    private final Boolean supported;
+    private final byte[] blob;
+    private final Boolean written;
+
+    @JsonCreator
+    public AuthenticationExtensionsLargeBlobOutputs(
+            @Nullable @JsonProperty("supported") Boolean supported,
+            @Nullable @JsonProperty("blob") byte[] blob,
+            @Nullable @JsonProperty("written") Boolean written) {
+        this.supported = supported;
+        this.blob = ArrayUtil.clone(blob);
+        this.written = written;
+    }
+
+    public @Nullable Boolean getSupported() {
+        return supported;
+    }
+
+    public @Nullable byte[] getBlob() {
+        return ArrayUtil.clone(blob);
+    }
+
+    public @Nullable Boolean getWritten() {
+        return written;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationExtensionsLargeBlobOutputs that = (AuthenticationExtensionsLargeBlobOutputs) o;
+        return Objects.equals(supported, that.supported) && Arrays.equals(blob, that.blob) && Objects.equals(written, that.written);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(supported, written);
+        result = 31 * result + Arrays.hashCode(blob);
+        return result;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/LargeBlobExtensionClientInput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/LargeBlobExtensionClientInput.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.data.extension.SingleValueExtensionInputBase;
+import com.webauthn4j.verifier.exception.ConstraintViolationException;
+import org.jetbrains.annotations.NotNull;
+
+public class LargeBlobExtensionClientInput
+        extends SingleValueExtensionInputBase<AuthenticationExtensionsLargeBlobInputs>
+        implements RegistrationExtensionClientInput, AuthenticationExtensionClientInput {
+
+    public static final String ID = "largeBlob";
+    public static final String KEY_LARGE_BLOB = "largeBlob";
+
+    public LargeBlobExtensionClientInput(@NotNull AuthenticationExtensionsLargeBlobInputs value) {
+        super(value);
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return ID;
+    }
+
+    @Override
+    public @NotNull AuthenticationExtensionsLargeBlobInputs getValue(@NotNull String key) {
+        if (!key.equals(KEY_LARGE_BLOB)) {
+            throw new IllegalArgumentException(String.format("%s is the only valid key.", KEY_LARGE_BLOB));
+        }
+        return getValue();
+    }
+
+    @SuppressWarnings({"ConstantConditions", "java:S2583"})
+    @Override
+    public void validate() {
+        if (getValue() == null) {
+            throw new ConstraintViolationException("value must not be null");
+        }
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/LargeBlobExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/LargeBlobExtensionClientOutput.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.data.extension.SingleValueExtensionOutputBase;
+import com.webauthn4j.verifier.exception.ConstraintViolationException;
+import org.jetbrains.annotations.NotNull;
+
+public class LargeBlobExtensionClientOutput
+        extends SingleValueExtensionOutputBase<AuthenticationExtensionsLargeBlobOutputs>
+        implements RegistrationExtensionClientOutput, AuthenticationExtensionClientOutput {
+
+    public static final String ID = "largeBlob";
+    public static final String KEY_LARGE_BLOB = "largeBlob";
+
+    public LargeBlobExtensionClientOutput(@NotNull AuthenticationExtensionsLargeBlobOutputs value) {
+        super(value);
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return ID;
+    }
+
+    @Override
+    public @NotNull AuthenticationExtensionsLargeBlobOutputs getValue(@NotNull String key) {
+        if (!key.equals(KEY_LARGE_BLOB)) {
+            throw new IllegalArgumentException(String.format("%s is the only valid key.", KEY_LARGE_BLOB));
+        }
+        return getValue();
+    }
+
+    @SuppressWarnings({"ConstantConditions", "java:S2583"})
+    @Override
+    public void validate() {
+        if (getValue() == null) {
+            throw new ConstraintViolationException("value must not be null");
+        }
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticationExtensionsClientInputsDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticationExtensionsClientInputsDeserializerTest.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.converter.jackson.deserializer.json;
 
 import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.extension.LargeBlobSupport;
 import com.webauthn4j.data.extension.client.*;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.exc.StreamReadException;
@@ -75,6 +76,63 @@ class AuthenticationExtensionsClientInputsDeserializerTest {
         //Then
         assertAll(
                 () -> assertThat(extensionInputs.getExtension(FIDOAppIDExtensionClientInput.class).getValue()).isEqualTo("dummy")
+        );
+    }
+
+    @Test
+    void shouldDeserializeLargeBlobRegistrationInput() {
+        //Given
+        String json = "{ \"largeBlob\": { \"support\": \"preferred\" } }";
+
+        //When
+        AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput> extensionInputs =
+                jsonMapper.readValue(
+                        json,
+                        new TypeReference<AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput>>() {
+                        }
+                );
+
+        //Then
+        assertAll(
+                () -> assertThat(extensionInputs.getExtension(LargeBlobExtensionClientInput.class).getValue().getSupport()).isEqualTo(LargeBlobSupport.PREFERRED)
+        );
+    }
+
+    @Test
+    void shouldDeserializeLargeBlobAuthenticationReadInput() {
+        //Given
+        String json = "{ \"largeBlob\": { \"read\": true } }";
+
+        //When
+        AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> extensionInputs =
+                jsonMapper.readValue(
+                        json,
+                        new TypeReference<AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput>>() {
+                        }
+                );
+
+        //Then
+        assertAll(
+                () -> assertThat(extensionInputs.getExtension(LargeBlobExtensionClientInput.class).getValue().getRead()).isTrue()
+        );
+    }
+
+    @Test
+    void shouldDeserializeLargeBlobAuthenticationWriteInput() {
+        //Given
+        String json = "{ \"largeBlob\": { \"write\": \"AQID\" } }";
+
+        //When
+        AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> extensionInputs =
+                jsonMapper.readValue(
+                        json,
+                        new TypeReference<AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput>>() {
+                        }
+                );
+
+        //Then
+        assertAll(
+                () -> assertThat(extensionInputs.getExtension(LargeBlobExtensionClientInput.class).getValue().getWrite()).isEqualTo(new byte[]{1, 2, 3})
         );
     }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/LargeBlobSupportTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/LargeBlobSupportTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LargeBlobSupportTest {
+
+    @Test
+    void create_from_preferred_string() {
+        assertThat(LargeBlobSupport.create("preferred")).isEqualTo(LargeBlobSupport.PREFERRED);
+    }
+
+    @Test
+    void create_from_required_string() {
+        assertThat(LargeBlobSupport.create("required")).isEqualTo(LargeBlobSupport.REQUIRED);
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void create_from_invalid_string_throws() {
+        assertThatThrownBy(() -> LargeBlobSupport.create("invalid")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void toString_returns_string_value() {
+        assertThat(LargeBlobSupport.PREFERRED).hasToString("preferred");
+        assertThat(LargeBlobSupport.REQUIRED).hasToString("required");
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputsTest.java
@@ -19,6 +19,7 @@ package com.webauthn4j.data.extension.client;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.extension.CredentialProtectionPolicy;
 import com.webauthn4j.data.extension.HMACGetSecretInput;
+import com.webauthn4j.data.extension.LargeBlobSupport;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
@@ -132,6 +133,36 @@ class AuthenticationExtensionsClientInputsTest {
         assertThatThrownBy(()->hmacSecretAuthenticationExtensionClientInput.getValue("hmacCreateSecret")).isInstanceOf(IllegalArgumentException.class);
         assertThat(hmacSecretAuthenticationExtensionClientInput.getValue("hmacGetSecret")).isEqualTo(new HMACGetSecretInput(new byte[32], new byte[32]));
 
+    }
+
+    @Test
+    void registration_largeBlob_test() {
+        AuthenticationExtensionsClientInputs.BuilderForRegistration builder = new AuthenticationExtensionsClientInputs.BuilderForRegistration();
+        builder.setLargeBlob(new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.REQUIRED, null, null));
+        AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput> target = builder.build();
+
+        assertThat(target.getLargeBlob()).isNotNull();
+        assertThat(target.getLargeBlob().getSupport()).isEqualTo(LargeBlobSupport.REQUIRED);
+    }
+
+    @Test
+    void authentication_largeBlob_read_test() {
+        AuthenticationExtensionsClientInputs.BuilderForAuthentication builder = new AuthenticationExtensionsClientInputs.BuilderForAuthentication();
+        builder.setLargeBlob(new AuthenticationExtensionsLargeBlobInputs(null, true, null));
+        AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> target = builder.build();
+
+        assertThat(target.getLargeBlob()).isNotNull();
+        assertThat(target.getLargeBlob().getRead()).isTrue();
+    }
+
+    @Test
+    void authentication_largeBlob_write_test() {
+        AuthenticationExtensionsClientInputs.BuilderForAuthentication builder = new AuthenticationExtensionsClientInputs.BuilderForAuthentication();
+        builder.setLargeBlob(new AuthenticationExtensionsLargeBlobInputs(null, null, new byte[]{1, 2, 3}));
+        AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> target = builder.build();
+
+        assertThat(target.getLargeBlob()).isNotNull();
+        assertThat(target.getLargeBlob().getWrite()).isEqualTo(new byte[]{1, 2, 3});
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputsTest.java
@@ -23,6 +23,7 @@ import com.webauthn4j.data.extension.HMACGetSecretOutput;
 import com.webauthn4j.data.extension.UvmEntries;
 import com.webauthn4j.data.extension.UvmEntry;
 import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,6 +124,36 @@ class AuthenticationExtensionsClientOutputsTest {
         assertThatThrownBy(()->hmacSecretAuthenticationExtensionClientOutput.getValue("hmac-secret")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(()->hmacSecretAuthenticationExtensionClientOutput.getValue("hmacCreateSecret")).isInstanceOf(IllegalArgumentException.class);
         assertThat(hmacSecretAuthenticationExtensionClientOutput.getValue("hmacGetSecret")).isEqualTo(new HMACGetSecretOutput(new byte[32], new byte[32]));
+    }
+
+    @Test
+    void registration_largeBlob_test() {
+        AuthenticationExtensionsClientOutputs.BuilderForRegistration builder = new AuthenticationExtensionsClientOutputs.BuilderForRegistration();
+        builder.setLargeBlob(new AuthenticationExtensionsLargeBlobOutputs(true, null, null));
+        AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> target = builder.build();
+
+        assertThat(target.getLargeBlob()).isNotNull();
+        assertThat(target.getLargeBlob().getSupported()).isTrue();
+    }
+
+    @Test
+    void authentication_largeBlob_blob_test() {
+        AuthenticationExtensionsClientOutputs.BuilderForAuthentication builder = new AuthenticationExtensionsClientOutputs.BuilderForAuthentication();
+        builder.setLargeBlob(new AuthenticationExtensionsLargeBlobOutputs(null, new byte[]{1, 2, 3}, null));
+        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> target = builder.build();
+
+        assertThat(target.getLargeBlob()).isNotNull();
+        assertThat(target.getLargeBlob().getBlob()).isEqualTo(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    void authentication_largeBlob_written_test() {
+        AuthenticationExtensionsClientOutputs.BuilderForAuthentication builder = new AuthenticationExtensionsClientOutputs.BuilderForAuthentication();
+        builder.setLargeBlob(new AuthenticationExtensionsLargeBlobOutputs(null, null, true));
+        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> target = builder.build();
+
+        assertThat(target.getLargeBlob()).isNotNull();
+        assertThat(target.getLargeBlob().getWritten()).isTrue();
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobInputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobInputsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.extension.LargeBlobSupport;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthenticationExtensionsLargeBlobInputsTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void constructor_with_support() {
+        AuthenticationExtensionsLargeBlobInputs target = new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.PREFERRED, null, null);
+        assertThat(target.getSupport()).isEqualTo(LargeBlobSupport.PREFERRED);
+        assertThat(target.getRead()).isNull();
+        assertThat(target.getWrite()).isNull();
+    }
+
+    @Test
+    void constructor_with_read() {
+        AuthenticationExtensionsLargeBlobInputs target = new AuthenticationExtensionsLargeBlobInputs(null, true, null);
+        assertThat(target.getSupport()).isNull();
+        assertThat(target.getRead()).isTrue();
+        assertThat(target.getWrite()).isNull();
+    }
+
+    @Test
+    void constructor_with_write() {
+        AuthenticationExtensionsLargeBlobInputs target = new AuthenticationExtensionsLargeBlobInputs(null, null, new byte[]{1, 2, 3});
+        assertThat(target.getSupport()).isNull();
+        assertThat(target.getRead()).isNull();
+        assertThat(target.getWrite()).isEqualTo(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    void write_is_defensively_copied() {
+        byte[] original = {1, 2, 3};
+        AuthenticationExtensionsLargeBlobInputs target = new AuthenticationExtensionsLargeBlobInputs(null, null, original);
+        original[0] = 99;
+        assertThat(target.getWrite()).isEqualTo(new byte[]{1, 2, 3});
+
+        byte[] retrieved = target.getWrite();
+        retrieved[0] = 99;
+        assertThat(target.getWrite()).isEqualTo(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    void equals_and_hashCode() {
+        AuthenticationExtensionsLargeBlobInputs a = new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.REQUIRED, null, null);
+        AuthenticationExtensionsLargeBlobInputs b = new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.REQUIRED, null, null);
+        AuthenticationExtensionsLargeBlobInputs c = new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.PREFERRED, null, null);
+
+        assertThat(a).isEqualTo(b).isNotEqualTo(c).isNotEqualTo(null);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void deserialization_with_support() {
+        String json = "{\"support\":\"required\"}";
+        AuthenticationExtensionsLargeBlobInputs result = jsonMapper.readValue(json, AuthenticationExtensionsLargeBlobInputs.class);
+        assertThat(result.getSupport()).isEqualTo(LargeBlobSupport.REQUIRED);
+        assertThat(result.getRead()).isNull();
+        assertThat(result.getWrite()).isNull();
+    }
+
+    @Test
+    void deserialization_with_read() {
+        String json = "{\"read\":true}";
+        AuthenticationExtensionsLargeBlobInputs result = jsonMapper.readValue(json, AuthenticationExtensionsLargeBlobInputs.class);
+        assertThat(result.getSupport()).isNull();
+        assertThat(result.getRead()).isTrue();
+    }
+
+    @Test
+    void deserialization_with_write() {
+        String json = "{\"write\":\"AQID\"}";
+        AuthenticationExtensionsLargeBlobInputs result = jsonMapper.readValue(json, AuthenticationExtensionsLargeBlobInputs.class);
+        assertThat(result.getWrite()).isEqualTo(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    void serialization_round_trip_with_support() {
+        AuthenticationExtensionsLargeBlobInputs original = new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.PREFERRED, null, null);
+        String json = jsonMapper.writeValueAsString(original);
+        AuthenticationExtensionsLargeBlobInputs restored = jsonMapper.readValue(json, AuthenticationExtensionsLargeBlobInputs.class);
+        assertThat(restored).isEqualTo(original);
+    }
+
+    @Test
+    void serialization_round_trip_with_write() {
+        AuthenticationExtensionsLargeBlobInputs original = new AuthenticationExtensionsLargeBlobInputs(null, null, new byte[]{4, 5, 6});
+        String json = jsonMapper.writeValueAsString(original);
+        AuthenticationExtensionsLargeBlobInputs restored = jsonMapper.readValue(json, AuthenticationExtensionsLargeBlobInputs.class);
+        assertThat(restored).isEqualTo(original);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobOutputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobOutputsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthenticationExtensionsLargeBlobOutputsTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void constructor_with_supported() {
+        AuthenticationExtensionsLargeBlobOutputs target = new AuthenticationExtensionsLargeBlobOutputs(true, null, null);
+        assertThat(target.getSupported()).isTrue();
+        assertThat(target.getBlob()).isNull();
+        assertThat(target.getWritten()).isNull();
+    }
+
+    @Test
+    void constructor_with_blob() {
+        AuthenticationExtensionsLargeBlobOutputs target = new AuthenticationExtensionsLargeBlobOutputs(null, new byte[]{1, 2, 3}, null);
+        assertThat(target.getSupported()).isNull();
+        assertThat(target.getBlob()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(target.getWritten()).isNull();
+    }
+
+    @Test
+    void constructor_with_written() {
+        AuthenticationExtensionsLargeBlobOutputs target = new AuthenticationExtensionsLargeBlobOutputs(null, null, true);
+        assertThat(target.getSupported()).isNull();
+        assertThat(target.getBlob()).isNull();
+        assertThat(target.getWritten()).isTrue();
+    }
+
+    @Test
+    void blob_is_defensively_copied() {
+        byte[] original = {1, 2, 3};
+        AuthenticationExtensionsLargeBlobOutputs target = new AuthenticationExtensionsLargeBlobOutputs(null, original, null);
+        original[0] = 99;
+        assertThat(target.getBlob()).isEqualTo(new byte[]{1, 2, 3});
+
+        byte[] retrieved = target.getBlob();
+        retrieved[0] = 99;
+        assertThat(target.getBlob()).isEqualTo(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    void equals_and_hashCode() {
+        AuthenticationExtensionsLargeBlobOutputs a = new AuthenticationExtensionsLargeBlobOutputs(true, null, null);
+        AuthenticationExtensionsLargeBlobOutputs b = new AuthenticationExtensionsLargeBlobOutputs(true, null, null);
+        AuthenticationExtensionsLargeBlobOutputs c = new AuthenticationExtensionsLargeBlobOutputs(false, null, null);
+        AuthenticationExtensionsLargeBlobOutputs d = new AuthenticationExtensionsLargeBlobOutputs(null, new byte[]{1}, null);
+
+        assertThat(a).isEqualTo(b).isNotEqualTo(c).isNotEqualTo(d).isNotEqualTo(null);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void deserialization_with_supported() {
+        String json = "{\"supported\":true}";
+        AuthenticationExtensionsLargeBlobOutputs result = jsonMapper.readValue(json, AuthenticationExtensionsLargeBlobOutputs.class);
+        assertThat(result.getSupported()).isTrue();
+    }
+
+    @Test
+    void deserialization_with_blob() {
+        String json = "{\"blob\":\"AQID\"}";
+        AuthenticationExtensionsLargeBlobOutputs result = jsonMapper.readValue(json, AuthenticationExtensionsLargeBlobOutputs.class);
+        assertThat(result.getBlob()).isEqualTo(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    void deserialization_with_written() {
+        String json = "{\"written\":false}";
+        AuthenticationExtensionsLargeBlobOutputs result = jsonMapper.readValue(json, AuthenticationExtensionsLargeBlobOutputs.class);
+        assertThat(result.getWritten()).isFalse();
+    }
+
+    @Test
+    void serialization_round_trip_with_blob() {
+        AuthenticationExtensionsLargeBlobOutputs original = new AuthenticationExtensionsLargeBlobOutputs(null, new byte[]{7, 8, 9}, null);
+        String json = jsonMapper.writeValueAsString(original);
+        AuthenticationExtensionsLargeBlobOutputs restored = jsonMapper.readValue(json, AuthenticationExtensionsLargeBlobOutputs.class);
+        assertThat(restored).isEqualTo(original);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/LargeBlobExtensionClientInputTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/LargeBlobExtensionClientInputTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.data.extension.LargeBlobSupport;
+import com.webauthn4j.verifier.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class LargeBlobExtensionClientInputTest {
+
+    @Test
+    void validate_with_valid_value() {
+        assertThatCode(new LargeBlobExtensionClientInput(new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.PREFERRED, null, null))::validate).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_with_null_value() {
+        assertThatThrownBy(new LargeBlobExtensionClientInput(null)::validate).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void getIdentifier_returns_largeBlob() {
+        LargeBlobExtensionClientInput target = new LargeBlobExtensionClientInput(new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.PREFERRED, null, null));
+        assertThat(target.getIdentifier()).isEqualTo("largeBlob");
+    }
+
+    @Test
+    void getValue_with_valid_key() {
+        AuthenticationExtensionsLargeBlobInputs inputs = new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.REQUIRED, null, null);
+        LargeBlobExtensionClientInput target = new LargeBlobExtensionClientInput(inputs);
+        assertThat(target.getValue("largeBlob")).isSameAs(inputs);
+    }
+
+    @Test
+    void getValue_with_invalid_key() {
+        LargeBlobExtensionClientInput target = new LargeBlobExtensionClientInput(new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.PREFERRED, null, null));
+        assertThatThrownBy(() -> target.getValue("invalid")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/LargeBlobExtensionClientOutputTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/LargeBlobExtensionClientOutputTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.verifier.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class LargeBlobExtensionClientOutputTest {
+
+    @Test
+    void validate_with_valid_value() {
+        assertThatCode(new LargeBlobExtensionClientOutput(new AuthenticationExtensionsLargeBlobOutputs(true, null, null))::validate).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_with_null_value() {
+        assertThatThrownBy(new LargeBlobExtensionClientOutput(null)::validate).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void getIdentifier_returns_largeBlob() {
+        LargeBlobExtensionClientOutput target = new LargeBlobExtensionClientOutput(new AuthenticationExtensionsLargeBlobOutputs(true, null, null));
+        assertThat(target.getIdentifier()).isEqualTo("largeBlob");
+    }
+
+    @Test
+    void getValue_with_valid_key() {
+        AuthenticationExtensionsLargeBlobOutputs outputs = new AuthenticationExtensionsLargeBlobOutputs(true, null, null);
+        LargeBlobExtensionClientOutput target = new LargeBlobExtensionClientOutput(outputs);
+        assertThat(target.getValue("largeBlob")).isSameAs(outputs);
+    }
+
+    @Test
+    void getValue_with_invalid_key() {
+        LargeBlobExtensionClientOutput target = new LargeBlobExtensionClientOutput(new AuthenticationExtensionsLargeBlobOutputs(true, null, null));
+        assertThatThrownBy(() -> target.getValue("invalid")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+}


### PR DESCRIPTION
Add client extension input/output classes, JSON deserializers, and container integration for the WebAuthn Level 3 largeBlob extension, enabling parsing and serialization of largeBlob extension data for both registration and authentication ceremonies.

Closes #1303