### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Enforce LF line endings on all platforms for reproducible builds.
+# Without this, text resource files (e.g. .pem, .conf) checked out with
+# OS-native line endings produce different JARs on Windows vs Linux.
+* text=auto eol=lf


### PR DESCRIPTION
Ensure text files are always checked out with LF line endings regardless of the OS. Without this, resource files like .pem and .conf in webauthn4j-test produce different JARs on Windows (CRLF) vs Linux (LF), breaking reproducible builds.