### PR TITLE
Add explicit assertions to tests missing them

### DIFF
--- a/webauthn4j-core/src/test/java/com/webauthn4j/util/AssertUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/util/AssertUtilTest.java
@@ -23,66 +23,61 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AssertUtilTest {
 
     @Test
     void notNull_test() {
         Object object = new Object();
-        AssertUtil.notNull(object, "message");
+        assertThatCode(() -> AssertUtil.notNull(object, "message")).doesNotThrowAnyException();
     }
 
     @Test
     void notNull_test_with_null() {
-        Throwable t = assertThrows(IllegalArgumentException.class,
-                () -> AssertUtil.notNull(null, "message")
-        );
-        assertThat(t).hasMessage("message");
+        assertThatThrownBy(() -> AssertUtil.notNull(null, "message"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("message");
     }
 
     @Test
     void notEmpty_test_with_list() {
-        AssertUtil.notEmpty(Collections.singletonList(new Object()), "message");
+        assertThatCode(() -> AssertUtil.notEmpty(Collections.singletonList(new Object()), "message")).doesNotThrowAnyException();
     }
 
     @Test
     void notEmpty_test_with_array() {
-        AssertUtil.notEmpty(Arrays.array(new Object()), "message");
+        assertThatCode(() -> AssertUtil.notEmpty(Arrays.array(new Object()), "message")).doesNotThrowAnyException();
     }
 
     @Test
     void notEmpty_test_with_null_as_set() {
-        Throwable t = assertThrows(IllegalArgumentException.class,
-                () -> AssertUtil.notEmpty((Set<?>) null, "message")
-        );
-        assertThat(t).hasMessage("message");
+        assertThatThrownBy(() -> AssertUtil.notEmpty((Set<?>) null, "message"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("message");
     }
 
     @Test
     void notEmpty_test_with_null_as_array() {
-        Throwable t = assertThrows(IllegalArgumentException.class,
-                () -> AssertUtil.notEmpty((Object[]) null, "message")
-        );
-        assertThat(t).hasMessage("message");
+        assertThatThrownBy(() -> AssertUtil.notEmpty((Object[]) null, "message"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("message");
     }
 
     @Test
     void notEmpty_test_with_empty_set() {
-        Throwable t = assertThrows(IllegalArgumentException.class,
-                () -> AssertUtil.notEmpty(new HashSet<>(), "message")
-        );
-        assertThat(t).hasMessage("message");
+        assertThatThrownBy(() -> AssertUtil.notEmpty(new HashSet<>(), "message"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("message");
     }
 
     @Test
     void notEmpty_test_with_empty_array() {
         Object[] value = new Object[0];
-        Throwable t = assertThrows(IllegalArgumentException.class,
-                () -> AssertUtil.notEmpty(value, "message")
-        );
-        assertThat(t).hasMessage("message");
+        assertThatThrownBy(() -> AssertUtil.notEmpty(value, "message"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("message");
     }
 
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/util/CertificateUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/util/CertificateUtilTest.java
@@ -25,7 +25,7 @@ import java.security.cert.X509Certificate;
 import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 class CertificateUtilTest {
@@ -47,14 +47,13 @@ class CertificateUtilTest {
     @Test
     void createPKIXParameters_test_with_empty_trustAnchors() {
         HashSet<TrustAnchor> trustAnchors = new HashSet<>();
-        Throwable t = assertThrows(IllegalArgumentException.class,
-                () -> CertificateUtil.createPKIXParameters(trustAnchors)
-        );
-        assertThat(t).hasMessage("trustAnchors is required; it must not be empty");
+        assertThatThrownBy(() -> CertificateUtil.createPKIXParameters(trustAnchors))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("trustAnchors is required; it must not be empty");
     }
 
     @Test
     void createKeystore_test() {
-        CertificateUtil.createKeyStore();
+        assertThat(CertificateUtil.createKeyStore()).isNotNull();
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/util/SignatureUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/util/SignatureUtilTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("ConstantConditions")
 class SignatureUtilTest {
@@ -40,25 +40,23 @@ class SignatureUtilTest {
         @Deprecated
         @Test
         void createSignature_test() {
-            SignatureUtil.createSignature("SHA256withRSA");
+            assertThat(SignatureUtil.createSignature("SHA256withRSA").getAlgorithm()).isEqualTo("SHA256withRSA");
         }
 
         @Deprecated
         @Test
         void createSignature_test_with_null() {
-            Throwable t = assertThrows(IllegalArgumentException.class,
-                    () -> SignatureUtil.createSignature((String) null)
-            );
-            assertThat(t).hasMessage("algorithm is required; it must not be null");
+            assertThatThrownBy(() -> SignatureUtil.createSignature((String) null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("algorithm is required; it must not be null");
         }
 
         @Deprecated
         @Test
         void createSignature_test_with_illegal_argument() {
-            Throwable t = assertThrows(IllegalArgumentException.class,
-                    () -> SignatureUtil.createSignature("dummyAlg")
-            );
-            assertThat(t).hasMessageContaining("dummyAlg Signature not available");
+            assertThatThrownBy(() -> SignatureUtil.createSignature("dummyAlg"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("dummyAlg Signature not available");
         }
 
     }


### PR DESCRIPTION
Tests for happy-path scenarios in AssertUtil, CertificateUtil, and SignatureUtil had no explicit assertions, relying on implicit "no exception thrown" behavior.

- `AssertUtilTest`: wrap void method calls (`notNull`, `notEmpty`) with `assertDoesNotThrow`
- `CertificateUtilTest`: assert `createKeyStore()` returns non-null
- `SignatureUtilTest`: assert `createSignature()` returns the correct algorithm, consistent with existing `createRS256_test`/`createES256_test` patterns