### PR TITLE
Add missing @deprecated Javadoc tags

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/CborConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/CborConverter.java
@@ -32,6 +32,8 @@ import java.io.InputStream;
 
 /**
  * A utility class for CBOR serialization/deserialization
+ *
+ * @deprecated Use {@link ObjectConverter#getCborMapper()} directly instead.
  */
 @Deprecated
 public class CborConverter {
@@ -45,6 +47,9 @@ public class CborConverter {
         this.objectConverter = objectConverter;
     }
 
+    /**
+     * @deprecated Use {@link ObjectConverter#rebuildWithCBORModule(JacksonModule)} instead.
+     */
     @Deprecated
     public void registerModule(JacksonModule module){
         this.objectConverter.cborMapper = objectConverter.getCborMapper().rebuild()

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/JsonConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/util/JsonConverter.java
@@ -31,6 +31,8 @@ import java.io.InputStream;
 
 /**
  * A utility class for JSON serialization/deserialization
+ *
+ * @deprecated Use {@link ObjectConverter#getJsonMapper()} directly instead.
  */
 @Deprecated
 public class JsonConverter {
@@ -45,6 +47,9 @@ public class JsonConverter {
         this.objectConverter = objectConverter;
     }
 
+    /**
+     * @deprecated Use {@link ObjectConverter#rebuildWithJSONModule(JacksonModule)} instead.
+     */
     @Deprecated
     public void registerModule(JacksonModule module){
         objectConverter.jsonMapper = objectConverter.getJsonMapper().rebuild()

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/SignatureAlgorithm.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/SignatureAlgorithm.java
@@ -99,6 +99,9 @@ public class SignatureAlgorithm {
         this.messageDigestAlgorithm = messageDigestAlgorithm;
     }
 
+    /**
+     * @deprecated Use {@link #create(String, String)} instead.
+     */
     @Deprecated
     public static SignatureAlgorithm create(@NotNull String value) {
         switch (value) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
@@ -93,7 +93,7 @@ public class AuthenticationObject extends CoreAuthenticationObject {
     }
 
     /**
-     * @deprecated Use {@link #getAuthenticationParameters()} instead.
+     * @deprecated Use {@code getAuthenticationParameters().getServerProperty()} instead.
      */
     @Deprecated
     @Override

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
@@ -92,6 +92,9 @@ public class AuthenticationObject extends CoreAuthenticationObject {
         return (AuthenticationParameters) super.getAuthenticationParameters();
     }
 
+    /**
+     * @deprecated Use {@link #getAuthenticationParameters()} instead.
+     */
     @Deprecated
     @Override
     public @NotNull ServerProperty getServerProperty() {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreAuthenticationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreAuthenticationObject.java
@@ -105,7 +105,7 @@ public class CoreAuthenticationObject {
     }
 
     /**
-     * @deprecated Use {@link #getAuthenticationParameters()} instead.
+     * @deprecated Use {@code getAuthenticationParameters().getServerProperty()} instead.
      */
     @Deprecated
     public @NotNull CoreServerProperty getServerProperty() {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreRegistrationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/CoreRegistrationObject.java
@@ -134,7 +134,7 @@ public class CoreRegistrationObject {
     }
 
     /**
-     * @deprecated Use {@link #getRegistrationParameters()} instead.
+     * @deprecated Use {@code getRegistrationParameters().getServerProperty()} instead.
      */
     @Deprecated
     public @NotNull CoreServerProperty getServerProperty() {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationObject.java
@@ -150,7 +150,7 @@ public class RegistrationObject extends CoreRegistrationObject {
     }
 
     /**
-     * @deprecated Use {@link #getRegistrationParameters()} instead.
+     * @deprecated Use {@code getRegistrationParameters().getServerProperty()} instead.
      */
     @Deprecated
     @Override

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationObject.java
@@ -149,6 +149,9 @@ public class RegistrationObject extends CoreRegistrationObject {
         return transports;
     }
 
+    /**
+     * @deprecated Use {@link #getRegistrationParameters()} instead.
+     */
     @Deprecated
     @Override
     public @NotNull ServerProperty getServerProperty() {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/exception/MaliciousCounterValueException.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/exception/MaliciousCounterValueException.java
@@ -39,6 +39,9 @@ public class MaliciousCounterValueException extends VerificationException {
         this.presentedCounter = presentedCounter;
     }
 
+    /**
+     * @deprecated Use {@link #MaliciousCounterValueException(String, long, long, Throwable)} instead.
+     */
     @Deprecated
     public MaliciousCounterValueException(@Nullable String message, @Nullable Throwable cause) {
         super(message, cause);
@@ -46,6 +49,9 @@ public class MaliciousCounterValueException extends VerificationException {
         this.presentedCounter = 0;
     }
 
+    /**
+     * @deprecated Use {@link #MaliciousCounterValueException(String, long, long)} instead.
+     */
     @Deprecated
     public MaliciousCounterValueException(@Nullable String message) {
         super(message);
@@ -53,6 +59,9 @@ public class MaliciousCounterValueException extends VerificationException {
         this.presentedCounter = 0;
     }
 
+    /**
+     * @deprecated Use {@link #MaliciousCounterValueException(String, long, long, Throwable)} instead.
+     */
     @Deprecated
     public MaliciousCounterValueException(@Nullable Throwable cause) {
         super(cause);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/internal/TopOriginVerifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/internal/TopOriginVerifier.java
@@ -115,7 +115,7 @@ public class TopOriginVerifier {
     }
 
     /**
-     * @deprecated Use {@link ServerProperty.Builder#anyTopOrigin()} or {@link ServerProperty.Builder#topOriginPredicate(OriginPredicate)} instead.
+     * @deprecated Deprecated along with {@link #setForceBlockCrossOrigin(boolean)}.
      */
     @Deprecated
     public boolean isForceBlockCrossOrigin() {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/internal/TopOriginVerifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/internal/TopOriginVerifier.java
@@ -114,6 +114,9 @@ public class TopOriginVerifier {
         this.forceBlockCrossOrigin = forceBlockCrossOrigin;
     }
 
+    /**
+     * @deprecated Use {@link ServerProperty.Builder#anyTopOrigin()} or {@link ServerProperty.Builder#topOriginPredicate(OriginPredicate)} instead.
+     */
     @Deprecated
     public boolean isForceBlockCrossOrigin() {
         return forceBlockCrossOrigin;

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
@@ -231,6 +231,9 @@ public class AuthenticatorGetInfo {
         this.authenticatorConfigCommands = authenticatorConfigCommands;
     }
 
+    /**
+     * @deprecated Use the full constructor instead.
+     */
     @Deprecated
     public AuthenticatorGetInfo(
             @NotNull List<String> versions,
@@ -554,6 +557,9 @@ public class AuthenticatorGetInfo {
             this.alwaysUv = alwaysUv;
         }
 
+        /**
+         * @deprecated Use the full constructor instead.
+         */
         @Deprecated
         public Options(
                 @Nullable PlatformOption plat,
@@ -595,6 +601,9 @@ public class AuthenticatorGetInfo {
             return pinUvAuthToken;
         }
 
+        /**
+         * @deprecated Use {@link #getPinUvAuthToken()} instead.
+         */
         @Deprecated
         @JsonIgnore
         public @Nullable UVTokenOption getUvToken() {
@@ -629,6 +638,9 @@ public class AuthenticatorGetInfo {
             return authnrCfg;
         }
 
+        /**
+         * @deprecated Use {@link #getAuthnrCfg()} instead.
+         */
         @Deprecated
         @JsonIgnore
         public @Nullable ConfigOption getConfig() {
@@ -928,6 +940,9 @@ public class AuthenticatorGetInfo {
             }
         }
 
+        /**
+         * @deprecated Use {@link PinUvAuthTokenOption} instead.
+         */
         @Deprecated
         public static class UVTokenOption {
 
@@ -961,6 +976,9 @@ public class AuthenticatorGetInfo {
             }
         }
 
+        /**
+         * @deprecated Use {@link AuthnrCfgOption} instead.
+         */
         @Deprecated
         public static class ConfigOption {
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
@@ -602,7 +602,7 @@ public class AuthenticatorGetInfo {
         }
 
         /**
-         * @deprecated Use {@link #getPinUvAuthToken()} instead.
+         * @deprecated The {@code uvToken} option was deprecated in CTAP 2.1 and replaced by {@code pinUvAuthToken}. Use {@link #getPinUvAuthToken()} instead.
          */
         @Deprecated
         @JsonIgnore
@@ -639,7 +639,7 @@ public class AuthenticatorGetInfo {
         }
 
         /**
-         * @deprecated Use {@link #getAuthnrCfg()} instead.
+         * @deprecated The {@code config} option was deprecated in CTAP 2.1 and replaced by {@code authnrCfg}. Use {@link #getAuthnrCfg()} instead.
          */
         @Deprecated
         @JsonIgnore
@@ -941,7 +941,7 @@ public class AuthenticatorGetInfo {
         }
 
         /**
-         * @deprecated Use {@link PinUvAuthTokenOption} instead.
+         * @deprecated The {@code uvToken} option was deprecated in CTAP 2.1 and replaced by {@code pinUvAuthToken}. Use {@link PinUvAuthTokenOption} instead.
          */
         @Deprecated
         public static class UVTokenOption {
@@ -977,7 +977,7 @@ public class AuthenticatorGetInfo {
         }
 
         /**
-         * @deprecated Use {@link AuthnrCfgOption} instead.
+         * @deprecated The {@code config} option was deprecated in CTAP 2.1 and replaced by {@code authnrCfg}. Use {@link AuthnrCfgOption} instead.
          */
         @Deprecated
         public static class ConfigOption {

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/BiometricAccuracyDescriptor.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/BiometricAccuracyDescriptor.java
@@ -55,6 +55,9 @@ public class BiometricAccuracyDescriptor {
         this.blockSlowdown = blockSlowdown;
     }
 
+    /**
+     * @deprecated Use the full constructor instead.
+     */
     @Deprecated
     public BiometricAccuracyDescriptor(
             @Nullable Double selfAttestedFAR,

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/MetadataStatement.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/MetadataStatement.java
@@ -200,6 +200,9 @@ public class MetadataStatement {
         this.cxConfigURL = cxConfigURL;
     }
 
+    /**
+     * @deprecated Use the full constructor instead.
+     */
     @Deprecated
     public MetadataStatement(
             @Nullable String legalHeader,

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/toc/StatusReport.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/toc/StatusReport.java
@@ -130,6 +130,9 @@ public class StatusReport {
         this.fipsPhysicalSecurityLevel = fipsPhysicalSecurityLevel;
     }
 
+    /**
+     * @deprecated Use the full constructor instead.
+     */
     @Deprecated
     public StatusReport(
             @NotNull AuthenticatorStatus status,

--- a/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
+++ b/webauthn4j-test/src/main/java/com/webauthn4j/test/TestDataUtil.java
@@ -287,6 +287,9 @@ public class TestDataUtil {
         return new AttestationObject(authenticatorData, attestationStatementProvider.apply(signature));
     }
 
+    /**
+     * @deprecated Use {@link #createAttestationObject(byte[], COSEKey, Function)} instead.
+     */
     @Deprecated(forRemoval = true)
     public static AttestationObject createAttestationObject(byte[] clientDataHash, PrivateKey attestationPrivateKey, Function<byte[], AttestationStatement> attestationStatementProvider) {
         AuthenticatorData<RegistrationExtensionAuthenticatorOutput> authenticatorData = createAuthenticatorData();
@@ -468,6 +471,9 @@ public class TestDataUtil {
         return createCredentialRecord(TestDataUtil.createAttestedCredentialData(), TestAttestationStatementUtil.createFIDOU2FAttestationStatement());
     }
 
+    /**
+     * @deprecated Use {@link #calculateSignature(COSEKey, byte[])} instead.
+     */
     @Deprecated
     public static byte[] calculateSignature(PrivateKey privateKey, byte[] signedData) {
         try {


### PR DESCRIPTION
Add `@deprecated` Javadoc tags with references to the replacement API for all `@Deprecated` annotations that were missing them (22 locations across 12 files).