### PR TITLE
Add ESP256/ESP384/ESP512 fully-specified COSE algorithm identifiers (RFC 9864)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/SignatureAlgorithm.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/SignatureAlgorithm.java
@@ -79,6 +79,10 @@ public class SignatureAlgorithm {
     public static final SignatureAlgorithm PS256 = new SignatureAlgorithm(JCA_RSA_SSA_PSS, SHA256);
     public static final SignatureAlgorithm PS384 = new SignatureAlgorithm(JCA_RSA_SSA_PSS, SHA384);
     public static final SignatureAlgorithm PS512 = new SignatureAlgorithm(JCA_RSA_SSA_PSS, SHA512);
+    // RFC 9864 fully-specified aliases — cryptographically identical to ES256/ES384/ES512
+    public static final SignatureAlgorithm ESP256 = ES256;
+    public static final SignatureAlgorithm ESP384 = ES384;
+    public static final SignatureAlgorithm ESP512 = ES512;
 
     private final String jcaName;
     private final @Nullable MessageDigestAlgorithm messageDigestAlgorithm;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifier.java
@@ -47,6 +47,9 @@ public class COSEAlgorithmIdentifier {
     public static final COSEAlgorithmIdentifier PS256;
     public static final COSEAlgorithmIdentifier PS384;
     public static final COSEAlgorithmIdentifier PS512;
+    public static final COSEAlgorithmIdentifier ESP256;
+    public static final COSEAlgorithmIdentifier ESP384;
+    public static final COSEAlgorithmIdentifier ESP512;
 
     private static final Map<COSEAlgorithmIdentifier, COSEKeyType> keyTypeMap = new HashMap<>();
     private static final Map<COSEAlgorithmIdentifier, SignatureAlgorithm> algorithmMap = new HashMap<>();
@@ -64,10 +67,16 @@ public class COSEAlgorithmIdentifier {
         PS256 = new COSEAlgorithmIdentifier(-37);
         PS384 = new COSEAlgorithmIdentifier(-38);
         PS512 = new COSEAlgorithmIdentifier(-39);
+        ESP256 = new COSEAlgorithmIdentifier(-9);
+        ESP384 = new COSEAlgorithmIdentifier(-51);
+        ESP512 = new COSEAlgorithmIdentifier(-52);
 
         keyTypeMap.put(COSEAlgorithmIdentifier.ES256, COSEKeyType.EC2);
         keyTypeMap.put(COSEAlgorithmIdentifier.ES384, COSEKeyType.EC2);
         keyTypeMap.put(COSEAlgorithmIdentifier.ES512, COSEKeyType.EC2);
+        keyTypeMap.put(COSEAlgorithmIdentifier.ESP256, COSEKeyType.EC2);
+        keyTypeMap.put(COSEAlgorithmIdentifier.ESP384, COSEKeyType.EC2);
+        keyTypeMap.put(COSEAlgorithmIdentifier.ESP512, COSEKeyType.EC2);
         keyTypeMap.put(COSEAlgorithmIdentifier.EdDSA, COSEKeyType.OKP);
         keyTypeMap.put(COSEAlgorithmIdentifier.RS1, COSEKeyType.RSA);
         keyTypeMap.put(COSEAlgorithmIdentifier.RS256, COSEKeyType.RSA);
@@ -80,6 +89,9 @@ public class COSEAlgorithmIdentifier {
         algorithmMap.put(COSEAlgorithmIdentifier.ES256, SignatureAlgorithm.ES256);
         algorithmMap.put(COSEAlgorithmIdentifier.ES384, SignatureAlgorithm.ES384);
         algorithmMap.put(COSEAlgorithmIdentifier.ES512, SignatureAlgorithm.ES512);
+        algorithmMap.put(COSEAlgorithmIdentifier.ESP256, SignatureAlgorithm.ESP256);
+        algorithmMap.put(COSEAlgorithmIdentifier.ESP384, SignatureAlgorithm.ESP384);
+        algorithmMap.put(COSEAlgorithmIdentifier.ESP512, SignatureAlgorithm.ESP512);
         algorithmMap.put(COSEAlgorithmIdentifier.EdDSA, SignatureAlgorithm.Ed25519);
         algorithmMap.put(COSEAlgorithmIdentifier.RS1, SignatureAlgorithm.RS1);
         algorithmMap.put(COSEAlgorithmIdentifier.RS256, SignatureAlgorithm.RS256);
@@ -89,9 +101,17 @@ public class COSEAlgorithmIdentifier {
         algorithmMap.put(COSEAlgorithmIdentifier.PS384, SignatureAlgorithm.PS384);
         algorithmMap.put(COSEAlgorithmIdentifier.PS512, SignatureAlgorithm.PS512);
 
-        for (Map.Entry<COSEAlgorithmIdentifier, SignatureAlgorithm> entry : algorithmMap.entrySet()) {
-            reverseAlgorithmMap.put(entry.getValue(), entry.getKey());
-        }
+        reverseAlgorithmMap.put(SignatureAlgorithm.ES256, COSEAlgorithmIdentifier.ES256);
+        reverseAlgorithmMap.put(SignatureAlgorithm.ES384, COSEAlgorithmIdentifier.ES384);
+        reverseAlgorithmMap.put(SignatureAlgorithm.ES512, COSEAlgorithmIdentifier.ES512);
+        reverseAlgorithmMap.put(SignatureAlgorithm.Ed25519, COSEAlgorithmIdentifier.EdDSA);
+        reverseAlgorithmMap.put(SignatureAlgorithm.RS1, COSEAlgorithmIdentifier.RS1);
+        reverseAlgorithmMap.put(SignatureAlgorithm.RS256, COSEAlgorithmIdentifier.RS256);
+        reverseAlgorithmMap.put(SignatureAlgorithm.RS384, COSEAlgorithmIdentifier.RS384);
+        reverseAlgorithmMap.put(SignatureAlgorithm.RS512, COSEAlgorithmIdentifier.RS512);
+        reverseAlgorithmMap.put(SignatureAlgorithm.PS256, COSEAlgorithmIdentifier.PS256);
+        reverseAlgorithmMap.put(SignatureAlgorithm.PS384, COSEAlgorithmIdentifier.PS384);
+        reverseAlgorithmMap.put(SignatureAlgorithm.PS512, COSEAlgorithmIdentifier.PS512);
     }
 
     private final long value;
@@ -105,6 +125,13 @@ public class COSEAlgorithmIdentifier {
         return new COSEAlgorithmIdentifier(value);
     }
 
+    /**
+     * @deprecated The mapping from SignatureAlgorithm to COSEAlgorithmIdentifier is no longer
+     * one-to-one since RFC 9864 introduced fully-specified identifiers (e.g. ESP256) that share
+     * the same SignatureAlgorithm as their polymorphic counterparts (e.g. ES256).
+     * Use the static constants directly (e.g. {@link #ES256}, {@link #ESP256}).
+     */
+    @Deprecated
     public static @NotNull COSEAlgorithmIdentifier create(@NotNull SignatureAlgorithm signatureAlgorithm) {
         COSEAlgorithmIdentifier coseAlgorithmIdentifier = reverseAlgorithmMap.get(signatureAlgorithm);
         if (coseAlgorithmIdentifier == null) {
@@ -181,6 +208,15 @@ public class COSEAlgorithmIdentifier {
         }
         else if(value == PS512.value){
             return "PS512";
+        }
+        else if(value == ESP256.value){
+            return "ESP256";
+        }
+        else if(value == ESP384.value){
+            return "ESP384";
+        }
+        else if(value == ESP512.value){
+            return "ESP512";
         }
         else {
             return String.format("Unknown COSEAlgorithmIdentifier(%d)", value);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
@@ -47,6 +47,9 @@ class COSEAlgorithmIdentifierTest {
                 () -> assertThat(COSEAlgorithmIdentifier.create(-37)).isEqualTo(COSEAlgorithmIdentifier.PS256),
                 () -> assertThat(COSEAlgorithmIdentifier.create(-38)).isEqualTo(COSEAlgorithmIdentifier.PS384),
                 () -> assertThat(COSEAlgorithmIdentifier.create(-39)).isEqualTo(COSEAlgorithmIdentifier.PS512),
+                () -> assertThat(COSEAlgorithmIdentifier.create(-9)).isEqualTo(COSEAlgorithmIdentifier.ESP256),
+                () -> assertThat(COSEAlgorithmIdentifier.create(-51)).isEqualTo(COSEAlgorithmIdentifier.ESP384),
+                () -> assertThat(COSEAlgorithmIdentifier.create(-52)).isEqualTo(COSEAlgorithmIdentifier.ESP512),
                 () -> assertThat(COSEAlgorithmIdentifier.create(-1)).isEqualTo(COSEAlgorithmIdentifier.create(-1))
         );
     }
@@ -85,7 +88,10 @@ class COSEAlgorithmIdentifierTest {
                 () -> assertThat(COSEAlgorithmIdentifier.EdDSA).hasToString("EdDSA"),
                 () -> assertThat(COSEAlgorithmIdentifier.PS256).hasToString("PS256"),
                 () -> assertThat(COSEAlgorithmIdentifier.PS384).hasToString("PS384"),
-                () -> assertThat(COSEAlgorithmIdentifier.PS512).hasToString("PS512")
+                () -> assertThat(COSEAlgorithmIdentifier.PS512).hasToString("PS512"),
+                () -> assertThat(COSEAlgorithmIdentifier.ESP256).hasToString("ESP256"),
+                () -> assertThat(COSEAlgorithmIdentifier.ESP384).hasToString("ESP384"),
+                () -> assertThat(COSEAlgorithmIdentifier.ESP512).hasToString("ESP512")
         );
     }
 
@@ -96,6 +102,24 @@ class COSEAlgorithmIdentifierTest {
         assertThat(COSEAlgorithmIdentifier.RS256.getValue()).isEqualTo(-257);
     }
 
+
+    @Test
+    void toSignatureAlgorithm_with_ESP_test() {
+        assertAll(
+                () -> assertThat(COSEAlgorithmIdentifier.ESP256.toSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.ESP256),
+                () -> assertThat(COSEAlgorithmIdentifier.ESP384.toSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.ESP384),
+                () -> assertThat(COSEAlgorithmIdentifier.ESP512.toSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.ESP512)
+        );
+    }
+
+    @Test
+    void getKeyType_with_ESP_test() {
+        assertAll(
+                () -> assertThat(COSEAlgorithmIdentifier.ESP256.getKeyType()).isEqualTo(COSEKeyType.EC2),
+                () -> assertThat(COSEAlgorithmIdentifier.ESP384.getKeyType()).isEqualTo(COSEKeyType.EC2),
+                () -> assertThat(COSEAlgorithmIdentifier.ESP512.getKeyType()).isEqualTo(COSEKeyType.EC2)
+        );
+    }
 
     @Test
     void invalid_data_toSignatureAlgorithm_test() {


### PR DESCRIPTION
- Add ESP256 (-9), ESP384 (-51), and ESP512 (-52) COSE algorithm identifiers as defined in RFC 9864
- These fully-specified identifiers replace the polymorphic ES256/ES384/ES512 by uniquely binding algorithm and curve
- Reuse existing signature verification logic (SHA256withECDSA, SHA384withECDSA, SHA512withECDSA) and EC2 key type
- Replace loop-based `reverseAlgorithmMap` construction with explicit entries to ensure deterministic backward-compatible behavior when multiple COSE identifiers map to the same `SignatureAlgorithm`

Partial implementation of #1380.