### PR TITLE
Avoid redundant getActualTypeArguments() call in AbstractStatementVerifier

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/attestation/statement/AbstractStatementVerifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/attestation/statement/AbstractStatementVerifier.java
@@ -34,11 +34,11 @@ public abstract class AbstractStatementVerifier<T extends AttestationStatement> 
 
     protected AbstractStatementVerifier() {
         ParameterizedType parameterizedType = (ParameterizedType) getClass().getGenericSuperclass();
-        if (parameterizedType.getActualTypeArguments().length == 0) {
-            // Throw an exception if the class is not extending AttestationStatement
+        Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+        if (actualTypeArguments.length == 0) {
             throw new IllegalStateException("Inheriting class must extend AttestationStatement");
         }
-        Type actualTypeArgument = parameterizedType.getActualTypeArguments()[0];
+        Type actualTypeArgument = actualTypeArguments[0];
 
         if (actualTypeArgument instanceof Class) {
             this.parameterizedTypeClass = (Class<?>) actualTypeArgument;


### PR DESCRIPTION
Store the result of `getActualTypeArguments()` in a local variable so the bounds check and the element access operate on the same array, instead of calling the method twice.

SonarCloud flags the double call as an `ArrayIndexOutOfBoundsException` risk (the check-then-act pattern on separate method calls), which is a false positive in this case since `ParameterizedType.getActualTypeArguments()` is a pure accessor. This change eliminates the false positive.