### PR TITLE
Specify UTC timezone explicitly in LocalDate.now() calls

### DIFF
--- a/webauthn4j-metadata-async/src/main/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProvider.java
+++ b/webauthn4j-metadata-async/src/main/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProvider.java
@@ -20,6 +20,7 @@ import com.webauthn4j.metadata.data.MetadataBLOB;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.locks.Lock;
@@ -49,7 +50,7 @@ public abstract class CachingMetadataBLOBAsyncProvider implements MetadataBLOBAs
             doProvide()
                     .thenAccept(metadataBLOB -> {
                         cachedMetadataBLOB = metadataBLOB;
-                        metadataBLOBLastUpdate = LocalDate.now();
+                        metadataBLOBLastUpdate = LocalDate.now(ZoneOffset.UTC);
                         synchronized (metadataBLOBFutureLock){
                             metadataBLOBFuture.complete(metadataBLOB);
                             metadataBLOBFuture = new CompletableFuture<>();
@@ -73,7 +74,7 @@ public abstract class CachingMetadataBLOBAsyncProvider implements MetadataBLOBAs
         if(cachedMetadataBLOB == null){
             return true;
         }
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
         LocalDate nextUpdate = cachedMetadataBLOB.getPayload().getNextUpdate();
         return (nextUpdate.isBefore(today) || nextUpdate.isEqual(today)) && metadataBLOBLastUpdate.isBefore(today);
     }

--- a/webauthn4j-metadata-async/src/test/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProviderTest.java
+++ b/webauthn4j-metadata-async/src/test/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProviderTest.java
@@ -28,9 +28,9 @@ class CachingMetadataBLOBAsyncProviderTest {
         LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
         LocalDate secondTrialDay = LocalDate.of(2020, 1, 3);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
-            mock.when(LocalDate::now).thenReturn(firstTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide().toCompletableFuture().get();
-            mock.when(LocalDate::now).thenReturn(secondTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(secondTrialDay);
             target.provide().toCompletableFuture().get();
             verify(target, times(2)).doProvide();
         }
@@ -44,9 +44,9 @@ class CachingMetadataBLOBAsyncProviderTest {
         LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
         LocalDate secondTrialDay = LocalDate.of(2020, 1, 2);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
-            mock.when(LocalDate::now).thenReturn(firstTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();
-            mock.when(LocalDate::now).thenReturn(secondTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(secondTrialDay);
             target.provide();
             verify(target, times(2)).doProvide();
         }
@@ -60,9 +60,9 @@ class CachingMetadataBLOBAsyncProviderTest {
         LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
         LocalDate secondTrialDay = LocalDate.of(2020, 1, 2);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
-            mock.when(LocalDate::now).thenReturn(firstTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();
-            mock.when(LocalDate::now).thenReturn(secondTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(secondTrialDay);
             target.provide();
             verify(target, times(1)).doProvide();
         }

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/CachingMetadataBLOBProvider.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/CachingMetadataBLOBProvider.java
@@ -20,6 +20,7 @@ import com.webauthn4j.metadata.data.MetadataBLOB;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 public abstract class CachingMetadataBLOBProvider implements MetadataBLOBProvider {
 
@@ -34,7 +35,7 @@ public abstract class CachingMetadataBLOBProvider implements MetadataBLOBProvide
                 refresh();
             }
         }
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
         LocalDate nextUpdate = cachedMetadataBLOB.getPayload().getNextUpdate();
         if((nextUpdate.isBefore(today) || nextUpdate.isEqual(today)) && cachedMetadataBLOBLastUpdate.isBefore(today)){
             refresh();
@@ -46,7 +47,7 @@ public abstract class CachingMetadataBLOBProvider implements MetadataBLOBProvide
     public void refresh(){
         synchronized (cachedMetadataBLOBLock){
             cachedMetadataBLOB = doProvide();
-            cachedMetadataBLOBLastUpdate = LocalDate.now();
+            cachedMetadataBLOBLastUpdate = LocalDate.now(ZoneOffset.UTC);
         }
     }
 

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/CachingMetadataBLOBProviderTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/CachingMetadataBLOBProviderTest.java
@@ -27,9 +27,9 @@ class CachingMetadataBLOBProviderTest {
         LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
         LocalDate secondTrialDay = LocalDate.of(2020, 1, 3);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
-            mock.when(LocalDate::now).thenReturn(firstTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();
-            mock.when(LocalDate::now).thenReturn(secondTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(secondTrialDay);
             target.provide();
             verify(target, times(2)).doProvide();
         }
@@ -43,9 +43,9 @@ class CachingMetadataBLOBProviderTest {
         LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
         LocalDate secondTrialDay = LocalDate.of(2020, 1, 2);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
-            mock.when(LocalDate::now).thenReturn(firstTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();
-            mock.when(LocalDate::now).thenReturn(secondTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(secondTrialDay);
             target.provide();
             verify(target, times(2)).doProvide();
         }
@@ -59,9 +59,9 @@ class CachingMetadataBLOBProviderTest {
         LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
         LocalDate secondTrialDay = LocalDate.of(2020, 1, 2);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
-            mock.when(LocalDate::now).thenReturn(firstTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();
-            mock.when(LocalDate::now).thenReturn(secondTrialDay);
+            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(secondTrialDay);
             target.provide();
             verify(target, times(1)).doProvide();
         }


### PR DESCRIPTION
`LocalDate.now()` without a timezone silently depends on the system default timezone, which can vary between environments. Use `LocalDate.now(ZoneOffset.UTC)` to make the timezone explicit.

Affected files:
- `CachingMetadataBLOBProvider` (sync)
- `CachingMetadataBLOBAsyncProvider` (async)
- Corresponding tests updated to mock `LocalDate.now(ZoneOffset.UTC)` instead of `LocalDate.now()`