### PR TITLE
Use idiomatic AssertJ assertions in test classes

### DIFF
--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/ClientCapabilityTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/ClientCapabilityTest.java
@@ -75,8 +75,8 @@ class ClientCapabilityTest {
 
     @Test
     void toString_test() {
-        assertThat(ClientCapability.CONDITIONAL_CREATE.toString()).isEqualTo("conditionalCreate");
-        assertThat(ClientCapability.HYBRID_TRANSPORT.toString()).isEqualTo("hybridTransport");
+        assertThat(ClientCapability.CONDITIONAL_CREATE).hasToString("conditionalCreate");
+        assertThat(ClientCapability.HYBRID_TRANSPORT).hasToString("hybridTransport");
     }
 
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/PinProtocolVersionTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/PinProtocolVersionTest.java
@@ -40,9 +40,10 @@ class PinProtocolVersionTest {
         PinProtocolVersion instanceB = new PinProtocolVersion(1);
         PinProtocolVersion instanceC = PinProtocolVersion.create(2);
 
-        assertThat(instanceA).isEqualTo(PinProtocolVersion.VERSION_1);
-        assertThat(instanceA).isEqualTo(instanceB);
-        assertThat(instanceA).hasSameHashCodeAs(instanceB);
+        assertThat(instanceA)
+                .isEqualTo(PinProtocolVersion.VERSION_1)
+                .isEqualTo(instanceB)
+                .hasSameHashCodeAs(instanceB);
 
         assertThat(instanceA).isNotEqualTo(instanceC);
     }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/authenticator/HMACGetSecretAuthenticatorInputTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/authenticator/HMACGetSecretAuthenticatorInputTest.java
@@ -62,11 +62,8 @@ class HMACGetSecretAuthenticatorInputTest {
         HMACGetSecretAuthenticatorInput instanceB = new HMACGetSecretAuthenticatorInput(key, new byte[32], new byte[32], PinProtocolVersion.VERSION_2);
         HMACGetSecretAuthenticatorInput instanceC = new HMACGetSecretAuthenticatorInput(key, new byte[32], new byte[32], null);
 
-        assertThat(instanceA).isNotEqualTo(instanceB);
-        assertThat(instanceA).doesNotHaveSameHashCodeAs(instanceB);
-
-        assertThat(instanceA).isNotEqualTo(instanceC);
-        assertThat(instanceA).doesNotHaveSameHashCodeAs(instanceC);
+        assertThat(instanceA).isNotEqualTo(instanceB).doesNotHaveSameHashCodeAs(instanceB);
+        assertThat(instanceA).isNotEqualTo(instanceC).doesNotHaveSameHashCodeAs(instanceC);
     }
 
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobInputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobInputsTest.java
@@ -69,8 +69,7 @@ class AuthenticationExtensionsLargeBlobInputsTest {
         AuthenticationExtensionsLargeBlobInputs b = new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.REQUIRED, null, null);
         AuthenticationExtensionsLargeBlobInputs c = new AuthenticationExtensionsLargeBlobInputs(LargeBlobSupport.PREFERRED, null, null);
 
-        assertThat(a).isEqualTo(b).isNotEqualTo(c).isNotEqualTo(null);
-        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b).isNotEqualTo(c).isNotEqualTo(null);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobOutputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsLargeBlobOutputsTest.java
@@ -69,8 +69,7 @@ class AuthenticationExtensionsLargeBlobOutputsTest {
         AuthenticationExtensionsLargeBlobOutputs c = new AuthenticationExtensionsLargeBlobOutputs(false, null, null);
         AuthenticationExtensionsLargeBlobOutputs d = new AuthenticationExtensionsLargeBlobOutputs(null, new byte[]{1}, null);
 
-        assertThat(a).isEqualTo(b).isNotEqualTo(c).isNotEqualTo(d).isNotEqualTo(null);
-        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b).isNotEqualTo(c).isNotEqualTo(d).isNotEqualTo(null);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/util/ECUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/util/ECUtilTest.java
@@ -31,8 +31,9 @@ class ECUtilTest {
     void createUncompressedPublicKey_test() {
         ECPublicKey publicKey = (ECPublicKey) TestAttestationUtil.load2tierTestRootCAPublicKey();
         byte[] uncompressed = ECUtil.createUncompressedPublicKey(publicKey);
-        assertThat(uncompressed).hasSize(65);
-        assertThat(uncompressed).isEqualTo(Base64UrlUtil.decode("BM13LrnFulQ14TNByrUKAXrIakbDx5QPf5R2W_nKOOtoLboP5lWJSpgo-sE6dY0XGTkXvOkeVmVGjDNBQITd_yI"));
+        assertThat(uncompressed)
+                .hasSize(65)
+                .isEqualTo(Base64UrlUtil.decode("BM13LrnFulQ14TNByrUKAXrIakbDx5QPf5R2W_nKOOtoLboP5lWJSpgo-sE6dY0XGTkXvOkeVmVGjDNBQITd_yI"));
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/util/UUIDUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/util/UUIDUtilTest.java
@@ -27,6 +27,6 @@ class UUIDUtilTest {
     @Test
     void fromString_test() {
         UUID uuid = UUIDUtil.fromString("015bdc7e-ee2c-4344-831d-b419abc928cd");
-        assertThat(uuid.toString()).isEqualTo("015bdc7e-ee2c-4344-831d-b419abc928cd");
+        assertThat(uuid).hasToString("015bdc7e-ee2c-4344-831d-b419abc928cd");
     }
 }

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
@@ -124,29 +124,30 @@ class AuthenticatorGetInfoTest {
         AuthenticatorGetInfo.Options options = jsonMapper.readValue(ALL_OPTIONS_JSON, AuthenticatorGetInfo.Options.class);
         String json = jsonMapper.writeValueAsString(options);
 
-        assertThat(json).contains("\"plat\":false");
-        assertThat(json).contains("\"rk\":true");
-        assertThat(json).contains("\"clientPin\":true");
-        assertThat(json).contains("\"up\":true");
-        assertThat(json).contains("\"uv\":true");
-        assertThat(json).contains("\"pinUvAuthToken\":true");
-        assertThat(json).contains("\"noMcGaPermissionsWithClientPin\":true");
-        assertThat(json).contains("\"largeBlobs\":true");
-        assertThat(json).contains("\"ep\":true");
-        assertThat(json).contains("\"bioEnroll\":true");
-        assertThat(json).contains("\"userVerificationMgmtPreview\":true");
-        assertThat(json).contains("\"uvBioEnroll\":true");
-        assertThat(json).contains("\"authnrCfg\":true");
-        assertThat(json).contains("\"uvAcfg\":true");
-        assertThat(json).contains("\"credMgmt\":true");
-        assertThat(json).contains("\"perCredMgmtRO\":true");
-        assertThat(json).contains("\"credentialMgmtPreview\":true");
-        assertThat(json).contains("\"setMinPINLength\":true");
-        assertThat(json).contains("\"makeCredUvNotRqd\":true");
-        assertThat(json).contains("\"alwaysUv\":true");
-        assertThat(json).doesNotContain("\"value\"");
-        assertThat(json).doesNotContain("\"uvToken\"");
-        assertThat(json).doesNotContain("\"config\"");
+        assertThat(json)
+                .contains("\"plat\":false")
+                .contains("\"rk\":true")
+                .contains("\"clientPin\":true")
+                .contains("\"up\":true")
+                .contains("\"uv\":true")
+                .contains("\"pinUvAuthToken\":true")
+                .contains("\"noMcGaPermissionsWithClientPin\":true")
+                .contains("\"largeBlobs\":true")
+                .contains("\"ep\":true")
+                .contains("\"bioEnroll\":true")
+                .contains("\"userVerificationMgmtPreview\":true")
+                .contains("\"uvBioEnroll\":true")
+                .contains("\"authnrCfg\":true")
+                .contains("\"uvAcfg\":true")
+                .contains("\"credMgmt\":true")
+                .contains("\"perCredMgmtRO\":true")
+                .contains("\"credentialMgmtPreview\":true")
+                .contains("\"setMinPINLength\":true")
+                .contains("\"makeCredUvNotRqd\":true")
+                .contains("\"alwaysUv\":true")
+                .doesNotContain("\"value\"")
+                .doesNotContain("\"uvToken\"")
+                .doesNotContain("\"config\"");
     }
 
     // ==================== Options round-trip ====================
@@ -164,10 +165,11 @@ class AuthenticatorGetInfoTest {
         String oldJson = "{\"plat\": false, \"rk\": true, \"uvToken\": true, \"config\": false}";
         AuthenticatorGetInfo.Options deserialized = jsonMapper.readValue(oldJson, AuthenticatorGetInfo.Options.class);
         String reserialized = jsonMapper.writeValueAsString(deserialized);
-        assertThat(reserialized).contains("\"pinUvAuthToken\":true");
-        assertThat(reserialized).contains("\"authnrCfg\":false");
-        assertThat(reserialized).doesNotContain("\"uvToken\"");
-        assertThat(reserialized).doesNotContain("\"config\"");
+        assertThat(reserialized)
+                .contains("\"pinUvAuthToken\":true")
+                .contains("\"authnrCfg\":false")
+                .doesNotContain("\"uvToken\"")
+                .doesNotContain("\"config\"");
 
         AuthenticatorGetInfo.Options roundTripped = jsonMapper.readValue(reserialized, AuthenticatorGetInfo.Options.class);
         assertThat(roundTripped).isEqualTo(deserialized);
@@ -275,10 +277,10 @@ class AuthenticatorGetInfoTest {
         AuthenticatorGetInfo.Options.UVTokenOption a = new AuthenticatorGetInfo.Options.UVTokenOption(true);
         AuthenticatorGetInfo.Options.UVTokenOption b = new AuthenticatorGetInfo.Options.UVTokenOption(true);
         AuthenticatorGetInfo.Options.UVTokenOption c = new AuthenticatorGetInfo.Options.UVTokenOption(false);
-        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
-        assertThat(a).isNotEqualTo(c);
-        assertThat(a).isNotEqualTo(null);
-        assertThat(a).isNotEqualTo("string");
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b)
+                .isNotEqualTo(c)
+                .isNotEqualTo(null)
+                .isNotEqualTo("string");
     }
 
     @SuppressWarnings("deprecation")
@@ -287,10 +289,10 @@ class AuthenticatorGetInfoTest {
         AuthenticatorGetInfo.Options.ConfigOption a = new AuthenticatorGetInfo.Options.ConfigOption(true);
         AuthenticatorGetInfo.Options.ConfigOption b = new AuthenticatorGetInfo.Options.ConfigOption(true);
         AuthenticatorGetInfo.Options.ConfigOption c = new AuthenticatorGetInfo.Options.ConfigOption(false);
-        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
-        assertThat(a).isNotEqualTo(c);
-        assertThat(a).isNotEqualTo(null);
-        assertThat(a).isNotEqualTo("string");
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b)
+                .isNotEqualTo(c)
+                .isNotEqualTo(null)
+                .isNotEqualTo("string");
     }
 
     // ==================== Options equals / hashCode ====================
@@ -299,10 +301,10 @@ class AuthenticatorGetInfoTest {
     void options_equals_and_hashCode_test() {
         AuthenticatorGetInfo.Options a = jsonMapper.readValue(ALL_OPTIONS_JSON, AuthenticatorGetInfo.Options.class);
         AuthenticatorGetInfo.Options b = jsonMapper.readValue(ALL_OPTIONS_JSON, AuthenticatorGetInfo.Options.class);
-        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
-        assertThat(a).isEqualTo(a);
-        assertThat(a).isNotEqualTo(null);
-        assertThat(a).isNotEqualTo("string");
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b)
+                .isEqualTo(a)
+                .isNotEqualTo(null)
+                .isNotEqualTo("string");
 
         AuthenticatorGetInfo.Options empty = jsonMapper.readValue("{}", AuthenticatorGetInfo.Options.class);
         assertThat(a).isNotEqualTo(empty);
@@ -313,10 +315,10 @@ class AuthenticatorGetInfoTest {
         AuthenticatorGetInfo.Options.PinUvAuthTokenOption a = new AuthenticatorGetInfo.Options.PinUvAuthTokenOption(true);
         AuthenticatorGetInfo.Options.PinUvAuthTokenOption b = new AuthenticatorGetInfo.Options.PinUvAuthTokenOption(true);
         AuthenticatorGetInfo.Options.PinUvAuthTokenOption c = new AuthenticatorGetInfo.Options.PinUvAuthTokenOption(false);
-        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
-        assertThat(a).isNotEqualTo(c);
-        assertThat(a).isNotEqualTo(null);
-        assertThat(a).isNotEqualTo("string");
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b)
+                .isNotEqualTo(c)
+                .isNotEqualTo(null)
+                .isNotEqualTo("string");
     }
 
     // ==================== Test data ====================


### PR DESCRIPTION
- Use `hasSameHashCodeAs()` instead of asserting on `hashCode()` directly
- Use `hasToString()` instead of asserting on `toString()` directly
- Join consecutive assertions on the same subject into a single chain

Affected files: `AuthenticationExtensionsLargeBlobInputsTest`, `AuthenticationExtensionsLargeBlobOutputsTest`, `ClientCapabilityTest`, `UUIDUtilTest`, `PinProtocolVersionTest`, `HMACGetSecretAuthenticatorInputTest`, `ECUtilTest`, `AuthenticatorGetInfoTest`