### PR TITLE
Add defensive copy to CollectionUtil unmodifiable methods

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/server/SimpleOriginPredicate.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/server/SimpleOriginPredicate.java
@@ -3,6 +3,7 @@ package com.webauthn4j.server;
 import com.webauthn4j.data.client.Origin;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -27,7 +28,7 @@ public class SimpleOriginPredicate implements OriginPredicate {
      * @param origins the set of allowed origins
      */
     SimpleOriginPredicate(Set<Origin> origins) {
-        this.origins = Collections.unmodifiableSet(origins);
+        this.origins = Collections.unmodifiableSet(new LinkedHashSet<>(origins));
     }
 
     /**
@@ -36,7 +37,7 @@ public class SimpleOriginPredicate implements OriginPredicate {
      * @param origin the allowed origin
      */
     SimpleOriginPredicate(Origin origin) {
-        this.origins = Collections.singleton(origin);
+        this.origins = Set.of(origin);
     }
 
     /**

--- a/webauthn4j-core/src/main/java/com/webauthn4j/util/CollectionUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/util/CollectionUtil.java
@@ -28,20 +28,19 @@ public class CollectionUtil {
     }
 
     public static <T> @Nullable List<T> unmodifiableList(@Nullable List<? extends T> list) {
-        return list == null ? null : Collections.unmodifiableList(list);
+        return list == null ? null : Collections.unmodifiableList(new ArrayList<>(list));
     }
 
     public static <T> @Nullable Set<T> unmodifiableSet(@Nullable Set<? extends T> set) {
-        return set == null ? null : Collections.unmodifiableSet(set);
+        return set == null ? null : Collections.unmodifiableSet(new LinkedHashSet<>(set));
     }
 
     @SafeVarargs
     public static <T> @NotNull Set<T> unmodifiableSet(@NotNull T... items) {
-        Set<T> set = new HashSet<>(Arrays.asList(items));
-        return Collections.unmodifiableSet(set);
+        return Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(items)));
     }
 
     public static <K, V> @Nullable Map<K, V> unmodifiableMap(@Nullable Map<? extends K, ? extends V> map) {
-        return map == null ? null : Collections.unmodifiableMap(map);
+        return map == null ? null : Collections.unmodifiableMap(new LinkedHashMap<>(map));
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/util/CollectionUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/util/CollectionUtilTest.java
@@ -1,0 +1,40 @@
+package com.webauthn4j.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectionUtilTest {
+
+    @Test
+    void unmodifiableList_should_not_be_affected_by_modification_to_original() {
+        List<String> original = new ArrayList<>(List.of("a", "b"));
+        List<String> unmodifiable = CollectionUtil.unmodifiableList(original);
+
+        original.add("c");
+
+        assertThat(unmodifiable).containsExactly("a", "b");
+    }
+
+    @Test
+    void unmodifiableSet_should_not_be_affected_by_modification_to_original() {
+        Set<String> original = new HashSet<>(Set.of("a", "b"));
+        Set<String> unmodifiable = CollectionUtil.unmodifiableSet(original);
+
+        original.add("c");
+
+        assertThat(unmodifiable).containsExactlyInAnyOrder("a", "b");
+    }
+
+    @Test
+    void unmodifiableMap_should_not_be_affected_by_modification_to_original() {
+        Map<String, String> original = new HashMap<>(Map.of("k1", "v1"));
+        Map<String, String> unmodifiable = CollectionUtil.unmodifiableMap(original);
+
+        original.put("k2", "v2");
+
+        assertThat(unmodifiable).containsOnlyKeys("k1").hasSize(1);
+    }
+}


### PR DESCRIPTION
CollectionUtil.unmodifiableList/Set/Map wrapped the original collection without copying, allowing callers to mutate the underlying data through the original reference. Use defensive copies (ArrayList, LinkedHashSet, LinkedHashMap) to ensure true immutability while preserving iteration order.

Also fix SimpleOriginPredicate which had the same issue with a direct Collections.unmodifiableSet call.