### PR TITLE
Add Pseudo-random function extension (prf) support

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
@@ -90,6 +90,7 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(HMACSecretRegistrationExtensionClientInput.class, new HMACSecretRegistrationExtensionClientInputDeserializer());
         this.addDeserializer(HMACSecretAuthenticationExtensionClientInput.class, new HMACSecretAuthenticationExtensionClientInputDeserializer());
         this.addDeserializer(LargeBlobExtensionClientInput.class, new LargeBlobExtensionClientInputDeserializer());
+        this.addDeserializer(PRFExtensionClientInput.class, new PRFExtensionClientInputDeserializer());
 
         // Extension output deserializers
         this.addDeserializer(FIDOAppIDExtensionClientOutput.class, new FIDOAppIDExtensionClientOutputDeserializer());
@@ -99,6 +100,7 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(HMACSecretRegistrationExtensionClientOutput.class, new HMACSecretRegistrationExtensionClientOutputDeserializer());
         this.addDeserializer(HMACSecretAuthenticationExtensionClientOutput.class, new HMACSecretAuthenticationExtensionClientOutputDeserializer());
         this.addDeserializer(LargeBlobExtensionClientOutput.class, new LargeBlobExtensionClientOutputDeserializer());
+        this.addDeserializer(PRFExtensionClientOutput.class, new PRFExtensionClientOutputDeserializer());
 
         this.addSerializer(AttachmentHint.class, new AttachmentHintToLongSerializer());
         this.addSerializer(AuthenticatorAttestationType.class, new AuthenticatorAttestationTypeToIntSerializer());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
@@ -91,6 +91,7 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(HMACSecretRegistrationExtensionClientInput.class, new HMACSecretRegistrationExtensionClientInputDeserializer());
         this.addDeserializer(HMACSecretAuthenticationExtensionClientInput.class, new HMACSecretAuthenticationExtensionClientInputDeserializer());
         this.addDeserializer(LargeBlobExtensionClientInput.class, new LargeBlobExtensionClientInputDeserializer());
+        this.addDeserializer(PRFExtensionClientInput.class, new PRFExtensionClientInputDeserializer());
 
         // Extension output deserializers
         this.addDeserializer(FIDOAppIDExtensionClientOutput.class, new FIDOAppIDExtensionClientOutputDeserializer());
@@ -100,6 +101,7 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(HMACSecretRegistrationExtensionClientOutput.class, new HMACSecretRegistrationExtensionClientOutputDeserializer());
         this.addDeserializer(HMACSecretAuthenticationExtensionClientOutput.class, new HMACSecretAuthenticationExtensionClientOutputDeserializer());
         this.addDeserializer(LargeBlobExtensionClientOutput.class, new LargeBlobExtensionClientOutputDeserializer());
+        this.addDeserializer(PRFExtensionClientOutput.class, new PRFExtensionClientOutputDeserializer());
 
         this.addSerializer(AttachmentHint.class, new AttachmentHintToLongSerializer());
         this.addSerializer(AuthenticatorAttestationType.class, new AuthenticatorAttestationTypeToIntSerializer());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/PRFExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/PRFExtensionClientInputDeserializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsPRFInputs;
+import com.webauthn4j.data.extension.client.PRFExtensionClientInput;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.Set;
+
+public class PRFExtensionClientInputDeserializer extends ExtensionClientInputDeserializer<PRFExtensionClientInput> {
+
+    public PRFExtensionClientInputDeserializer() {
+        super(PRFExtensionClientInput.class);
+    }
+
+    @Override
+    public @NotNull Set<String> getKeys() {
+        return Set.of(PRFExtensionClientInput.KEY_PRF);
+    }
+
+    @Override
+    public PRFExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
+        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        JsonNode prfNode = node.get(PRFExtensionClientInput.KEY_PRF);
+        if (prfNode == null || prfNode.isNull() || !prfNode.isObject()) return null;
+        AuthenticationExtensionsPRFInputs inputs = ctxt.readTreeAsValue(prfNode, AuthenticationExtensionsPRFInputs.class);
+        return new PRFExtensionClientInput(inputs);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/PRFExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/PRFExtensionClientOutputDeserializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsPRFOutputs;
+import com.webauthn4j.data.extension.client.PRFExtensionClientOutput;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.Set;
+
+public class PRFExtensionClientOutputDeserializer extends ExtensionClientOutputDeserializer<PRFExtensionClientOutput> {
+
+    public PRFExtensionClientOutputDeserializer() {
+        super(PRFExtensionClientOutput.class);
+    }
+
+    @Override
+    public @NotNull Set<String> getKeys() {
+        return Set.of(PRFExtensionClientOutput.KEY_PRF);
+    }
+
+    @Override
+    public PRFExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) {
+        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        JsonNode prfNode = node.get(PRFExtensionClientOutput.KEY_PRF);
+        if (prfNode == null || prfNode.isNull() || !prfNode.isObject()) return null;
+        AuthenticationExtensionsPRFOutputs outputs = ctxt.readTreeAsValue(prfNode, AuthenticationExtensionsPRFOutputs.class);
+        return new PRFExtensionClientOutput(outputs);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputs.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputs.java
@@ -48,7 +48,8 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
             CredentialProtectionExtensionClientInput.class,
             HMACSecretRegistrationExtensionClientInput.class,
             HMACSecretAuthenticationExtensionClientInput.class,
-            LargeBlobExtensionClientInput.class
+            LargeBlobExtensionClientInput.class,
+            PRFExtensionClientInput.class
     );
 
     private static final Set<String> KNOWN_KEYS = Set.of(
@@ -60,7 +61,8 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
             CredentialProtectionExtensionClientInput.KEY_ENFORCE_CREDENTIAL_PROTECTION_POLICY,
             HMACSecretRegistrationExtensionClientInput.KEY_HMAC_CREATE_SECRET,
             HMACSecretAuthenticationExtensionClientInput.KEY_HMAC_GET_SECRET,
-            LargeBlobExtensionClientInput.KEY_LARGE_BLOB
+            LargeBlobExtensionClientInput.KEY_LARGE_BLOB,
+            PRFExtensionClientInput.KEY_PRF
     );
 
     @JsonIgnore
@@ -140,6 +142,8 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
                 return getHMACGetSecret();
             case LargeBlobExtensionClientInput.KEY_LARGE_BLOB:
                 return getLargeBlob();
+            case PRFExtensionClientInput.KEY_PRF:
+                return getPrf();
             default:
                 JsonNode node = rawData.get(key);
                 if (node == null || node.isNull()) return null;
@@ -208,6 +212,11 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
         return ext != null ? ext.getValue() : null;
     }
 
+    @JsonIgnore
+    public @Nullable AuthenticationExtensionsPRFInputs getPrf() {
+        PRFExtensionClientInput ext = lookupExtension(PRFExtensionClientInput.class);
+        return ext != null ? ext.getValue() : null;
+    }
 
 
     @SuppressWarnings("unchecked")
@@ -317,6 +326,11 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
             return this;
         }
 
+        public @NotNull BuilderForRegistration setPrf(@Nullable AuthenticationExtensionsPRFInputs prf) {
+            if (prf != null) values.put("prf", prf);
+            return this;
+        }
+
         public @NotNull BuilderForRegistration set(@NotNull String key, @Nullable Object value) {
             AssertUtil.notNull(key, "key must not be null.");
             AssertUtil.notNull(value, "value must not be null.");
@@ -362,6 +376,11 @@ public class AuthenticationExtensionsClientInputs<T extends ExtensionClientInput
 
         public @NotNull BuilderForAuthentication setLargeBlob(@Nullable AuthenticationExtensionsLargeBlobInputs largeBlob) {
             if (largeBlob != null) values.put("largeBlob", largeBlob);
+            return this;
+        }
+
+        public @NotNull BuilderForAuthentication setPrf(@Nullable AuthenticationExtensionsPRFInputs prf) {
+            if (prf != null) values.put("prf", prf);
             return this;
         }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputs.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputs.java
@@ -30,7 +30,8 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
             CredentialPropertiesExtensionClientOutput.class,
             HMACSecretRegistrationExtensionClientOutput.class,
             HMACSecretAuthenticationExtensionClientOutput.class,
-            LargeBlobExtensionClientOutput.class
+            LargeBlobExtensionClientOutput.class,
+            PRFExtensionClientOutput.class
     );
 
     private static final Set<String> KNOWN_KEYS = Set.of(
@@ -40,7 +41,8 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
             CredentialPropertiesExtensionClientOutput.KEY_CRED_PROPS,
             HMACSecretRegistrationExtensionClientOutput.KEY_HMAC_CREATE_SECRET,
             HMACSecretAuthenticationExtensionClientOutput.KEY_HMAC_GET_SECRET,
-            LargeBlobExtensionClientOutput.KEY_LARGE_BLOB
+            LargeBlobExtensionClientOutput.KEY_LARGE_BLOB,
+            PRFExtensionClientOutput.KEY_PRF
     );
 
     @JsonIgnore
@@ -115,6 +117,8 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
                 return getHMACGetSecret();
             case LargeBlobExtensionClientOutput.KEY_LARGE_BLOB:
                 return getLargeBlob();
+            case PRFExtensionClientOutput.KEY_PRF:
+                return getPrf();
             default:
                 JsonNode node = rawData.get(key);
                 if (node == null || node.isNull()) return null;
@@ -169,6 +173,11 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
         return ext != null ? ext.getValue() : null;
     }
 
+    @JsonIgnore
+    public @Nullable AuthenticationExtensionsPRFOutputs getPrf() {
+        PRFExtensionClientOutput ext = lookupExtension(PRFExtensionClientOutput.class);
+        return ext != null ? ext.getValue() : null;
+    }
 
 
     @SuppressWarnings("unchecked")
@@ -270,6 +279,11 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
             return this;
         }
 
+        public @NotNull BuilderForRegistration setPrf(@Nullable AuthenticationExtensionsPRFOutputs prf) {
+            if (prf != null) values.put("prf", prf);
+            return this;
+        }
+
         public @NotNull BuilderForRegistration set(@NotNull String key, @Nullable Object value) {
             AssertUtil.notNull(key, "key must not be null.");
             AssertUtil.notNull(value, "value must not be null.");
@@ -315,6 +329,11 @@ public class AuthenticationExtensionsClientOutputs<T extends ExtensionClientOutp
 
         public @NotNull BuilderForAuthentication setLargeBlob(@Nullable AuthenticationExtensionsLargeBlobOutputs largeBlob) {
             if (largeBlob != null) values.put("largeBlob", largeBlob);
+            return this;
+        }
+
+        public @NotNull BuilderForAuthentication setPrf(@Nullable AuthenticationExtensionsPRFOutputs prf) {
+            if (prf != null) values.put("prf", prf);
             return this;
         }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFInputs.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFInputs.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#dictdef-authenticationextensionsprfinputs">
+ * §10.1.4. Pseudo-random function extension (prf)</a>
+ */
+public class AuthenticationExtensionsPRFInputs {
+
+    private final AuthenticationExtensionsPRFValues eval;
+    private final Map<String, AuthenticationExtensionsPRFValues> evalByCredential;
+
+    @JsonCreator
+    public AuthenticationExtensionsPRFInputs(
+            @Nullable @JsonProperty("eval") AuthenticationExtensionsPRFValues eval,
+            @Nullable @JsonProperty("evalByCredential") Map<String, AuthenticationExtensionsPRFValues> evalByCredential) {
+        this.eval = eval;
+        this.evalByCredential = evalByCredential == null ? null : Collections.unmodifiableMap(new LinkedHashMap<>(evalByCredential));
+    }
+
+    public @Nullable AuthenticationExtensionsPRFValues getEval() {
+        return eval;
+    }
+
+    public @Nullable Map<String, AuthenticationExtensionsPRFValues> getEvalByCredential() {
+        return evalByCredential;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationExtensionsPRFInputs that = (AuthenticationExtensionsPRFInputs) o;
+        return Objects.equals(eval, that.eval) && Objects.equals(evalByCredential, that.evalByCredential);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eval, evalByCredential);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFOutputs.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFOutputs.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#dictdef-authenticationextensionsprfoutputs">
+ * §10.1.4. Pseudo-random function extension (prf)</a>
+ */
+public class AuthenticationExtensionsPRFOutputs {
+
+    private final Boolean enabled;
+    private final AuthenticationExtensionsPRFValues results;
+
+    @JsonCreator
+    public AuthenticationExtensionsPRFOutputs(
+            @Nullable @JsonProperty("enabled") Boolean enabled,
+            @Nullable @JsonProperty("results") AuthenticationExtensionsPRFValues results) {
+        this.enabled = enabled;
+        this.results = results;
+    }
+
+    public @Nullable Boolean getEnabled() {
+        return enabled;
+    }
+
+    public @Nullable AuthenticationExtensionsPRFValues getResults() {
+        return results;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationExtensionsPRFOutputs that = (AuthenticationExtensionsPRFOutputs) o;
+        return Objects.equals(enabled, that.enabled) && Objects.equals(results, that.results);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, results);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFValues.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFValues.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.webauthn4j.util.ArrayUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#dictdef-authenticationextensionsprfvalues">
+ * §10.1.4. Pseudo-random function extension (prf)</a>
+ */
+public class AuthenticationExtensionsPRFValues {
+
+    private final byte[] first;
+    private final byte[] second;
+
+    @JsonCreator
+    public AuthenticationExtensionsPRFValues(
+            @NotNull @JsonProperty("first") byte[] first,
+            @Nullable @JsonProperty("second") byte[] second) {
+        this.first = ArrayUtil.clone(first);
+        this.second = ArrayUtil.clone(second);
+    }
+
+    public @NotNull byte[] getFirst() {
+        return ArrayUtil.clone(first);
+    }
+
+    public @Nullable byte[] getSecond() {
+        return ArrayUtil.clone(second);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationExtensionsPRFValues that = (AuthenticationExtensionsPRFValues) o;
+        return Arrays.equals(first, that.first) && Arrays.equals(second, that.second);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(first);
+        result = 31 * result + Arrays.hashCode(second);
+        return result;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFValues.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFValues.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.webauthn4j.util.ArrayUtil;
+import com.webauthn4j.util.AssertUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#dictdef-authenticationextensionsprfvalues">
+ * §10.1.4. Pseudo-random function extension (prf)</a>
+ */
+public class AuthenticationExtensionsPRFValues {
+
+    private final byte[] first;
+    private final byte[] second;
+
+    @JsonCreator
+    public AuthenticationExtensionsPRFValues(
+            @NotNull @JsonProperty("first") byte[] first,
+            @Nullable @JsonProperty("second") byte[] second) {
+        AssertUtil.notNull(first, "first must not be null");
+        this.first = ArrayUtil.clone(first);
+        this.second = ArrayUtil.clone(second);
+    }
+
+    public @NotNull byte[] getFirst() {
+        return ArrayUtil.clone(first);
+    }
+
+    public @Nullable byte[] getSecond() {
+        return ArrayUtil.clone(second);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationExtensionsPRFValues that = (AuthenticationExtensionsPRFValues) o;
+        return Arrays.equals(first, that.first) && Arrays.equals(second, that.second);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(first);
+        result = 31 * result + Arrays.hashCode(second);
+        return result;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/PRFExtensionClientInput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/PRFExtensionClientInput.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.data.extension.SingleValueExtensionInputBase;
+import com.webauthn4j.verifier.exception.ConstraintViolationException;
+import org.jetbrains.annotations.NotNull;
+
+public class PRFExtensionClientInput
+        extends SingleValueExtensionInputBase<AuthenticationExtensionsPRFInputs>
+        implements RegistrationExtensionClientInput, AuthenticationExtensionClientInput {
+
+    public static final String ID = "prf";
+    public static final String KEY_PRF = "prf";
+
+    public PRFExtensionClientInput(@NotNull AuthenticationExtensionsPRFInputs value) {
+        super(value);
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return ID;
+    }
+
+    @Override
+    public @NotNull AuthenticationExtensionsPRFInputs getValue(@NotNull String key) {
+        if (!key.equals(KEY_PRF)) {
+            throw new IllegalArgumentException(String.format("%s is the only valid key.", KEY_PRF));
+        }
+        return getValue();
+    }
+
+    @SuppressWarnings({"ConstantConditions", "java:S2583"})
+    @Override
+    public void validate() {
+        if (getValue() == null) {
+            throw new ConstraintViolationException("value must not be null");
+        }
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/PRFExtensionClientOutput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/client/PRFExtensionClientOutput.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.data.extension.SingleValueExtensionOutputBase;
+import com.webauthn4j.verifier.exception.ConstraintViolationException;
+import org.jetbrains.annotations.NotNull;
+
+public class PRFExtensionClientOutput
+        extends SingleValueExtensionOutputBase<AuthenticationExtensionsPRFOutputs>
+        implements RegistrationExtensionClientOutput, AuthenticationExtensionClientOutput {
+
+    public static final String ID = "prf";
+    public static final String KEY_PRF = "prf";
+
+    public PRFExtensionClientOutput(@NotNull AuthenticationExtensionsPRFOutputs value) {
+        super(value);
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return ID;
+    }
+
+    @Override
+    public @NotNull AuthenticationExtensionsPRFOutputs getValue(@NotNull String key) {
+        if (!key.equals(KEY_PRF)) {
+            throw new IllegalArgumentException(String.format("%s is the only valid key.", KEY_PRF));
+        }
+        return getValue();
+    }
+
+    @SuppressWarnings({"ConstantConditions", "java:S2583"})
+    @Override
+    public void validate() {
+        if (getValue() == null) {
+            throw new ConstraintViolationException("value must not be null");
+        }
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticationExtensionsClientInputsDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticationExtensionsClientInputsDeserializerTest.java
@@ -137,6 +137,25 @@ class AuthenticationExtensionsClientInputsDeserializerTest {
     }
 
     @Test
+    void shouldDeserializePRFInput() {
+        //Given
+        String json = "{ \"prf\": { \"eval\": { \"first\": \"AQ\" } } }";
+
+        //When
+        AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput> extensionInputs =
+                jsonMapper.readValue(
+                        json,
+                        new TypeReference<AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput>>() {
+                        }
+                );
+
+        //Then
+        assertAll(
+                () -> assertThat(extensionInputs.getExtension(PRFExtensionClientInput.class).getValue().getEval().getFirst()).isEqualTo(new byte[]{1})
+        );
+    }
+
+    @Test
     void shouldThrowExceptionForInvalidInput() {
         //Given
         String invalidJson = "{invalid-json}";

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputsTest.java
@@ -166,6 +166,30 @@ class AuthenticationExtensionsClientInputsTest {
     }
 
     @Test
+    void registration_prf_test() {
+        AuthenticationExtensionsClientInputs.BuilderForRegistration builder = new AuthenticationExtensionsClientInputs.BuilderForRegistration();
+        AuthenticationExtensionsPRFInputs prfInputs = new AuthenticationExtensionsPRFInputs(
+                new AuthenticationExtensionsPRFValues(new byte[]{1, 2}, null), null);
+        builder.setPrf(prfInputs);
+        AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput> target = builder.build();
+
+        assertThat(target.getPrf()).isNotNull();
+        assertThat(target.getPrf().getEval().getFirst()).isEqualTo(new byte[]{1, 2});
+    }
+
+    @Test
+    void authentication_prf_test() {
+        AuthenticationExtensionsClientInputs.BuilderForAuthentication builder = new AuthenticationExtensionsClientInputs.BuilderForAuthentication();
+        AuthenticationExtensionsPRFInputs prfInputs = new AuthenticationExtensionsPRFInputs(
+                new AuthenticationExtensionsPRFValues(new byte[]{3, 4}, null), null);
+        builder.setPrf(prfInputs);
+        AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> target = builder.build();
+
+        assertThat(target.getPrf()).isNotNull();
+        assertThat(target.getPrf().getEval().getFirst()).isEqualTo(new byte[]{3, 4});
+    }
+
+    @Test
     void equals_hashCode_test() {
         AuthenticationExtensionsClientInputs.BuilderForAuthentication builder1 = new AuthenticationExtensionsClientInputs.BuilderForAuthentication();
         builder1.setAppid("dummyAppid");

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputsTest.java
@@ -157,6 +157,27 @@ class AuthenticationExtensionsClientOutputsTest {
     }
 
     @Test
+    void registration_prf_test() {
+        AuthenticationExtensionsClientOutputs.BuilderForRegistration builder = new AuthenticationExtensionsClientOutputs.BuilderForRegistration();
+        builder.setPrf(new AuthenticationExtensionsPRFOutputs(true, null));
+        AuthenticationExtensionsClientOutputs<RegistrationExtensionClientOutput> target = builder.build();
+
+        assertThat(target.getPrf()).isNotNull();
+        assertThat(target.getPrf().getEnabled()).isTrue();
+    }
+
+    @Test
+    void authentication_prf_test() {
+        AuthenticationExtensionsClientOutputs.BuilderForAuthentication builder = new AuthenticationExtensionsClientOutputs.BuilderForAuthentication();
+        AuthenticationExtensionsPRFValues results = new AuthenticationExtensionsPRFValues(new byte[]{1, 2}, null);
+        builder.setPrf(new AuthenticationExtensionsPRFOutputs(null, results));
+        AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> target = builder.build();
+
+        assertThat(target.getPrf()).isNotNull();
+        assertThat(target.getPrf().getResults().getFirst()).isEqualTo(new byte[]{1, 2});
+    }
+
+    @Test
     void equals_hashCode_test() {
         UvmEntries uvm = new UvmEntries(Collections.singletonList(new UvmEntry(UserVerificationMethod.FINGERPRINT_INTERNAL, KeyProtectionType.SOFTWARE, MatcherProtectionType.ON_CHIP)));
         AuthenticationExtensionsClientOutputs.BuilderForAuthentication builder1 = new AuthenticationExtensionsClientOutputs.BuilderForAuthentication();

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFInputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFInputsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthenticationExtensionsPRFInputsTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void constructor_with_eval_only() {
+        AuthenticationExtensionsPRFValues eval = new AuthenticationExtensionsPRFValues(new byte[]{1}, null);
+        AuthenticationExtensionsPRFInputs target = new AuthenticationExtensionsPRFInputs(eval, null);
+        assertThat(target.getEval()).isEqualTo(eval);
+        assertThat(target.getEvalByCredential()).isNull();
+    }
+
+    @Test
+    void constructor_with_evalByCredential() {
+        AuthenticationExtensionsPRFValues values = new AuthenticationExtensionsPRFValues(new byte[]{1}, null);
+        Map<String, AuthenticationExtensionsPRFValues> evalByCredential = Map.of("credId123", values);
+        AuthenticationExtensionsPRFInputs target = new AuthenticationExtensionsPRFInputs(null, evalByCredential);
+        assertThat(target.getEval()).isNull();
+        assertThat(target.getEvalByCredential()).containsKey("credId123");
+    }
+
+    @Test
+    void equals_and_hashCode() {
+        AuthenticationExtensionsPRFValues eval = new AuthenticationExtensionsPRFValues(new byte[]{1}, null);
+        AuthenticationExtensionsPRFInputs a = new AuthenticationExtensionsPRFInputs(eval, null);
+        AuthenticationExtensionsPRFInputs b = new AuthenticationExtensionsPRFInputs(eval, null);
+        AuthenticationExtensionsPRFInputs c = new AuthenticationExtensionsPRFInputs(null, null);
+        assertThat(a).isEqualTo(b).isNotEqualTo(c).isNotEqualTo(null);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void deserialization_with_eval() {
+        String json = "{\"eval\":{\"first\":\"AQ\"}}";
+        AuthenticationExtensionsPRFInputs result = jsonMapper.readValue(json, AuthenticationExtensionsPRFInputs.class);
+        assertThat(result.getEval()).isNotNull();
+        assertThat(result.getEval().getFirst()).isEqualTo(new byte[]{1});
+    }
+
+    @Test
+    void deserialization_with_evalByCredential() {
+        String json = "{\"evalByCredential\":{\"credId\":{\"first\":\"AQ\",\"second\":\"Ag\"}}}";
+        AuthenticationExtensionsPRFInputs result = jsonMapper.readValue(json, AuthenticationExtensionsPRFInputs.class);
+        assertThat(result.getEvalByCredential()).containsKey("credId");
+        assertThat(result.getEvalByCredential().get("credId").getFirst()).isEqualTo(new byte[]{1});
+        assertThat(result.getEvalByCredential().get("credId").getSecond()).isEqualTo(new byte[]{2});
+    }
+
+    @Test
+    void serialization_round_trip() {
+        AuthenticationExtensionsPRFValues eval = new AuthenticationExtensionsPRFValues(new byte[]{1, 2}, new byte[]{3, 4});
+        AuthenticationExtensionsPRFValues credValues = new AuthenticationExtensionsPRFValues(new byte[]{5}, null);
+        AuthenticationExtensionsPRFInputs original = new AuthenticationExtensionsPRFInputs(eval, Map.of("cred1", credValues));
+        String json = jsonMapper.writeValueAsString(original);
+        AuthenticationExtensionsPRFInputs restored = jsonMapper.readValue(json, AuthenticationExtensionsPRFInputs.class);
+        assertThat(restored).isEqualTo(original);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFOutputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFOutputsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthenticationExtensionsPRFOutputsTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void constructor_with_enabled_only() {
+        AuthenticationExtensionsPRFOutputs target = new AuthenticationExtensionsPRFOutputs(true, null);
+        assertThat(target.getEnabled()).isTrue();
+        assertThat(target.getResults()).isNull();
+    }
+
+    @Test
+    void constructor_with_results_only() {
+        AuthenticationExtensionsPRFValues results = new AuthenticationExtensionsPRFValues(new byte[]{1}, null);
+        AuthenticationExtensionsPRFOutputs target = new AuthenticationExtensionsPRFOutputs(null, results);
+        assertThat(target.getEnabled()).isNull();
+        assertThat(target.getResults()).isEqualTo(results);
+    }
+
+    @Test
+    void constructor_with_enabled_and_results() {
+        AuthenticationExtensionsPRFValues results = new AuthenticationExtensionsPRFValues(new byte[]{1}, new byte[]{2});
+        AuthenticationExtensionsPRFOutputs target = new AuthenticationExtensionsPRFOutputs(true, results);
+        assertThat(target.getEnabled()).isTrue();
+        assertThat(target.getResults()).isEqualTo(results);
+    }
+
+    @Test
+    void equals_and_hashCode() {
+        AuthenticationExtensionsPRFOutputs a = new AuthenticationExtensionsPRFOutputs(true, null);
+        AuthenticationExtensionsPRFOutputs b = new AuthenticationExtensionsPRFOutputs(true, null);
+        AuthenticationExtensionsPRFOutputs c = new AuthenticationExtensionsPRFOutputs(false, null);
+        assertThat(a).isEqualTo(b).isNotEqualTo(c).isNotEqualTo(null);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void deserialization_with_enabled() {
+        String json = "{\"enabled\":true}";
+        AuthenticationExtensionsPRFOutputs result = jsonMapper.readValue(json, AuthenticationExtensionsPRFOutputs.class);
+        assertThat(result.getEnabled()).isTrue();
+        assertThat(result.getResults()).isNull();
+    }
+
+    @Test
+    void deserialization_with_results() {
+        String json = "{\"results\":{\"first\":\"AQID\",\"second\":\"BAUG\"}}";
+        AuthenticationExtensionsPRFOutputs result = jsonMapper.readValue(json, AuthenticationExtensionsPRFOutputs.class);
+        assertThat(result.getResults()).isNotNull();
+        assertThat(result.getResults().getFirst()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(result.getResults().getSecond()).isEqualTo(new byte[]{4, 5, 6});
+    }
+
+    @Test
+    void serialization_round_trip() {
+        AuthenticationExtensionsPRFValues results = new AuthenticationExtensionsPRFValues(new byte[]{1}, new byte[]{2});
+        AuthenticationExtensionsPRFOutputs original = new AuthenticationExtensionsPRFOutputs(true, results);
+        String json = jsonMapper.writeValueAsString(original);
+        AuthenticationExtensionsPRFOutputs restored = jsonMapper.readValue(json, AuthenticationExtensionsPRFOutputs.class);
+        assertThat(restored).isEqualTo(original);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFValuesTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFValuesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthenticationExtensionsPRFValuesTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void constructor_with_first_only() {
+        AuthenticationExtensionsPRFValues target = new AuthenticationExtensionsPRFValues(new byte[]{1, 2, 3}, null);
+        assertThat(target.getFirst()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(target.getSecond()).isNull();
+    }
+
+    @Test
+    void constructor_with_first_and_second() {
+        AuthenticationExtensionsPRFValues target = new AuthenticationExtensionsPRFValues(new byte[]{1}, new byte[]{2});
+        assertThat(target.getFirst()).isEqualTo(new byte[]{1});
+        assertThat(target.getSecond()).isEqualTo(new byte[]{2});
+    }
+
+    @Test
+    void defensive_copy() {
+        byte[] first = {1, 2, 3};
+        byte[] second = {4, 5, 6};
+        AuthenticationExtensionsPRFValues target = new AuthenticationExtensionsPRFValues(first, second);
+        first[0] = 99;
+        second[0] = 99;
+        assertThat(target.getFirst()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(target.getSecond()).isEqualTo(new byte[]{4, 5, 6});
+
+        target.getFirst()[0] = 99;
+        target.getSecond()[0] = 99;
+        assertThat(target.getFirst()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(target.getSecond()).isEqualTo(new byte[]{4, 5, 6});
+    }
+
+    @Test
+    void equals_and_hashCode() {
+        AuthenticationExtensionsPRFValues a = new AuthenticationExtensionsPRFValues(new byte[]{1}, new byte[]{2});
+        AuthenticationExtensionsPRFValues b = new AuthenticationExtensionsPRFValues(new byte[]{1}, new byte[]{2});
+        AuthenticationExtensionsPRFValues c = new AuthenticationExtensionsPRFValues(new byte[]{3}, null);
+        assertThat(a).isEqualTo(b).isNotEqualTo(c).isNotEqualTo(null);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void deserialization_with_first_only() {
+        String json = "{\"first\":\"AQID\"}";
+        AuthenticationExtensionsPRFValues result = jsonMapper.readValue(json, AuthenticationExtensionsPRFValues.class);
+        assertThat(result.getFirst()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(result.getSecond()).isNull();
+    }
+
+    @Test
+    void serialization_round_trip() {
+        AuthenticationExtensionsPRFValues original = new AuthenticationExtensionsPRFValues(new byte[]{1, 2}, new byte[]{3, 4});
+        String json = jsonMapper.writeValueAsString(original);
+        AuthenticationExtensionsPRFValues restored = jsonMapper.readValue(json, AuthenticationExtensionsPRFValues.class);
+        assertThat(restored).isEqualTo(original);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFValuesTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsPRFValuesTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AuthenticationExtensionsPRFValuesTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void constructor_with_first_only() {
+        AuthenticationExtensionsPRFValues target = new AuthenticationExtensionsPRFValues(new byte[]{1, 2, 3}, null);
+        assertThat(target.getFirst()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(target.getSecond()).isNull();
+    }
+
+    @Test
+    void constructor_with_first_and_second() {
+        AuthenticationExtensionsPRFValues target = new AuthenticationExtensionsPRFValues(new byte[]{1}, new byte[]{2});
+        assertThat(target.getFirst()).isEqualTo(new byte[]{1});
+        assertThat(target.getSecond()).isEqualTo(new byte[]{2});
+    }
+
+    @Test
+    void constructor_with_null_first() {
+        assertThatThrownBy(() -> new AuthenticationExtensionsPRFValues(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("first must not be null");
+    }
+
+    @Test
+    void defensive_copy() {
+        byte[] first = {1, 2, 3};
+        byte[] second = {4, 5, 6};
+        AuthenticationExtensionsPRFValues target = new AuthenticationExtensionsPRFValues(first, second);
+        first[0] = 99;
+        second[0] = 99;
+        assertThat(target.getFirst()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(target.getSecond()).isEqualTo(new byte[]{4, 5, 6});
+
+        target.getFirst()[0] = 99;
+        target.getSecond()[0] = 99;
+        assertThat(target.getFirst()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(target.getSecond()).isEqualTo(new byte[]{4, 5, 6});
+    }
+
+    @Test
+    void equals_and_hashCode() {
+        AuthenticationExtensionsPRFValues a = new AuthenticationExtensionsPRFValues(new byte[]{1}, new byte[]{2});
+        AuthenticationExtensionsPRFValues b = new AuthenticationExtensionsPRFValues(new byte[]{1}, new byte[]{2});
+        AuthenticationExtensionsPRFValues c = new AuthenticationExtensionsPRFValues(new byte[]{3}, null);
+        assertThat(a).isEqualTo(b).isNotEqualTo(c).isNotEqualTo(null);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void deserialization_with_first_only() {
+        String json = "{\"first\":\"AQID\"}";
+        AuthenticationExtensionsPRFValues result = jsonMapper.readValue(json, AuthenticationExtensionsPRFValues.class);
+        assertThat(result.getFirst()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(result.getSecond()).isNull();
+    }
+
+    @Test
+    void deserialization_without_first() {
+        assertThatThrownBy(() -> jsonMapper.readValue("{}", AuthenticationExtensionsPRFValues.class))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("first must not be null");
+    }
+
+    @Test
+    void serialization_round_trip() {
+        AuthenticationExtensionsPRFValues original = new AuthenticationExtensionsPRFValues(new byte[]{1, 2}, new byte[]{3, 4});
+        String json = jsonMapper.writeValueAsString(original);
+        AuthenticationExtensionsPRFValues restored = jsonMapper.readValue(json, AuthenticationExtensionsPRFValues.class);
+        assertThat(restored).isEqualTo(original);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/PRFExtensionClientInputTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/PRFExtensionClientInputTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.verifier.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class PRFExtensionClientInputTest {
+
+    @Test
+    void validate_with_valid_value() {
+        AuthenticationExtensionsPRFInputs inputs = new AuthenticationExtensionsPRFInputs(
+                new AuthenticationExtensionsPRFValues(new byte[]{1}, null), null);
+        assertThatCode(new PRFExtensionClientInput(inputs)::validate).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_with_null_value() {
+        assertThatThrownBy(new PRFExtensionClientInput(null)::validate).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void getIdentifier_returns_prf() {
+        AuthenticationExtensionsPRFInputs inputs = new AuthenticationExtensionsPRFInputs(null, null);
+        assertThat(new PRFExtensionClientInput(inputs).getIdentifier()).isEqualTo("prf");
+    }
+
+    @Test
+    void getValue_with_valid_key() {
+        AuthenticationExtensionsPRFInputs inputs = new AuthenticationExtensionsPRFInputs(null, null);
+        PRFExtensionClientInput target = new PRFExtensionClientInput(inputs);
+        assertThat(target.getValue("prf")).isSameAs(inputs);
+    }
+
+    @Test
+    void getValue_with_invalid_key() {
+        AuthenticationExtensionsPRFInputs inputs = new AuthenticationExtensionsPRFInputs(null, null);
+        PRFExtensionClientInput target = new PRFExtensionClientInput(inputs);
+        assertThatThrownBy(() -> target.getValue("invalid")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/PRFExtensionClientOutputTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/PRFExtensionClientOutputTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data.extension.client;
+
+import com.webauthn4j.verifier.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class PRFExtensionClientOutputTest {
+
+    @Test
+    void validate_with_valid_value() {
+        AuthenticationExtensionsPRFOutputs outputs = new AuthenticationExtensionsPRFOutputs(true, null);
+        assertThatCode(new PRFExtensionClientOutput(outputs)::validate).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_with_null_value() {
+        assertThatThrownBy(new PRFExtensionClientOutput(null)::validate).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void getIdentifier_returns_prf() {
+        AuthenticationExtensionsPRFOutputs outputs = new AuthenticationExtensionsPRFOutputs(true, null);
+        assertThat(new PRFExtensionClientOutput(outputs).getIdentifier()).isEqualTo("prf");
+    }
+
+    @Test
+    void getValue_with_valid_key() {
+        AuthenticationExtensionsPRFOutputs outputs = new AuthenticationExtensionsPRFOutputs(true, null);
+        PRFExtensionClientOutput target = new PRFExtensionClientOutput(outputs);
+        assertThat(target.getValue("prf")).isSameAs(outputs);
+    }
+
+    @Test
+    void getValue_with_invalid_key() {
+        AuthenticationExtensionsPRFOutputs outputs = new AuthenticationExtensionsPRFOutputs(true, null);
+        PRFExtensionClientOutput target = new PRFExtensionClientOutput(outputs);
+        assertThatThrownBy(() -> target.getValue("invalid")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+}


### PR DESCRIPTION
Add client extension input/output classes, WebIDL dictionary data classes, JSON deserializers, and container integration for the WebAuthn Level 3 prf extension, enabling parsing and serialization of PRF extension data for both registration and authentication ceremonies.