### PR TITLE
Bump github/codeql-action from 4.36.2 to 4.36.3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,4 +66,4 @@ jobs:
         run: ./gradlew build javadoc asciidoc
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4


### PR DESCRIPTION
## Summary
- Bump both `github/codeql-action/init` and `github/codeql-action/analyze` from 4.36.2 to 4.36.3
- Supersedes #1409 and #1410, which each updated only one of the two actions, causing a version mismatch error: `Loaded a configuration file for version '4.36.3', but running version '4.36.2'`