### PR TITLE
Reject non-integer values in COSEAlgorithmIdentifierDeserializer

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/COSEAlgorithmIdentifierDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/COSEAlgorithmIdentifierDeserializer.java
@@ -3,8 +3,10 @@ package com.webauthn4j.converter.jackson.deserializer.cbor;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import org.jetbrains.annotations.NotNull;
 import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.exc.InvalidFormatException;
 
 public class COSEAlgorithmIdentifierDeserializer extends StdDeserializer<COSEAlgorithmIdentifier> {
 
@@ -14,6 +16,9 @@ public class COSEAlgorithmIdentifierDeserializer extends StdDeserializer<COSEAlg
 
     @Override
     public COSEAlgorithmIdentifier deserialize(@NotNull JsonParser p, @NotNull DeserializationContext ctxt) {
+        if (p.currentToken() != JsonToken.VALUE_NUMBER_INT) {
+            throw InvalidFormatException.from(p, "Expected an integer value for COSEAlgorithmIdentifier", p.getText(), COSEAlgorithmIdentifier.class);
+        }
         long value = p.getValueAsLong();
         return COSEAlgorithmIdentifier.create(value);
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/COSEAlgorithmIdentifierDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/COSEAlgorithmIdentifierDeserializer.java
@@ -16,17 +16,8 @@ public class COSEAlgorithmIdentifierDeserializer extends StdDeserializer<COSEAlg
 
     @Override
     public COSEAlgorithmIdentifier deserialize(@NotNull JsonParser p, @NotNull DeserializationContext ctxt) {
-        if (p.currentToken() == JsonToken.VALUE_STRING) {
-            String text = p.getText();
-            try {
-                long value = Long.parseLong(text);
-                return COSEAlgorithmIdentifier.create(value);
-            } catch (NumberFormatException e) {
-                throw InvalidFormatException.from(p, "Expected a numeric value for COSEAlgorithmIdentifier", text, COSEAlgorithmIdentifier.class);
-            }
-        }
         if (p.currentToken() != JsonToken.VALUE_NUMBER_INT) {
-            throw InvalidFormatException.from(p, "Expected a numeric value for COSEAlgorithmIdentifier", p.getText(), COSEAlgorithmIdentifier.class);
+            throw InvalidFormatException.from(p, "Expected an integer value for COSEAlgorithmIdentifier", p.getText(), COSEAlgorithmIdentifier.class);
         }
         long value = p.getValueAsLong();
         return COSEAlgorithmIdentifier.create(value);

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/cbor/COSEAlgorithmIdentifierDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/cbor/COSEAlgorithmIdentifierDeserializerTest.java
@@ -1,0 +1,40 @@
+package com.webauthn4j.converter.jackson.deserializer.cbor;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.exc.InvalidFormatException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class COSEAlgorithmIdentifierDeserializerTest {
+
+    private final ObjectConverter objectConverter = new ObjectConverter();
+
+    @Test
+    void deserialize_with_integer_value() {
+        var cborMapper = objectConverter.getCborMapper();
+        byte[] cborNeg7 = new byte[]{0x26}; // CBOR integer -7
+        var result = cborMapper.readValue(cborNeg7, COSEAlgorithmIdentifier.class);
+        assertThat(result).isEqualTo(COSEAlgorithmIdentifier.ES256);
+    }
+
+    @Test
+    void deserialize_with_string_value_should_throw() {
+        var cborMapper = objectConverter.getCborMapper();
+        byte[] cborString = new byte[]{0x62, 0x2D, 0x37}; // CBOR text string "-7"
+        assertThrows(InvalidFormatException.class, () ->
+                cborMapper.readValue(cborString, COSEAlgorithmIdentifier.class)
+        );
+    }
+
+    @Test
+    void deserialize_with_boolean_value_should_throw() {
+        var cborMapper = objectConverter.getCborMapper();
+        byte[] cborTrue = new byte[]{(byte) 0xF5}; // CBOR true
+        assertThrows(InvalidFormatException.class, () ->
+                cborMapper.readValue(cborTrue, COSEAlgorithmIdentifier.class)
+        );
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/json/COSEAlgorithmIdentifierDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/json/COSEAlgorithmIdentifierDeserializerTest.java
@@ -1,0 +1,37 @@
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.exc.InvalidFormatException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class COSEAlgorithmIdentifierDeserializerTest {
+
+    private final ObjectConverter objectConverter = new ObjectConverter();
+
+    @Test
+    void deserialize_with_integer_value() {
+        var jsonMapper = objectConverter.getJsonMapper();
+        var result = jsonMapper.readValue("-7", COSEAlgorithmIdentifier.class);
+        assertThat(result).isEqualTo(COSEAlgorithmIdentifier.ES256);
+    }
+
+    @Test
+    void deserialize_with_string_value_should_throw() {
+        var jsonMapper = objectConverter.getJsonMapper();
+        assertThrows(InvalidFormatException.class, () ->
+                jsonMapper.readValue("\"-7\"", COSEAlgorithmIdentifier.class)
+        );
+    }
+
+    @Test
+    void deserialize_with_boolean_value_should_throw() {
+        var jsonMapper = objectConverter.getJsonMapper();
+        assertThrows(InvalidFormatException.class, () ->
+                jsonMapper.readValue("true", COSEAlgorithmIdentifier.class)
+        );
+    }
+}


### PR DESCRIPTION
Both JSON and CBOR deserializers previously accepted non-integer values for COSEAlgorithmIdentifier (e.g., string "-7" coerced to integer -7). This violates the WebAuthn and CTAP specs which require alg to be an integer type. Now both deserializers check the token type and reject non-integer values with InvalidFormatException.