### PR TITLE
Add draft release creation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
+        id: setup-java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
@@ -84,3 +85,28 @@ jobs:
           PGP_SIGNING_KEY_PASSPHRASE: ${{ secrets.PGP_SIGNING_KEY_PASSPHRASE }}
         run: |
           ./gradlew publishToCentralPortal
+
+      - name: Create draft release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          VERSION=$(grep "webAuthn4JVersion" gradle.properties | cut -d'=' -f2)
+          JDK_VERSION="${{ steps.setup-java.outputs.version }}"
+          gh release create "${VERSION}.RELEASE" \
+            --draft \
+            --generate-notes \
+            --title "${VERSION}.RELEASE"
+          EXISTING_NOTES=$(gh release view "${VERSION}.RELEASE" --json body --jq .body)
+          GRADLE_VERSION=$(grep "distributionUrl" gradle/wrapper/gradle-wrapper.properties | sed 's/.*gradle-\(.*\)-bin.zip/\1/')
+          gh release edit "${VERSION}.RELEASE" --notes "$(cat <<EOF
+          ${EXISTING_NOTES}
+
+          ## Build Configuration
+
+          | Item | Value |
+          |------|-------|
+          | JDK | Eclipse Temurin \`${JDK_VERSION}\` |
+          | Gradle | \`${GRADLE_VERSION}\` |
+          EOF
+          )"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,36 @@ git clone https://github.com/webauthn4j/webauthn4j
 ./gradlew build
 ```
 
+### Reproducible builds
+
+WebAuthn4J is committed to software supply chain security. All release artifacts support
+reproducible builds — you can rebuild from source and verify that the result is bit-for-bit
+identical to the artifacts published on Maven Central.
+
+The exact JDK version used for each release is listed in the [release notes](https://github.com/webauthn4j/webauthn4j/releases).
+
+```sh
+git clone https://github.com/webauthn4j/webauthn4j.git
+cd webauthn4j
+git checkout <VERSION>.RELEASE
+./gradlew jar -PtoolchainJdkVersion=<JDK_VERSION>
+```
+
+Then compare the locally built JARs against Maven Central:
+
+```sh
+VERSION=<VERSION>.RELEASE
+find . -path "*/build/libs/webauthn4j-*-${VERSION}.jar" | while read jar; do
+  module=$(basename "$jar" "-${VERSION}.jar")
+  local=$(sha256sum "$jar" | cut -d' ' -f1)
+  central=$(curl -sL "https://repo1.maven.org/maven2/com/webauthn4j/${module}/${VERSION}/${module}-${VERSION}.jar" \
+    | sha256sum | cut -d' ' -f1)
+  echo "$module: $([ "$local" = "$central" ] && echo MATCH || echo MISMATCH)"
+done
+```
+
+All modules should show `MATCH`.
+
 ## How to use
 
 Parse and Validation on WebAuthn registration

--- a/docs/internal/release-procedure.md
+++ b/docs/internal/release-procedure.md
@@ -10,11 +10,11 @@ It will automatically executes following steps:
 1. Create a release commit by updating the `isSnapshot` flag, and versions in documents from the `HEAD` of the `master` branch.
 2. Create a release tag
 3. Publish to Maven Central
+4. Create a draft GitHub Release with auto-generated changelog and reproducible build instructions (including the exact JDK version used)
 
 After the release workflow completion, bump-version workflow is automatically triggered, and it will create a commit that bumps to the next patch version.
 
-### Prepare a release note
+### Review and publish the release note
 
-Write a release note on the GitHub: https://github.com/webauthn4j/webauthn4j/releases
-
-Click "Generate release notes" button or use `gh release create <tag> --generate-notes` to generate a release note draft based on `.github/release.yml`.
+The release workflow creates a draft release at https://github.com/webauthn4j/webauthn4j/releases.
+Review the auto-generated content, edit as needed, then publish it.


### PR DESCRIPTION
Create a draft GitHub Release after publishing to Maven Central, with auto-generated changelog and reproducible build verification instructions including the exact JDK version used. The draft is published manually after review.