### PR TITLE
Group CodeQL action updates into a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
       interval: daily
     labels:
       - "dev-dependencies"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
Dependabot creates separate PRs for `github/codeql-action/init` and `github/codeql-action/analyze`, causing CI failures due to version mismatch when only one is merged. This adds a Dependabot group to combine all `github/codeql-action/*` updates into a single PR.