### PR TITLE
Add toolchain pinning plugin for reproducible builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build with Gradle
-        run: ./gradlew check -PtestJavaVersion=${{ matrix.java_version }} -x :integration-tests:fido-mds-integration:check
+        run: ./gradlew check -PtoolchainJdkVersion=${{ matrix.java_version }} -x :integration-tests:fido-mds-integration:check
 
   # Run FIDO MDS integration tests separately to avoid rate limiting
   # from the FIDO Metadata Service (https://mds.fidoalliance.org/).

--- a/.github/workflows/pr-gate-ci.yml
+++ b/.github/workflows/pr-gate-ci.yml
@@ -52,7 +52,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build with Gradle
-        run: ./gradlew check -PtestJavaVersion=${{ matrix.java_version }} -x :integration-tests:fido-mds-integration:check
+        run: ./gradlew check -PtoolchainJdkVersion=${{ matrix.java_version }} -x :integration-tests:fido-mds-integration:check
 
   # Run FIDO MDS integration tests separately to avoid rate limiting
   # from the FIDO Metadata Service (https://mds.fidoalliance.org/).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,14 +34,6 @@ subprojects {
     apply(plugin = "jacoco")
 
     java {
-        // Pin the compilation JDK via Gradle Toolchains to ensure reproducible builds.
-        // module-info.class embeds the compiler JDK version string, so using different
-        // JDKs produces different bytecode even with the same source/target compatibility.
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(25)
-            vendor = JvmVendorSpec.ADOPTIUM
-        }
-
         // Use sourceCompatibility/targetCompatibility instead of options.release so that
         // APIs introduced after JDK 17 (e.g. ML-DSA in JDK 24) remain accessible at compile
         // time. --release would restrict the API surface to JDK 17. Users who call those newer
@@ -56,18 +48,6 @@ subprojects {
     tasks.withType<JavaCompile>().configureEach {
         options.compilerArgs.add("-Xlint:-module") // Suppress 'module not found' warning regarding 'exports to' directive on multi-module projects.
         options.compilerArgs.add("-Werror") // Treat all warnings as errors
-    }
-
-    // Allow overriding the JDK used for test execution via -PtestJavaVersion=XX.
-    // This enables matrix testing across multiple JDK versions while keeping
-    // compilation fixed to the toolchain JDK for reproducible builds.
-    val testJavaVersion = findProperty("testJavaVersion")?.toString()
-    if (testJavaVersion != null) {
-        tasks.withType<Test>().configureEach {
-            javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(testJavaVersion)
-            }
-        }
     }
 
     // Ensure reproducible builds: deterministic file order and fixed timestamps in archives.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,12 +16,15 @@
 
 pluginManagement {
     includeBuild("maven-central-publish-plugin")
+    includeBuild("toolchain-pinning-plugin")
 }
 
 plugins {
-    // Enable automatic JDK download for Gradle Toolchains.
-    // Without this, CI environments fail when the toolchain JDK is not pre-installed.
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+    id("com.webauthn4j.toolchain-pinning")
+}
+
+toolchainPinning {
+    toolchainJdkVersion = providers.gradleProperty("toolchainJdkVersion")
 }
 
 include("webauthn4j-core")

--- a/toolchain-pinning-plugin/README.md
+++ b/toolchain-pinning-plugin/README.md
@@ -1,0 +1,105 @@
+# Toolchain Pinning Plugin
+
+A Gradle settings plugin that pins the JDK used for compilation by downloading a specific version
+from the [Eclipse Adoptium (Temurin)](https://adoptium.net/) API.
+
+## Overview
+
+When `-PtoolchainJdkVersion` is specified, this plugin:
+
+1. **Configures Gradle Toolchains** on all Java projects with the corresponding major version
+2. **Downloads the specified JDK** from the Adoptium API if not already cached
+3. **Disables local JDK auto-detection** when an exact version is specified, ensuring the
+   pinned version is always used
+
+This overrides any toolchain configuration in `build.gradle.kts`. When `toolchainJdkVersion` is
+not set, the plugin does nothing and the build uses whatever JDK is available in the environment.
+
+Downloaded JDKs are cached in `~/.gradle/jdks/` and reused across builds.
+
+## Configuration
+
+The plugin is applied in `settings.gradle.kts`:
+
+```kotlin
+pluginManagement {
+    includeBuild("toolchain-pinning-plugin")
+}
+
+plugins {
+    id("com.webauthn4j.toolchain-pinning")
+}
+
+toolchainPinning {
+    toolchainJdkVersion = providers.gradleProperty("toolchainJdkVersion")
+}
+```
+
+## Usage
+
+### Use the environment JDK (default)
+
+```sh
+./gradlew build
+```
+
+No `toolchainJdkVersion` property is set. Gradle uses whatever JDK is available in the environment
+(e.g., `JAVA_HOME` or the JDK set up by CI). No download occurs.
+
+### Download the latest JDK for a major version
+
+```sh
+./gradlew build -PtoolchainJdkVersion=21
+```
+
+Gradle downloads the **latest Adoptium JDK 21** (if not already cached) and uses it
+for the build.
+
+### Download an exact JDK version
+
+```sh
+./gradlew build -PtoolchainJdkVersion=25.0.3+9
+```
+
+Gradle downloads **exactly JDK 25.0.3+9** from Adoptium and uses it for the build.
+
+## How it works
+
+When `toolchainJdkVersion` is set, the plugin performs three actions:
+
+### 1. Toolchain auto-configuration
+
+The plugin calls `java.toolchain.languageVersion.set(...)` on all projects where the
+`java` plugin is applied. This overrides any manually configured toolchain and tells Gradle
+which major JDK version is required.
+
+### 2. JDK resolution via Adoptium API
+
+The plugin registers a `JavaToolchainResolver` that constructs download URLs for the
+[Adoptium API v3](https://api.adoptium.net/):
+
+- **Exact version** (e.g., `25.0.3+9`): `https://api.adoptium.net/v3/binary/version/jdk-{version}/...`
+- **Major version only** (e.g., `21`): `https://api.adoptium.net/v3/binary/latest/{major}/ga/...`
+
+Downloading, extracting, and caching are handled by Gradle itself.
+
+### 3. Local JDK auto-detection bypass
+
+When an exact version is specified (the version string contains a dot), the plugin
+automatically disables Gradle's local JDK auto-detection (`org.gradle.java.installations.auto-detect=false`).
+This prevents Gradle from using a locally installed JDK with a different patch version.
+
+## Caveats
+
+Do not configure `java.toolchain.languageVersion` manually in `build.gradle.kts` when using
+this plugin with `-PtoolchainJdkVersion`. The plugin auto-configures toolchains on all Java
+projects, so a manual setting would conflict and may cause the build to use an unexpected
+JDK version.
+
+## Supported platforms
+
+| OS      | Architecture |
+|---------|-------------|
+| Linux   | x64, aarch64 |
+| Windows | x64, aarch64 |
+| macOS   | x64, aarch64 |

--- a/toolchain-pinning-plugin/build.gradle.kts
+++ b/toolchain-pinning-plugin/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        register("toolchainPinning") {
+            id = "com.webauthn4j.toolchain-pinning"
+            implementationClass = "com.webauthn4j.gradle.toolchain.ToolchainPinningPlugin"
+        }
+    }
+}

--- a/toolchain-pinning-plugin/settings.gradle.kts
+++ b/toolchain-pinning-plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "toolchain-pinning-plugin"

--- a/toolchain-pinning-plugin/src/main/kotlin/com/webauthn4j/gradle/toolchain/AdoptiumToolchainResolver.kt
+++ b/toolchain-pinning-plugin/src/main/kotlin/com/webauthn4j/gradle/toolchain/AdoptiumToolchainResolver.kt
@@ -1,0 +1,55 @@
+package com.webauthn4j.gradle.toolchain
+
+import org.gradle.jvm.toolchain.JavaToolchainDownload
+import org.gradle.jvm.toolchain.JavaToolchainRequest
+import org.gradle.jvm.toolchain.JavaToolchainResolver
+import org.gradle.platform.Architecture
+import org.gradle.platform.OperatingSystem
+import java.net.URI
+import java.net.URLEncoder
+import java.util.*
+
+abstract class AdoptiumToolchainResolver : JavaToolchainResolver {
+
+    var toolchainJdkVersion: String? = null
+
+    override fun resolve(request: JavaToolchainRequest): Optional<JavaToolchainDownload> {
+        val platform = request.buildPlatform
+        val os = mapOperatingSystem(platform.operatingSystem)
+        val arch = mapArchitecture(platform.architecture)
+
+        val version = toolchainJdkVersion
+        if (version == null) {
+            return resolveLatest(request.javaToolchainSpec.languageVersion.get().asInt(), os, arch)
+        }
+        else if (ToolchainJdkVersionParser.isMajorVersionOnly(version)) {
+            return resolveLatest(version.toInt(), os, arch)
+        } else {
+            return resolveExact(version, os, arch)
+        }
+    }
+
+    private fun resolveExact(version: String, os: String, arch: String): Optional<JavaToolchainDownload> {
+        val encodedVersion = URLEncoder.encode(version, Charsets.UTF_8)
+        val url = URI("https://api.adoptium.net/v3/binary/version/jdk-$encodedVersion/$os/$arch/jdk/hotspot/normal/eclipse?project=jdk")
+        return Optional.of(JavaToolchainDownload.fromUri(url))
+    }
+
+    private fun resolveLatest(majorVersion: Int, os: String, arch: String): Optional<JavaToolchainDownload> {
+        val url = URI("https://api.adoptium.net/v3/binary/latest/$majorVersion/ga/$os/$arch/jdk/hotspot/normal/eclipse?project=jdk")
+        return Optional.of(JavaToolchainDownload.fromUri(url))
+    }
+
+    private fun mapOperatingSystem(os: OperatingSystem): String = when (os) {
+        OperatingSystem.LINUX -> "linux"
+        OperatingSystem.WINDOWS -> "windows"
+        OperatingSystem.MAC_OS -> "mac"
+        else -> throw IllegalArgumentException("Unsupported operating system: $os")
+    }
+
+    private fun mapArchitecture(arch: Architecture): String = when (arch) {
+        Architecture.X86_64 -> "x64"
+        Architecture.AARCH64 -> "aarch64"
+        else -> throw IllegalArgumentException("Unsupported architecture: $arch")
+    }
+}

--- a/toolchain-pinning-plugin/src/main/kotlin/com/webauthn4j/gradle/toolchain/ToolchainJdkVersionParser.kt
+++ b/toolchain-pinning-plugin/src/main/kotlin/com/webauthn4j/gradle/toolchain/ToolchainJdkVersionParser.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.gradle.toolchain
+
+object ToolchainJdkVersionParser {
+
+    fun isMajorVersionOnly(version: String): Boolean = version.all { it.isDigit() }
+
+    fun extractMajorVersion(version: String): Int = version.substringBefore(".").toInt()
+}

--- a/toolchain-pinning-plugin/src/main/kotlin/com/webauthn4j/gradle/toolchain/ToolchainPinningExtension.kt
+++ b/toolchain-pinning-plugin/src/main/kotlin/com/webauthn4j/gradle/toolchain/ToolchainPinningExtension.kt
@@ -1,0 +1,7 @@
+package com.webauthn4j.gradle.toolchain
+
+import org.gradle.api.provider.Property
+
+abstract class ToolchainPinningExtension {
+    abstract val toolchainJdkVersion: Property<String>
+}

--- a/toolchain-pinning-plugin/src/main/kotlin/com/webauthn4j/gradle/toolchain/ToolchainPinningPlugin.kt
+++ b/toolchain-pinning-plugin/src/main/kotlin/com/webauthn4j/gradle/toolchain/ToolchainPinningPlugin.kt
@@ -1,0 +1,66 @@
+package com.webauthn4j.gradle.toolchain
+
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.SettingsInternal
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JvmToolchainManagementPlugin
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainResolverRegistry
+import org.gradle.kotlin.dsl.jvm
+import org.gradle.kotlin.dsl.the
+
+abstract class ToolchainPinningPlugin : Plugin<Settings> {
+
+    override fun apply(target: Settings) {
+        val extension = target.extensions.create(
+            "toolchainPinning",
+            ToolchainPinningExtension::class.java
+        )
+
+        target.gradle.settingsEvaluated {
+            val toolchainJdkVersion = extension.toolchainJdkVersion.orNull
+
+            // Pass the version to the resolver instance via shared build services.
+            target.gradle.sharedServices.registrations.forEach { registration ->
+                val service = registration.service.orNull
+                if (service is AdoptiumToolchainResolver) {
+                    service.toolchainJdkVersion = toolchainJdkVersion
+                }
+            }
+
+            // When an exact version is specified (e.g. 25.0.3+9), disable local JDK
+            // auto-detection to force downloading and using the pinned version.
+            if (toolchainJdkVersion != null && !ToolchainJdkVersionParser.isMajorVersionOnly(toolchainJdkVersion)) {
+                System.setProperty("org.gradle.java.installations.auto-detect", "false")
+            }
+        }
+
+        target.gradle.allprojects {
+            plugins.withType(JavaPlugin::class.java) {
+                val toolchainJdkVersion = extension.toolchainJdkVersion.orNull
+                if (toolchainJdkVersion != null) {
+                    the<org.gradle.api.plugins.JavaPluginExtension>().toolchain {
+                        languageVersion.set(JavaLanguageVersion.of(ToolchainJdkVersionParser.extractMajorVersion(toolchainJdkVersion)))
+                    }
+                }
+            }
+        }
+
+        target.plugins.apply(JvmToolchainManagementPlugin::class.java)
+
+        val registry = (target as SettingsInternal).services.get(JavaToolchainResolverRegistry::class.java)
+        registry.register(AdoptiumToolchainResolver::class.java)
+
+        @Suppress("UnstableApiUsage")
+        target.toolchainManagement {
+            jvm {
+                javaRepositories {
+                    repository("adoptium") {
+                        resolverClass.set(AdoptiumToolchainResolver::class.java)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a Gradle settings plugin that pins the JDK used for compilation by downloading a specific version from the Adoptium API. Usage:

  Major version:  -PtoolchainJdkVersion=21
  Exact version:  -PtoolchainJdkVersion=25.0.3+9

When toolchainJdkVersion is not set, the build uses whatever JDK is available in the environment. When set, the plugin:

- Auto-configures Gradle Toolchains on all Java projects
- Downloads the specified JDK from Adoptium
- Disables local JDK auto-detection for exact versions

Configuration is exposed via ToolchainPinningExtension, and the version is passed to the resolver through Gradle's shared build service registry. Replace the Foojay resolver plugin and unify the previous testJavaVersion property.