### PR TITLE
Remove unused imports

### DIFF
--- a/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAuthenticationObject.java
+++ b/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCAuthenticationObject.java
@@ -18,7 +18,6 @@ package com.webauthn4j.appattest.verifier;
 
 import com.webauthn4j.appattest.authenticator.DCAppleDevice;
 import com.webauthn4j.appattest.data.DCAssertionParameters;
-import com.webauthn4j.data.CoreAuthenticationParameters;
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput;
 import com.webauthn4j.server.CoreServerProperty;

--- a/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCRegistrationObject.java
+++ b/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCRegistrationObject.java
@@ -17,7 +17,6 @@
 package com.webauthn4j.appattest.verifier;
 
 import com.webauthn4j.appattest.data.DCAttestationParameters;
-import com.webauthn4j.data.CoreRegistrationParameters;
 import com.webauthn4j.data.attestation.AttestationObject;
 import com.webauthn4j.server.CoreServerProperty;
 import com.webauthn4j.util.ArrayUtil;

--- a/webauthn4j-core-async/src/main/java/com/webauthn4j/async/verifier/AuthenticationDataAsyncVerifier.java
+++ b/webauthn4j-core-async/src/main/java/com/webauthn4j/async/verifier/AuthenticationDataAsyncVerifier.java
@@ -21,7 +21,6 @@ import com.webauthn4j.verifier.internal.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;

--- a/webauthn4j-core-async/src/main/java/com/webauthn4j/async/verifier/RegistrationDataAsyncVerifier.java
+++ b/webauthn4j-core-async/src/main/java/com/webauthn4j/async/verifier/RegistrationDataAsyncVerifier.java
@@ -24,7 +24,6 @@ import com.webauthn4j.verifier.exception.ConstraintViolationException;
 import com.webauthn4j.verifier.exception.InconsistentClientDataTypeException;
 import com.webauthn4j.verifier.internal.*;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;

--- a/webauthn4j-core/src/test/java/com/webauthn4j/verifier/exception/CertificateExceptionTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/verifier/exception/CertificateExceptionTest.java
@@ -17,14 +17,12 @@
 package com.webauthn4j.verifier.exception;
 
 import com.webauthn4j.test.TestAttestationUtil;
-import com.webauthn4j.test.TestDataUtil;
 import org.junit.jupiter.api.Test;
 
 import java.security.cert.X509Certificate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.Mockito.mock;
 
 class CertificateExceptionTest {
 


### PR DESCRIPTION
Remove unused imports from 5 files across 3 modules:

- `DCAuthenticationObject`: `CoreAuthenticationParameters`
- `DCRegistrationObject`: `CoreRegistrationParameters`
- `AuthenticationDataAsyncVerifier`: `java.util.Iterator`
- `RegistrationDataAsyncVerifier`: `java.util.Iterator`
- `CertificateExceptionTest`: `TestDataUtil`, `Mockito.mock`