### PR TITLE
Add CBOR canonical serializer for PublicKeyCredentialParameters

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
@@ -84,6 +84,7 @@ public class WebAuthnCBORModule extends SimpleModule {
         this.addDeserializer(JWS.class, new JWSDeserializer(objectConverter));
         this.addSerializer(new PackedAttestationStatementSerializer());
         this.addSerializer(new PublicKeyCredentialDescriptorSerializer());
+        this.addSerializer(new PublicKeyCredentialParametersSerializer());
         this.addSerializer(new RSACOSEKeySerializer());
         this.addSerializer(new TPMAttestationStatementSerializer());
         this.addSerializer(new TPMSAttestSerializer());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialParametersSerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialParametersSerializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.serializer.cbor;
+
+import com.webauthn4j.data.PublicKeyCredentialParameters;
+
+import java.util.Arrays;
+
+public class PublicKeyCredentialParametersSerializer extends AbstractCtapCanonicalCborSerializer<PublicKeyCredentialParameters> {
+
+    public PublicKeyCredentialParametersSerializer() {
+        super(PublicKeyCredentialParameters.class, Arrays.asList(
+                new FieldSerializationRule<>("alg", PublicKeyCredentialParameters::getAlg),
+                new FieldSerializationRule<>("type", PublicKeyCredentialParameters::getType)
+        ));
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialParametersTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialParametersTest.java
@@ -21,6 +21,7 @@ import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.exc.ValueInstantiationException;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.cbor.CBORMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class PublicKeyCredentialParametersTest {
 
-    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+    private final ObjectConverter objectConverter = new ObjectConverter();
+    private final JsonMapper jsonMapper = objectConverter.getJsonMapper();
+    private final CBORMapper cborMapper = objectConverter.getCborMapper();
 
     @Test
     void deserialize_test_with_invalid_value() {
@@ -47,6 +50,15 @@ class PublicKeyCredentialParametersTest {
                 () -> assertThat(parameters.getType()).isEqualTo(PublicKeyCredentialType.PUBLIC_KEY),
                 () -> assertThat(parameters.getAlg()).isEqualTo(COSEAlgorithmIdentifier.ES256)
         );
+    }
+
+    @Test
+    void cbor_serialize_deserialize_test() {
+        PublicKeyCredentialParameters original =
+                new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256);
+        byte[] encoded = cborMapper.writeValueAsBytes(original);
+        PublicKeyCredentialParameters decoded = cborMapper.readValue(encoded, PublicKeyCredentialParameters.class);
+        assertThat(decoded).isEqualTo(original);
     }
 
     @Test


### PR DESCRIPTION
Without a custom serializer, Jackson outputs map keys in field declaration order (`type`, `alg`), which violates CTAP2 canonical CBOR encoding (shorter keys first). This causes FIDO conformance test failures with "Response CBOR is not canonical".

Add `PublicKeyCredentialParametersSerializer` that emits `"alg"` (3 bytes) before `"type"` (4 bytes), following the same `AbstractCtapCanonicalCborSerializer` pattern used by `PublicKeyCredentialDescriptorSerializer`.