### PR TITLE
Add Ed25519/Ed448 fully-specified COSE algorithm identifiers (RFC 9864)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/SignatureAlgorithmDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/SignatureAlgorithmDeserializer.java
@@ -33,6 +33,8 @@ public class SignatureAlgorithmDeserializer extends StdDeserializer<SignatureAlg
                 return SignatureAlgorithm.RS512;
             case "ed25519":
                 return SignatureAlgorithm.Ed25519;
+            case "ed448":
+                return SignatureAlgorithm.Ed448;
             case "SHA256withRSA/PSS":
                 return SignatureAlgorithm.PS256;
             case "SHA384withRSA/PSS":

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/SignatureAlgorithm.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/SignatureAlgorithm.java
@@ -56,6 +56,7 @@ public class SignatureAlgorithm {
     private static final String JCA_SHA_384_WITH_RSA = "SHA384withRSA";
     private static final String JCA_SHA_512_WITH_RSA = "SHA512withRSA";
     private static final String JCA_ED_25519 = "ed25519";
+    private static final String JCA_ED_448 = "ed448";
     private static final String JCA_RSA_SSA_PSS = "RSASSA-PSS";
 
     private static final String SHA_256_WITH_RSA_PSS = "SHA256withRSA/PSS";
@@ -76,6 +77,12 @@ public class SignatureAlgorithm {
      * Therefore, messageDigestAlgorithm is null.
      */
     public static final SignatureAlgorithm Ed25519 = new SignatureAlgorithm(JCA_ED_25519, null);
+    /**
+     * Ed448 is a pure signature scheme, like Ed25519.
+     * The message is not pre-hashed before signing.
+     * Therefore, messageDigestAlgorithm is null.
+     */
+    public static final SignatureAlgorithm Ed448 = new SignatureAlgorithm(JCA_ED_448, null);
     public static final SignatureAlgorithm PS256 = new SignatureAlgorithm(JCA_RSA_SSA_PSS, SHA256);
     public static final SignatureAlgorithm PS384 = new SignatureAlgorithm(JCA_RSA_SSA_PSS, SHA384);
     public static final SignatureAlgorithm PS512 = new SignatureAlgorithm(JCA_RSA_SSA_PSS, SHA512);
@@ -111,6 +118,8 @@ public class SignatureAlgorithm {
                 return RS512;
             case JCA_ED_25519:
                 return Ed25519;
+            case JCA_ED_448:
+                return Ed448;
             case JCA_RSA_SSA_PSS:
                 throw new IllegalArgumentException(String.format("value %s is not supported by SignatureAlgorithm.create(value). Use SignatureAlgorithm.create(jcaName, messageDigestJcaName) instead.", value));
             default:
@@ -203,6 +212,8 @@ public class SignatureAlgorithm {
                 return "RS512";
             case JCA_ED_25519:
                 return "Ed25519";
+            case JCA_ED_448:
+                return "Ed448";
             case SHA_256_WITH_RSA_PSS:
                 return "PS256";
             case SHA_384_WITH_RSA_PSS:

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/Curve.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/Curve.java
@@ -38,7 +38,11 @@ public enum Curve {
      * ED25519.getParameterSpec() is only supportred on JDK15+
      * @since JDK 15
      */
-    ED25519(6, 32);
+    ED25519(6, 32),
+    /**
+     * @since JDK 15
+     */
+    ED448(7, 57);
 
     private final int value;
     private final int size;
@@ -58,6 +62,8 @@ public enum Curve {
                 return SECP521R1;
             case 6:
                 return ED25519;
+            case 7:
+                return ED448;
             default:
                 throw new IllegalArgumentException("value '" + value + "' is out of range");
         }
@@ -93,7 +99,10 @@ public enum Curve {
                 return ECUtil.P_521_SPEC;
             case ED25519:
                 //noinspection Since15
-                return new NamedParameterSpec("Ed25519");
+                return NamedParameterSpec.ED25519;
+            case ED448:
+                //noinspection Since15
+                return NamedParameterSpec.ED448;
             default:
                 throw new IllegalStateException();
         }
@@ -110,6 +119,8 @@ public enum Curve {
                 return "SECP521R1";
             case ED25519:
                 return "ED25519";
+            case ED448:
+                return "ED448";
             default:
                 return "Unknown Curve";
         }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/EdDSACOSEKey.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/EdDSACOSEKey.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 public class EdDSACOSEKey extends AbstractCOSEKey {
 
     private static final String CURVE_NULL_CHECK_MESSAGE = "curve must not be null";
-    private static final String ALG_VALUE_CHECK_MESSAGE = "alg must be EdDSA";
+    private static final String ALG_VALUE_CHECK_MESSAGE = "alg must be EdDSA, Ed25519, or Ed448";
 
     @JsonProperty("-1")
     private final Curve curve;
@@ -68,7 +68,7 @@ public class EdDSACOSEKey extends AbstractCOSEKey {
      * @return {@link EdDSACOSEKey}
      */
     public static @NotNull EdDSACOSEKey create(@NotNull EdECPrivateKey privateKey, @Nullable COSEAlgorithmIdentifier alg) {
-        AssertUtil.isTrue(alg == COSEAlgorithmIdentifier.EdDSA, ALG_VALUE_CHECK_MESSAGE);
+        AssertUtil.isTrue(isEdDSAFamilyAlgorithm(alg), ALG_VALUE_CHECK_MESSAGE);
         byte[] d = privateKey.getBytes().orElseThrow(()-> new IllegalArgumentException("privateKey must not be null"));
         Curve curve = getCurve(privateKey.getParams());
 
@@ -90,7 +90,7 @@ public class EdDSACOSEKey extends AbstractCOSEKey {
      * @return {@link EdDSACOSEKey}
      */
     public static @NotNull EdDSACOSEKey create(@NotNull EdECPublicKey publicKey, @Nullable COSEAlgorithmIdentifier alg) {
-        AssertUtil.isTrue(alg == COSEAlgorithmIdentifier.EdDSA, ALG_VALUE_CHECK_MESSAGE);
+        AssertUtil.isTrue(isEdDSAFamilyAlgorithm(alg), ALG_VALUE_CHECK_MESSAGE);
         Curve curve = getCurve(publicKey.getParams());
         byte[] x = calcCOSEXParam(publicKey);
         return new EdDSACOSEKey(
@@ -110,7 +110,7 @@ public class EdDSACOSEKey extends AbstractCOSEKey {
      * @return {@link EdDSACOSEKey}
      */
     public static @NotNull EdDSACOSEKey create(@NotNull KeyPair keyPair, @Nullable COSEAlgorithmIdentifier alg) {
-        AssertUtil.isTrue(alg == COSEAlgorithmIdentifier.EdDSA, ALG_VALUE_CHECK_MESSAGE);
+        AssertUtil.isTrue(isEdDSAFamilyAlgorithm(alg), ALG_VALUE_CHECK_MESSAGE);
         EdECPublicKey edECPublicKey = (EdECPublicKey)keyPair.getPublic();
         EdECPrivateKey edECPrivateKey = (EdECPrivateKey) keyPair.getPrivate();
         Curve curve = getCurve(edECPublicKey.getParams());
@@ -222,12 +222,14 @@ public class EdDSACOSEKey extends AbstractCOSEKey {
         if (curve == null) {
             throw new ConstraintViolationException(CURVE_NULL_CHECK_MESSAGE);
         }
-        if (curve != Curve.ED25519) {
-            throw new ConstraintViolationException("curve must be Ed25519");
+        if (curve != Curve.ED25519 && curve != Curve.ED448) {
+            throw new ConstraintViolationException("curve must be Ed25519 or Ed448");
         }
         COSEAlgorithmIdentifier algorithm = getAlgorithm();
-        if (algorithm != null && !Objects.equals(algorithm,COSEAlgorithmIdentifier.EdDSA)) {
-            throw new ConstraintViolationException("algorithm must be EdDSA if present");
+        if (algorithm != null) {
+            if (!isEdDSAFamilyAlgorithm(algorithm)) {
+                throw new ConstraintViolationException("algorithm must be EdDSA, Ed25519, or Ed448 if present");
+            }
         }
 
         if (!hasPublicKey() && !hasPrivateKey()) {
@@ -238,12 +240,21 @@ public class EdDSACOSEKey extends AbstractCOSEKey {
         }
     }
 
+    private static boolean isEdDSAFamilyAlgorithm(COSEAlgorithmIdentifier alg) {
+        return Objects.equals(alg, COSEAlgorithmIdentifier.EdDSA) ||
+                Objects.equals(alg, COSEAlgorithmIdentifier.Ed25519) ||
+                Objects.equals(alg, COSEAlgorithmIdentifier.Ed448);
+    }
+
     static Curve getCurve(NamedParameterSpec namedParameterSpec){
         if(Objects.equals(namedParameterSpec.getName(), NamedParameterSpec.ED25519.getName())){
             return Curve.ED25519;
         }
+        else if(Objects.equals(namedParameterSpec.getName(), NamedParameterSpec.ED448.getName())){
+            return Curve.ED448;
+        }
         else {
-            throw new IllegalArgumentException(String.format("%s is not supported. Ed25519 is the only supported curve.", namedParameterSpec.getName()));
+            throw new IllegalArgumentException(String.format("%s is not supported. Ed25519 and Ed448 are the supported curves.", namedParameterSpec.getName()));
         }
     }
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifier.java
@@ -40,16 +40,28 @@ public class COSEAlgorithmIdentifier {
     public static final COSEAlgorithmIdentifier ES256;
     public static final COSEAlgorithmIdentifier ES384;
     public static final COSEAlgorithmIdentifier ES512;
-    /**
-     * EdDSA is only supported on JDK 15 or later
-     */
-    public static final COSEAlgorithmIdentifier EdDSA;
-    public static final COSEAlgorithmIdentifier PS256;
-    public static final COSEAlgorithmIdentifier PS384;
-    public static final COSEAlgorithmIdentifier PS512;
     public static final COSEAlgorithmIdentifier ESP256;
     public static final COSEAlgorithmIdentifier ESP384;
     public static final COSEAlgorithmIdentifier ESP512;
+    /**
+     * EdDSA is a polymorphic algorithm identifier that does not specify a curve.
+     * WebAuthn Level 3 §5.8.5 restricts COSEAlgorithmIdentifier.EdDSA(-8) to the Ed25519 curve (crv=6),
+     * so this identifier is treated as equivalent to {@link #Ed25519} for
+     * signature verification purposes.
+     * For Ed448, use {@link #Ed448} instead.
+     *
+     * <p>In {@code pubKeyCredParams}, this identifier is preferred over {@link #Ed25519}
+     * for backward compatibility, as many existing authenticators support -8 but not -19.
+     *
+     * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-alg-identifier">WebAuthn Level 3 §5.8.5</a>
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc9864.html">RFC 9864</a>
+     */
+    public static final COSEAlgorithmIdentifier EdDSA;
+    public static final COSEAlgorithmIdentifier Ed25519;
+    public static final COSEAlgorithmIdentifier Ed448;
+    public static final COSEAlgorithmIdentifier PS256;
+    public static final COSEAlgorithmIdentifier PS384;
+    public static final COSEAlgorithmIdentifier PS512;
 
     private static final Map<COSEAlgorithmIdentifier, COSEKeyType> keyTypeMap = new HashMap<>();
     private static final Map<COSEAlgorithmIdentifier, SignatureAlgorithm> algorithmMap = new HashMap<>();
@@ -70,6 +82,8 @@ public class COSEAlgorithmIdentifier {
         ESP256 = new COSEAlgorithmIdentifier(-9);
         ESP384 = new COSEAlgorithmIdentifier(-51);
         ESP512 = new COSEAlgorithmIdentifier(-52);
+        Ed25519 = new COSEAlgorithmIdentifier(-19);
+        Ed448 = new COSEAlgorithmIdentifier(-53);
 
         keyTypeMap.put(COSEAlgorithmIdentifier.ES256, COSEKeyType.EC2);
         keyTypeMap.put(COSEAlgorithmIdentifier.ES384, COSEKeyType.EC2);
@@ -78,6 +92,8 @@ public class COSEAlgorithmIdentifier {
         keyTypeMap.put(COSEAlgorithmIdentifier.ESP384, COSEKeyType.EC2);
         keyTypeMap.put(COSEAlgorithmIdentifier.ESP512, COSEKeyType.EC2);
         keyTypeMap.put(COSEAlgorithmIdentifier.EdDSA, COSEKeyType.OKP);
+        keyTypeMap.put(COSEAlgorithmIdentifier.Ed25519, COSEKeyType.OKP);
+        keyTypeMap.put(COSEAlgorithmIdentifier.Ed448, COSEKeyType.OKP);
         keyTypeMap.put(COSEAlgorithmIdentifier.RS1, COSEKeyType.RSA);
         keyTypeMap.put(COSEAlgorithmIdentifier.RS256, COSEKeyType.RSA);
         keyTypeMap.put(COSEAlgorithmIdentifier.RS384, COSEKeyType.RSA);
@@ -92,7 +108,10 @@ public class COSEAlgorithmIdentifier {
         algorithmMap.put(COSEAlgorithmIdentifier.ESP256, SignatureAlgorithm.ESP256);
         algorithmMap.put(COSEAlgorithmIdentifier.ESP384, SignatureAlgorithm.ESP384);
         algorithmMap.put(COSEAlgorithmIdentifier.ESP512, SignatureAlgorithm.ESP512);
+        // WebAuthn Level 3 §5.8.5 restricts COSEAlgorithmIdentifier.EdDSA(-8) to Ed25519 curve
         algorithmMap.put(COSEAlgorithmIdentifier.EdDSA, SignatureAlgorithm.Ed25519);
+        algorithmMap.put(COSEAlgorithmIdentifier.Ed25519, SignatureAlgorithm.Ed25519);
+        algorithmMap.put(COSEAlgorithmIdentifier.Ed448, SignatureAlgorithm.Ed448);
         algorithmMap.put(COSEAlgorithmIdentifier.RS1, SignatureAlgorithm.RS1);
         algorithmMap.put(COSEAlgorithmIdentifier.RS256, SignatureAlgorithm.RS256);
         algorithmMap.put(COSEAlgorithmIdentifier.RS384, SignatureAlgorithm.RS384);
@@ -104,7 +123,8 @@ public class COSEAlgorithmIdentifier {
         reverseAlgorithmMap.put(SignatureAlgorithm.ES256, COSEAlgorithmIdentifier.ES256);
         reverseAlgorithmMap.put(SignatureAlgorithm.ES384, COSEAlgorithmIdentifier.ES384);
         reverseAlgorithmMap.put(SignatureAlgorithm.ES512, COSEAlgorithmIdentifier.ES512);
-        reverseAlgorithmMap.put(SignatureAlgorithm.Ed25519, COSEAlgorithmIdentifier.EdDSA);
+        reverseAlgorithmMap.put(SignatureAlgorithm.Ed25519, COSEAlgorithmIdentifier.Ed25519);
+        reverseAlgorithmMap.put(SignatureAlgorithm.Ed448, COSEAlgorithmIdentifier.Ed448);
         reverseAlgorithmMap.put(SignatureAlgorithm.RS1, COSEAlgorithmIdentifier.RS1);
         reverseAlgorithmMap.put(SignatureAlgorithm.RS256, COSEAlgorithmIdentifier.RS256);
         reverseAlgorithmMap.put(SignatureAlgorithm.RS384, COSEAlgorithmIdentifier.RS384);
@@ -197,8 +217,23 @@ public class COSEAlgorithmIdentifier {
         else if(value == ES512.value){
             return "ES512";
         }
+        else if(value == ESP256.value){
+            return "ESP256";
+        }
+        else if(value == ESP384.value){
+            return "ESP384";
+        }
+        else if(value == ESP512.value){
+            return "ESP512";
+        }
         else if(value == EdDSA.value){
             return "EdDSA";
+        }
+        else if(value == Ed25519.value){
+            return "Ed25519";
+        }
+        else if(value == Ed448.value){
+            return "Ed448";
         }
         else if(value == PS256.value){
             return "PS256";
@@ -208,15 +243,6 @@ public class COSEAlgorithmIdentifier {
         }
         else if(value == PS512.value){
             return "PS512";
-        }
-        else if(value == ESP256.value){
-            return "ESP256";
-        }
-        else if(value == ESP384.value){
-            return "ESP384";
-        }
-        else if(value == ESP512.value){
-            return "ESP512";
         }
         else {
             return String.format("Unknown COSEAlgorithmIdentifier(%d)", value);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/CurveTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/CurveTest.java
@@ -42,6 +42,7 @@ class CurveTest {
                 () -> assertThat(Curve.create(2)).isEqualTo(Curve.SECP384R1),
                 () -> assertThat(Curve.create(3)).isEqualTo(Curve.SECP521R1),
                 () -> assertThat(Curve.create(6)).isEqualTo(Curve.ED25519),
+                () -> assertThat(Curve.create(7)).isEqualTo(Curve.ED448),
                 () -> assertThatThrownBy(() -> Curve.create(4)).isInstanceOf(IllegalArgumentException.class)
         );
     }
@@ -67,7 +68,8 @@ class CurveTest {
                 () -> assertThat(Curve.SECP256R1.getParameterSpec()).isEqualTo(ECUtil.P_256_SPEC),
                 () -> assertThat(Curve.SECP384R1.getParameterSpec()).isEqualTo(ECUtil.P_384_SPEC),
                 () -> assertThat(Curve.SECP521R1.getParameterSpec()).isEqualTo(ECUtil.P_521_SPEC),
-                () -> assertThat(((NamedParameterSpec)Curve.ED25519.getParameterSpec()).getName()).isEqualTo(NamedParameterSpec.ED25519.getName())
+                () -> assertThat(Curve.ED25519.getParameterSpec()).isSameAs(NamedParameterSpec.ED25519),
+                () -> assertThat(Curve.ED448.getParameterSpec()).isSameAs(NamedParameterSpec.ED448)
         );
     }
 
@@ -79,7 +81,8 @@ class CurveTest {
                 () -> assertThat(Curve.SECP256R1).hasToString("SECP256R1"),
                 () -> assertThat(Curve.SECP384R1).hasToString("SECP384R1"),
                 () -> assertThat(Curve.SECP521R1).hasToString("SECP521R1"),
-                () -> assertThat(Curve.ED25519).hasToString("ED25519")
+                () -> assertThat(Curve.ED25519).hasToString("ED25519"),
+                () -> assertThat(Curve.ED448).hasToString("ED448")
         );
     }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EdDSACOSEKeyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EdDSACOSEKeyTest.java
@@ -226,6 +226,61 @@ class EdDSACOSEKeyTest {
 
 
     @Test
+    void ed448_keyPair_test(){
+        // Given
+        KeyPair keyPair = EdDSAUtil.createEd448KeyPair();
+
+        // When
+        COSEKey coseKey = EdDSACOSEKey.create(keyPair, COSEAlgorithmIdentifier.Ed448);
+
+        // Then
+        assertThat(coseKey.hasPublicKey()).isTrue();
+        assertThat(coseKey.hasPrivateKey()).isTrue();
+        assertThat(coseKey.getPublicKey().getEncoded()).isEqualTo(keyPair.getPublic().getEncoded());
+        assertThat(coseKey.getPrivateKey().getEncoded()).isEqualTo(keyPair.getPrivate().getEncoded());
+    }
+
+    @Test
+    void validate_with_ed448_curve_and_EdDSA_algorithm_test() {
+        // Given
+        KeyPair keyPair = EdDSAUtil.createEd448KeyPair();
+        EdDSACOSEKey instance = EdDSACOSEKey.create(keyPair, COSEAlgorithmIdentifier.EdDSA);
+
+        // When
+        // Then
+        assertThatCode(instance::validate).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_with_ed448_curve_and_Ed448_algorithm_test() {
+        // Given
+        KeyPair keyPair = EdDSAUtil.createEd448KeyPair();
+        EdDSACOSEKey instance = EdDSACOSEKey.create(keyPair, COSEAlgorithmIdentifier.Ed448);
+
+        // When
+        // Then
+        assertThatCode(instance::validate).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_with_ed25519_curve_and_Ed25519_algorithm_test() {
+        // Given
+        KeyPair keyPair = EdDSAUtil.createEd25519KeyPair();
+        EdDSACOSEKey instance = EdDSACOSEKey.create(keyPair, COSEAlgorithmIdentifier.Ed25519);
+
+        // When
+        // Then
+        assertThatCode(instance::validate).doesNotThrowAnyException();
+    }
+
+    @Test
+    void getCurve_ed448_test(){
+        // When
+        // Then
+        assertThat(EdDSACOSEKey.getCurve(NamedParameterSpec.ED448)).isEqualTo(Curve.ED448);
+    }
+
+    @Test
     void getCurve_not_supported_curve_test(){
         // When
         // Then

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
@@ -50,6 +50,8 @@ class COSEAlgorithmIdentifierTest {
                 () -> assertThat(COSEAlgorithmIdentifier.create(-9)).isEqualTo(COSEAlgorithmIdentifier.ESP256),
                 () -> assertThat(COSEAlgorithmIdentifier.create(-51)).isEqualTo(COSEAlgorithmIdentifier.ESP384),
                 () -> assertThat(COSEAlgorithmIdentifier.create(-52)).isEqualTo(COSEAlgorithmIdentifier.ESP512),
+                () -> assertThat(COSEAlgorithmIdentifier.create(-19)).isEqualTo(COSEAlgorithmIdentifier.Ed25519),
+                () -> assertThat(COSEAlgorithmIdentifier.create(-53)).isEqualTo(COSEAlgorithmIdentifier.Ed448),
                 () -> assertThat(COSEAlgorithmIdentifier.create(-1)).isEqualTo(COSEAlgorithmIdentifier.create(-1))
         );
     }
@@ -66,7 +68,7 @@ class COSEAlgorithmIdentifierTest {
                 () -> assertThat(COSEAlgorithmIdentifier.create(SignatureAlgorithm.ES256)).isEqualTo(COSEAlgorithmIdentifier.ES256),
                 () -> assertThat(COSEAlgorithmIdentifier.create(SignatureAlgorithm.ES384)).isEqualTo(COSEAlgorithmIdentifier.ES384),
                 () -> assertThat(COSEAlgorithmIdentifier.create(SignatureAlgorithm.ES512)).isEqualTo(COSEAlgorithmIdentifier.ES512),
-                () -> assertThat(COSEAlgorithmIdentifier.create(SignatureAlgorithm.Ed25519)).isEqualTo(COSEAlgorithmIdentifier.EdDSA),
+                () -> assertThat(COSEAlgorithmIdentifier.create(SignatureAlgorithm.Ed25519)).isEqualTo(COSEAlgorithmIdentifier.Ed25519),
                 () -> assertThat(COSEAlgorithmIdentifier.create(SignatureAlgorithm.PS256)).isEqualTo(COSEAlgorithmIdentifier.PS256),
                 () -> assertThat(COSEAlgorithmIdentifier.create(SignatureAlgorithm.PS384)).isEqualTo(COSEAlgorithmIdentifier.PS384),
                 () -> assertThat(COSEAlgorithmIdentifier.create(SignatureAlgorithm.PS512)).isEqualTo(COSEAlgorithmIdentifier.PS512)
@@ -91,7 +93,9 @@ class COSEAlgorithmIdentifierTest {
                 () -> assertThat(COSEAlgorithmIdentifier.PS512).hasToString("PS512"),
                 () -> assertThat(COSEAlgorithmIdentifier.ESP256).hasToString("ESP256"),
                 () -> assertThat(COSEAlgorithmIdentifier.ESP384).hasToString("ESP384"),
-                () -> assertThat(COSEAlgorithmIdentifier.ESP512).hasToString("ESP512")
+                () -> assertThat(COSEAlgorithmIdentifier.ESP512).hasToString("ESP512"),
+                () -> assertThat(COSEAlgorithmIdentifier.Ed25519).hasToString("Ed25519"),
+                () -> assertThat(COSEAlgorithmIdentifier.Ed448).hasToString("Ed448")
         );
     }
 
@@ -104,20 +108,24 @@ class COSEAlgorithmIdentifierTest {
 
 
     @Test
-    void toSignatureAlgorithm_with_ESP_test() {
+    void toSignatureAlgorithm_with_fully_specified_test() {
         assertAll(
                 () -> assertThat(COSEAlgorithmIdentifier.ESP256.toSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.ESP256),
                 () -> assertThat(COSEAlgorithmIdentifier.ESP384.toSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.ESP384),
-                () -> assertThat(COSEAlgorithmIdentifier.ESP512.toSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.ESP512)
+                () -> assertThat(COSEAlgorithmIdentifier.ESP512.toSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.ESP512),
+                () -> assertThat(COSEAlgorithmIdentifier.Ed25519.toSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.Ed25519),
+                () -> assertThat(COSEAlgorithmIdentifier.Ed448.toSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.Ed448)
         );
     }
 
     @Test
-    void getKeyType_with_ESP_test() {
+    void getKeyType_with_fully_specified_test() {
         assertAll(
                 () -> assertThat(COSEAlgorithmIdentifier.ESP256.getKeyType()).isEqualTo(COSEKeyType.EC2),
                 () -> assertThat(COSEAlgorithmIdentifier.ESP384.getKeyType()).isEqualTo(COSEKeyType.EC2),
-                () -> assertThat(COSEAlgorithmIdentifier.ESP512.getKeyType()).isEqualTo(COSEKeyType.EC2)
+                () -> assertThat(COSEAlgorithmIdentifier.ESP512.getKeyType()).isEqualTo(COSEKeyType.EC2),
+                () -> assertThat(COSEAlgorithmIdentifier.Ed25519.getKeyType()).isEqualTo(COSEKeyType.OKP),
+                () -> assertThat(COSEAlgorithmIdentifier.Ed448.getKeyType()).isEqualTo(COSEKeyType.OKP)
         );
     }
 

--- a/webauthn4j-core/src/test/java/test/EdDSAUtil.java
+++ b/webauthn4j-core/src/test/java/test/EdDSAUtil.java
@@ -10,8 +10,21 @@ import java.security.NoSuchAlgorithmException;
 public class EdDSAUtil {
 
     public static @NotNull KeyPair createKeyPair() {
+        return createEd25519KeyPair();
+    }
+
+    public static @NotNull KeyPair createEd25519KeyPair() {
         try {
             KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("Ed25519");
+            return keyPairGenerator.generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new UnexpectedCheckedException(e);
+        }
+    }
+
+    public static @NotNull KeyPair createEd448KeyPair() {
+        try {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("Ed448");
             return keyPairGenerator.generateKeyPair();
         } catch (NoSuchAlgorithmException e) {
             throw new UnexpectedCheckedException(e);


### PR DESCRIPTION
RFC 9864 introduces fully-specified COSE algorithm identifiers to solve the problem
that polymorphic identifiers like EdDSA(-8) cannot be used for algorithm negotiation —
EdDSA alone does not tell whether Ed25519 or Ed448 is supported.

WebAuthn Level 3 §5.8.5 already worked around this by restricting EdDSA(-8) to
Ed25519 (crv=6). This means Ed448 can only be negotiated via the new Ed448(-53)
identifier. This PR adds Ed25519(-19) and Ed448(-53) to formalize these bindings.

EdDSA(-8) continues to map to SignatureAlgorithm.Ed25519, following the WebAuthn
restriction. SignatureAlgorithm has no EdDSA constant — it is a fully-specified type,
and the polymorphic concept exists only at the COSEAlgorithmIdentifier level.

Completes #1380.