### PR TITLE
implement serializable

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/client/challenge/DefaultChallenge.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/client/challenge/DefaultChallenge.java
@@ -22,11 +22,12 @@ import com.webauthn4j.util.Base64UrlUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.UUID;
 
-public class DefaultChallenge implements Challenge {
+public class DefaultChallenge implements Challenge, Serializable {
     private final byte[] value;
 
     /**

--- a/webauthn4j-core/src/main/java/com/webauthn4j/server/ServerProperty.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/server/ServerProperty.java
@@ -23,6 +23,7 @@ import com.webauthn4j.util.AssertUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
@@ -31,7 +32,7 @@ import java.util.Set;
 /**
  * Data transfer object that represents relying party server property for verifiers
  */
-public class ServerProperty extends CoreServerProperty {
+public class ServerProperty extends CoreServerProperty implements Serializable {
 
     // ~ Instance fields
     // ================================================================================================

--- a/webauthn4j-core/src/main/java/com/webauthn4j/server/SimpleOriginPredicate.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/server/SimpleOriginPredicate.java
@@ -2,6 +2,7 @@ package com.webauthn4j.server;
 
 import com.webauthn4j.data.client.Origin;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -18,7 +19,7 @@ import java.util.Set;
  *
  * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-validating-origin">WebAuthn Level 3 § 13.4.9 Validating the origin of a credential</a>
  */
-public class SimpleOriginPredicate implements OriginPredicate {
+public class SimpleOriginPredicate implements OriginPredicate, Serializable {
 
     private final Set<Origin> origins;
 


### PR DESCRIPTION
When I used `webauthn4j-spring-security-core` with redis session, could not login by webauthn.

build.gradle
```
implementation "org.springframework.boot:spring-boot-starter-session-data-redis"
implementation "com.webauthn4j:webauthn4j-spring-security-core"
```

request to `http://localhost:8080/webauthn/assertion/options`
then throw Exception 
```
Caused by: java.lang.IllegalArgumentException: DefaultSerializer requires a Serializable payload but received an object of type [com.webauthn4j.data.client.challenge.DefaultChallenge]
```

----

if I create `ChallengeRepository` bean implemented `Serializable` 
```
    @Bean
    fun challengeRepository(): ChallengeRepository =
        object : HttpSessionChallengeRepository() {
            override fun generateChallenge(): Challenge {
                return object : DefaultChallenge(), Serializable {}
            }
        }
```

request to POST `http://localhost:8080/login`
then throw Exception 
```
Caused by: java.io.NotSerializableException: com.webauthn4j.server.ServerProperty
```

----

I added `Serializable` to class that is stored as session data.