### PR TITLE
Enable reproducible builds with Gradle Toolchains

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,7 +7,7 @@ on:
     types: [completed]
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 25
 
 jobs:
   bump-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: [17]
+        java_version: [25]
         os: [ubuntu-24.04]
 
     steps:
@@ -57,7 +57,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build with Gradle
-        run: ./gradlew check -x :integration-tests:fido-mds-integration:check
+        run: ./gradlew check -PtestJavaVersion=${{ matrix.java_version }} -x :integration-tests:fido-mds-integration:check
 
   # Run FIDO MDS integration tests separately to avoid rate limiting
   # from the FIDO Metadata Service (https://mds.fidoalliance.org/).
@@ -71,11 +71,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 25
           cache: 'gradle'
 
       - name: Run FIDO MDS integration tests
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: [17]
+        java_version: [25]
         os: [ubuntu-24.04]
 
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
         language: ['java']
-        java_version: [17]
+        java_version: [25]
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 25
 
 jobs:
   build:

--- a/.github/workflows/pr-gate-ci.yml
+++ b/.github/workflows/pr-gate-ci.yml
@@ -3,7 +3,7 @@ name: Pull Request Gate CI
 on: pull_request
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 25
 
 jobs:
   build:
@@ -52,7 +52,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build with Gradle
-        run: ./gradlew check -x :integration-tests:fido-mds-integration:check
+        run: ./gradlew check -PtestJavaVersion=${{ matrix.java_version }} -x :integration-tests:fido-mds-integration:check
 
   # Run FIDO MDS integration tests separately to avoid rate limiting
   # from the FIDO Metadata Service (https://mds.fidoalliance.org/).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 25
 
 jobs:
   release:

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: [17]
+        java_version: [25]
         os: [ubuntu-24.04]
 
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,18 @@ subprojects {
     apply(plugin = "jacoco")
 
     java {
+        // Pin the compilation JDK via Gradle Toolchains to ensure reproducible builds.
+        // module-info.class embeds the compiler JDK version string, so using different
+        // JDKs produces different bytecode even with the same source/target compatibility.
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(25)
+            vendor = JvmVendorSpec.ADOPTIUM
+        }
+
+        // Use sourceCompatibility/targetCompatibility instead of options.release so that
+        // APIs introduced after JDK 17 (e.g. ML-DSA in JDK 24) remain accessible at compile
+        // time. --release would restrict the API surface to JDK 17. Users who call those newer
+        // APIs must run on a JDK that provides them.
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
 
@@ -41,9 +53,29 @@ subprojects {
         withJavadocJar()
     }
 
-    tasks.compileJava {
+    tasks.withType<JavaCompile>().configureEach {
         options.compilerArgs.add("-Xlint:-module") // Suppress 'module not found' warning regarding 'exports to' directive on multi-module projects.
         options.compilerArgs.add("-Werror") // Treat all warnings as errors
+    }
+
+    // Allow overriding the JDK used for test execution via -PtestJavaVersion=XX.
+    // This enables matrix testing across multiple JDK versions while keeping
+    // compilation fixed to the toolchain JDK for reproducible builds.
+    val testJavaVersion = findProperty("testJavaVersion")?.toString()
+    if (testJavaVersion != null) {
+        tasks.withType<Test>().configureEach {
+            javaLauncher = javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(testJavaVersion)
+            }
+        }
+    }
+
+    // Ensure reproducible builds: deterministic file order and fixed timestamps in archives.
+    // This is the default since Gradle 9.0, but stated explicitly for clarity and to prevent
+    // accidental regression if defaults change.
+    tasks.withType<AbstractArchiveTask>().configureEach {
+        isReproducibleFileOrder = true
+        isPreserveFileTimestamps = false
     }
 
     tasks.test {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,12 @@ pluginManagement {
     includeBuild("maven-central-publish-plugin")
 }
 
+plugins {
+    // Enable automatic JDK download for Gradle Toolchains.
+    // Without this, CI environments fail when the toolchain JDK is not pre-installed.
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 include("webauthn4j-core")
 include("webauthn4j-core-async")
 include("webauthn4j-metadata")


### PR DESCRIPTION
Introduce Gradle Toolchains to pin the compilation JDK to version 25, ensuring consistent bytecode output regardless of the build environment. Use sourceCompatibility/targetCompatibility (not --release) to produce Java 17-compatible bytecode while keeping post-JDK 17 APIs like ML-DSA accessible at compile time.

Add -PtestJavaVersion property to allow matrix testing across multiple JDK versions while keeping compilation deterministic. Explicitly enable reproducible archive settings (file order and timestamps) for clarity.

Update all CI workflows to use JDK 25 for compilation, with matrix-test jobs setting up both JDK 25 (for toolchain) and the target JDK (for test execution).