### PR TITLE
Remove unused -PfailBuildOnCVSS=4 Gradle property from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build with Gradle
-        run: ./gradlew build javadoc asciidoc -PfailBuildOnCVSS=4 -x :integration-tests:fido-mds-integration:check
+        run: ./gradlew build javadoc asciidoc -x :integration-tests:fido-mds-integration:check
 
   matrix-test:
     name: Test on java ${{ matrix.java_version }} and ${{ matrix.os }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,7 +63,7 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Build with Gradle
-        run: ./gradlew build javadoc asciidoc -PfailBuildOnCVSS=4
+        run: ./gradlew build javadoc asciidoc
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/pr-gate-ci.yml
+++ b/.github/workflows/pr-gate-ci.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build with Gradle
-        run: ./gradlew build javadoc generateReferenceEN generateReferenceJA -PfailBuildOnCVSS=4 -x :integration-tests:fido-mds-integration:check
+        run: ./gradlew build javadoc generateReferenceEN generateReferenceJA -x :integration-tests:fido-mds-integration:check
 
   matrix-test:
     name: Test on java ${{ matrix.java_version }} and ${{ matrix.os }}


### PR DESCRIPTION
The OWASP Dependency-Check plugin is no longer applied in the build, so this property has no effect and is silently ignored by Gradle.