### PR TITLE
Remove contradictory @Nullable from assertRpIdHash parameter

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AuthenticatorData.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/authenticator/AuthenticatorData.java
@@ -191,7 +191,7 @@ public class AuthenticatorData<T extends ExtensionAuthenticatorOutput> {
                 ')';
     }
 
-    private void assertRpIdHash(@Nullable @NotNull byte[] rpIdHash) {
+    private void assertRpIdHash(@NotNull byte[] rpIdHash) {
         AssertUtil.notNull(rpIdHash, "rpIdHash must not be null");
     }
 }


### PR DESCRIPTION
The `assertRpIdHash` parameter in `AuthenticatorData` had both `@Nullable` and `@NotNull` annotations simultaneously. Since all callers (constructors) declare the parameter as `@NotNull`, keep only `@NotNull`.