### PR TITLE
Suppress S6416 false positive on assertCoseKey null guard

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/AttestedCredentialDataConverter.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/AttestedCredentialDataConverter.java
@@ -76,6 +76,7 @@ public class AttestedCredentialDataConverter {
         return new AttestedCredentialData(aaguid, credentialId, coseKey);
     }
 
+    @SuppressWarnings("javabugs:S6416")
     private static void assertCoseKey(@Nullable COSEKey coseKey) {
         AssertUtil.notNull(coseKey, "coseKey must not be null");
     }


### PR DESCRIPTION
`AssertUtil.notNull()` is a null validation guard that intentionally accepts `@Nullable` input and throws `IllegalArgumentException` when null is passed. SonarCloud rule `javabugs:S6416` does not recognize this pattern as a guard and flags it as a potential bug.

Add `@SuppressWarnings("javabugs:S6416")` to the `assertCoseKey` method to suppress this false positive.