### PR TITLE
Suppress missing Javadoc doclint warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.webauthn4j.gradle.VersionUtils
 import org.asciidoctor.gradle.jvm.AsciidoctorTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import java.net.URI
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import java.nio.charset.StandardCharsets
 
 plugins {
@@ -72,9 +73,10 @@ subprojects {
     }
 
     tasks.javadoc{
-        options {
+        (options as StandardJavadocDocletOptions).apply {
             charset("UTF-8")
             encoding("UTF-8")
+            addStringOption("Xdoclint:all,-missing", "-quiet")
         }
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreMaliciousCounterValueHandler.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreMaliciousCounterValueHandler.java
@@ -21,12 +21,13 @@ import org.jetbrains.annotations.NotNull;
 /**
  * strategy interface to handle malicious counter value detection during authentication.
  * <p>
- * This interface is similar to {@link MaliciousCounterValueHandler} but works with 
+ * This interface is similar to {@link MaliciousCounterValueHandler} but works with
  * {@link CoreAuthenticationObject} instead of {@link AuthenticationObject}
+ * </p>
  * <p>
  * Implementations of this interface define strategies for handling suspicious counter
  * values, whether to throw an exception, log a warning, or take other mitigating actions.
- * <p>
+ * </p>
  */
 public interface CoreMaliciousCounterValueHandler {
 


### PR DESCRIPTION
Add -Xdoclint:all,-missing to javadoc task options to suppress 554 "no comment" warnings while keeping other doclint checks. Also fix an invalid empty <p> tag in CoreMaliciousCounterValueHandler.