### PR TITLE
Fix naming convention violations in test classes

### DIFF
--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.attestation.statement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.SignatureAlgorithm;
 import org.junit.jupiter.api.Test;
@@ -201,7 +202,7 @@ class COSEAlgorithmIdentifierTest {
 
     static class TestDTO {
         @SuppressWarnings("WeakerAccess")
-        @com.fasterxml.jackson.annotation.JsonProperty("cose_alg_id")
+        @JsonProperty("cose_alg_id")
         public COSEAlgorithmIdentifier coseAlgId;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
@@ -148,7 +148,7 @@ class COSEAlgorithmIdentifierTest {
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
 
         // Then
-        assertThat(dto.cose_alg_id).isEqualTo(COSEAlgorithmIdentifier.RS256);
+        assertThat(dto.coseAlgId).isEqualTo(COSEAlgorithmIdentifier.RS256);
     }
 
     @Test
@@ -196,11 +196,12 @@ class COSEAlgorithmIdentifierTest {
         TestDTO data = jsonMapper.readValue(json, TestDTO.class);
 
         // Then
-        assertThat(data.cose_alg_id).isNull();
+        assertThat(data.coseAlgId).isNull();
     }
 
     static class TestDTO {
         @SuppressWarnings("WeakerAccess")
-        public COSEAlgorithmIdentifier cose_alg_id;
+        @com.fasterxml.jackson.annotation.JsonProperty("cose_alg_id")
+        public COSEAlgorithmIdentifier coseAlgId;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifierTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.attestation.statement;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.SignatureAlgorithm;
 import org.junit.jupiter.api.Test;
@@ -143,7 +142,7 @@ class COSEAlgorithmIdentifierTest {
     @Test
     void deserialize_test() {
         // Given
-        String json = "{\"cose_alg_id\":-257}";
+        String json = "{\"coseAlgId\":-257}";
 
         // When
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
@@ -155,7 +154,7 @@ class COSEAlgorithmIdentifierTest {
     @Test
     void deserialize_test_with_non_predefined_value() {
         // Given
-        String json = "{\"cose_alg_id\":0}";
+        String json = "{\"coseAlgId\":0}";
 
         // When
         // Then
@@ -167,7 +166,7 @@ class COSEAlgorithmIdentifierTest {
     @Test
     void deserialize_test_with_empty_string_value() {
         // Given
-        String json = "{\"cose_alg_id\": \"\"}";
+        String json = "{\"coseAlgId\": \"\"}";
 
         // When
         // Then
@@ -179,7 +178,7 @@ class COSEAlgorithmIdentifierTest {
     @Test
     void deserialize_test_with_invalid_value() {
         // Given
-        String json = "{\"cose_alg_id\": \"invalid\"}";
+        String json = "{\"coseAlgId\": \"invalid\"}";
 
         // When
         // Then
@@ -191,7 +190,7 @@ class COSEAlgorithmIdentifierTest {
     @Test
     void deserialize_test_with_null() {
         // Given
-        String json = "{\"cose_alg_id\":null}";
+        String json = "{\"coseAlgId\":null}";
 
         // When
         TestDTO data = jsonMapper.readValue(json, TestDTO.class);
@@ -202,7 +201,6 @@ class COSEAlgorithmIdentifierTest {
 
     static class TestDTO {
         @SuppressWarnings("WeakerAccess")
-        @JsonProperty("cose_alg_id")
         public COSEAlgorithmIdentifier coseAlgId;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyOperationTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyOperationTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.attestation.statement;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.exc.InvalidFormatException;
@@ -66,7 +65,7 @@ class COSEKeyOperationTest {
     @Test
     void fromString_test() {
         // Given
-        String json = "{\"cose_key_op\":1}";
+        String json = "{\"coseKeyOp\":1}";
 
         // When
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
@@ -78,7 +77,7 @@ class COSEKeyOperationTest {
     @Test
     void fromString_test_with_invalid_value() {
         // Given
-        String json = "{\"cose_key_op\":0}";
+        String json = "{\"coseKeyOp\":0}";
 
         // When
         // Then
@@ -88,7 +87,6 @@ class COSEKeyOperationTest {
     }
 
     static class TestDTO {
-        @JsonProperty("cose_key_op")
         public COSEKeyOperation coseKeyOp;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyOperationTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyOperationTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.attestation.statement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.exc.InvalidFormatException;
@@ -87,7 +88,7 @@ class COSEKeyOperationTest {
     }
 
     static class TestDTO {
-        @com.fasterxml.jackson.annotation.JsonProperty("cose_key_op")
+        @JsonProperty("cose_key_op")
         public COSEKeyOperation coseKeyOp;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyOperationTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyOperationTest.java
@@ -71,7 +71,7 @@ class COSEKeyOperationTest {
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
 
         // Then
-        assertThat(dto.cose_key_op).isEqualTo(COSEKeyOperation.SIGN);
+        assertThat(dto.coseKeyOp).isEqualTo(COSEKeyOperation.SIGN);
     }
 
     @Test
@@ -87,6 +87,7 @@ class COSEKeyOperationTest {
     }
 
     static class TestDTO {
-        public COSEKeyOperation cose_key_op;
+        @com.fasterxml.jackson.annotation.JsonProperty("cose_key_op")
+        public COSEKeyOperation coseKeyOp;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyTypeTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.attestation.statement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.exc.InvalidFormatException;
@@ -77,7 +78,7 @@ class COSEKeyTypeTest {
     }
 
     static class TestDTO {
-        @com.fasterxml.jackson.annotation.JsonProperty("cose_key_type")
+        @JsonProperty("cose_key_type")
         public COSEKeyType coseKeyType;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyTypeTest.java
@@ -61,7 +61,7 @@ class COSEKeyTypeTest {
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
 
         // Then
-        assertThat(dto.cose_key_type).isEqualTo(COSEKeyType.RESERVED);
+        assertThat(dto.coseKeyType).isEqualTo(COSEKeyType.RESERVED);
     }
 
     @Test
@@ -77,6 +77,7 @@ class COSEKeyTypeTest {
     }
 
     static class TestDTO {
-        public COSEKeyType cose_key_type;
+        @com.fasterxml.jackson.annotation.JsonProperty("cose_key_type")
+        public COSEKeyType coseKeyType;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/COSEKeyTypeTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.attestation.statement;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.exc.InvalidFormatException;
@@ -56,7 +55,7 @@ class COSEKeyTypeTest {
     @Test
     void fromString_test() {
         // Given
-        String json = "{\"cose_key_type\":0}";
+        String json = "{\"coseKeyType\":0}";
 
         // When
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
@@ -68,7 +67,7 @@ class COSEKeyTypeTest {
     @Test
     void fromString_test_with_invalid_value() {
         // Given
-        String json = "{\"cose_key_type\":-1}";
+        String json = "{\"coseKeyType\":-1}";
 
         // When
         // Then
@@ -78,7 +77,6 @@ class COSEKeyTypeTest {
     }
 
     static class TestDTO {
-        @JsonProperty("cose_key_type")
         public COSEKeyType coseKeyType;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMEccCurveTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMEccCurveTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.attestation.statement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.util.ECUtil;
 import com.webauthn4j.util.exception.NotImplementedException;
@@ -112,7 +113,7 @@ class TPMEccCurveTest {
     }
 
     static class TestDTO {
-        @com.fasterxml.jackson.annotation.JsonProperty("tpm_ecc_curve")
+        @JsonProperty("tpm_ecc_curve")
         public TPMEccCurve tpmEccCurve;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMEccCurveTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMEccCurveTest.java
@@ -82,7 +82,7 @@ class TPMEccCurveTest {
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
 
         // Then
-        assertThat(dto.tpm_ecc_curve).isEqualTo(TPMEccCurve.TPM_ECC_NIST_P256);
+        assertThat(dto.tpmEccCurve).isEqualTo(TPMEccCurve.TPM_ECC_NIST_P256);
     }
 
     @Test
@@ -112,6 +112,7 @@ class TPMEccCurveTest {
     }
 
     static class TestDTO {
-        public TPMEccCurve tpm_ecc_curve;
+        @com.fasterxml.jackson.annotation.JsonProperty("tpm_ecc_curve")
+        public TPMEccCurve tpmEccCurve;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMEccCurveTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMEccCurveTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.attestation.statement;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.util.ECUtil;
 import com.webauthn4j.util.exception.NotImplementedException;
@@ -77,7 +76,7 @@ class TPMEccCurveTest {
     @Test
     void fromString_test() {
         // Given
-        String json = "{\"tpm_ecc_curve\":3}";
+        String json = "{\"tpmEccCurve\":3}";
 
         // When
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
@@ -89,7 +88,7 @@ class TPMEccCurveTest {
     @Test
     void fromString_test_with_invalid_value() {
         // Given
-        String json = "{\"tpm_ecc_curve\":-1}";
+        String json = "{\"tpmEccCurve\":-1}";
 
         // When
         // Then
@@ -113,7 +112,6 @@ class TPMEccCurveTest {
     }
 
     static class TestDTO {
-        @JsonProperty("tpm_ecc_curve")
         public TPMEccCurve tpmEccCurve;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
@@ -52,7 +52,7 @@ class TPMGeneratedTest {
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
 
         // Then
-        assertThat(dto.tpm_generated).isEqualTo(TPMGenerated.TPM_GENERATED_VALUE);
+        assertThat(dto.tpmGenerated).isEqualTo(TPMGenerated.TPM_GENERATED_VALUE);
     }
 
     @Test
@@ -69,6 +69,7 @@ class TPMGeneratedTest {
     }
 
     static class TestDTO {
-        public TPMGenerated tpm_generated;
+        @com.fasterxml.jackson.annotation.JsonProperty("tpm_generated")
+        public TPMGenerated tpmGenerated;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.attestation.statement;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.util.Base64UrlUtil;
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ class TPMGeneratedTest {
     void fromString_test() {
         // Given
         byte[] source = new byte[]{(byte) 0xff, (byte) 0x54, (byte) 0x43, (byte) 0x47};
-        String json = "{\"tpm_generated\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
+        String json = "{\"tpmGenerated\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
 
         // When
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
@@ -60,7 +59,7 @@ class TPMGeneratedTest {
     void fromString_test_with_invalid_value() {
         // Given
         byte[] source = new byte[]{(byte) 0xff, (byte) 0xaa, (byte) 0xff, (byte) 0xaa};
-        String sourceString = "{\"tpm_generated\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
+        String sourceString = "{\"tpmGenerated\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
 
         // When
         // Then
@@ -70,7 +69,6 @@ class TPMGeneratedTest {
     }
 
     static class TestDTO {
-        @JsonProperty("tpm_generated")
         public TPMGenerated tpmGenerated;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMGeneratedTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.attestation.statement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.util.Base64UrlUtil;
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,7 @@ class TPMGeneratedTest {
     }
 
     static class TestDTO {
-        @com.fasterxml.jackson.annotation.JsonProperty("tpm_generated")
+        @JsonProperty("tpm_generated")
         public TPMGenerated tpmGenerated;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgHashTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgHashTest.java
@@ -63,7 +63,7 @@ class TPMIAlgHashTest {
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
 
         // Then
-        assertThat(dto.tpmi_alg_hash).isEqualTo(TPMIAlgHash.TPM_ALG_SHA256);
+        assertThat(dto.tpmiAlgHash).isEqualTo(TPMIAlgHash.TPM_ALG_SHA256);
     }
 
     @Test
@@ -79,6 +79,7 @@ class TPMIAlgHashTest {
     }
 
     static class TestDTO {
-        public TPMIAlgHash tpmi_alg_hash;
+        @com.fasterxml.jackson.annotation.JsonProperty("tpmi_alg_hash")
+        public TPMIAlgHash tpmiAlgHash;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgHashTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgHashTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.attestation.statement;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.exc.InvalidFormatException;
@@ -58,7 +57,7 @@ class TPMIAlgHashTest {
     @Test
     void fromString_test() {
         // Given
-        String json = "{\"tpmi_alg_hash\":11}";
+        String json = "{\"tpmiAlgHash\":11}";
 
         // When
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
@@ -70,7 +69,7 @@ class TPMIAlgHashTest {
     @Test
     void fromString_test_with_invalid_value() {
         // Given
-        String json = "{\"tpmi_alg_hash\":-1}";
+        String json = "{\"tpmiAlgHash\":-1}";
 
         // When
         // Then
@@ -80,7 +79,6 @@ class TPMIAlgHashTest {
     }
 
     static class TestDTO {
-        @JsonProperty("tpmi_alg_hash")
         public TPMIAlgHash tpmiAlgHash;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgHashTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgHashTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.attestation.statement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.exc.InvalidFormatException;
@@ -79,7 +80,7 @@ class TPMIAlgHashTest {
     }
 
     static class TestDTO {
-        @com.fasterxml.jackson.annotation.JsonProperty("tpmi_alg_hash")
+        @JsonProperty("tpmi_alg_hash")
         public TPMIAlgHash tpmiAlgHash;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgPublicTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgPublicTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.attestation.statement;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.exc.InvalidFormatException;
@@ -55,7 +54,7 @@ class TPMIAlgPublicTest {
     @Test
     void fromString_test() {
         // Given
-        String json = "{\"tpmi_alg_pub\":24}";
+        String json = "{\"tpmiAlgPub\":24}";
 
         // When
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
@@ -67,7 +66,7 @@ class TPMIAlgPublicTest {
     @Test
     void fromString_test_with_invalid_value() {
         // Given
-        String json = "{\"tpmi_alg_pub\":-1}";
+        String json = "{\"tpmiAlgPub\":-1}";
 
         // When
         // Then
@@ -77,7 +76,6 @@ class TPMIAlgPublicTest {
     }
 
     static class TestDTO {
-        @JsonProperty("tpmi_alg_pub")
         public TPMIAlgPublic tpmiAlgPub;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgPublicTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgPublicTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.attestation.statement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.exc.InvalidFormatException;
@@ -76,7 +77,7 @@ class TPMIAlgPublicTest {
     }
 
     static class TestDTO {
-        @com.fasterxml.jackson.annotation.JsonProperty("tpmi_alg_pub")
+        @JsonProperty("tpmi_alg_pub")
         public TPMIAlgPublic tpmiAlgPub;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgPublicTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMIAlgPublicTest.java
@@ -60,7 +60,7 @@ class TPMIAlgPublicTest {
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
 
         // Then
-        assertThat(dto.tpmi_alg_pub).isEqualTo(TPMIAlgPublic.TPM_ALG_ECDSA);
+        assertThat(dto.tpmiAlgPub).isEqualTo(TPMIAlgPublic.TPM_ALG_ECDSA);
     }
 
     @Test
@@ -76,6 +76,7 @@ class TPMIAlgPublicTest {
     }
 
     static class TestDTO {
-        public TPMIAlgPublic tpmi_alg_pub;
+        @com.fasterxml.jackson.annotation.JsonProperty("tpmi_alg_pub")
+        public TPMIAlgPublic tpmiAlgPub;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
@@ -65,7 +65,7 @@ class TPMISTAttestTest {
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
 
         // Then
-        assertThat(dto.tpmi_st_attest).isEqualTo(TPMISTAttest.TPM_ST_ATTEST_CERTIFY);
+        assertThat(dto.tpmiStAttest).isEqualTo(TPMISTAttest.TPM_ST_ATTEST_CERTIFY);
     }
 
     @Test
@@ -82,6 +82,7 @@ class TPMISTAttestTest {
     }
 
     static class TestDTO {
-        public TPMISTAttest tpmi_st_attest;
+        @com.fasterxml.jackson.annotation.JsonProperty("tpmi_st_attest")
+        public TPMISTAttest tpmiStAttest;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.attestation.statement;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.util.Base64UrlUtil;
 import org.junit.jupiter.api.Test;
@@ -60,7 +59,7 @@ class TPMISTAttestTest {
     void fromString_test() {
         // Given
         byte[] source = new byte[]{(byte) 0x80, (byte) 0x17};
-        String json = "{\"tpmi_st_attest\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
+        String json = "{\"tpmiStAttest\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
 
         // When
         TestDTO dto = jsonMapper.readValue(json, TestDTO.class);
@@ -73,7 +72,7 @@ class TPMISTAttestTest {
     void fromString_test_with_invalid_value() {
         // Given
         byte[] source = new byte[]{(byte) 0xff, (byte) 0xaa};
-        String sourceString = "{\"tpmi_st_attest\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
+        String sourceString = "{\"tpmiStAttest\":\"" + Base64UrlUtil.encodeToString(source) + "\"}";
 
         // When
         // Then
@@ -83,7 +82,6 @@ class TPMISTAttestTest {
     }
 
     static class TestDTO {
-        @JsonProperty("tpmi_st_attest")
         public TPMISTAttest tpmiStAttest;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/statement/TPMISTAttestTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.attestation.statement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.util.Base64UrlUtil;
 import org.junit.jupiter.api.Test;
@@ -82,7 +83,7 @@ class TPMISTAttestTest {
     }
 
     static class TestDTO {
-        @com.fasterxml.jackson.annotation.JsonProperty("tpmi_st_attest")
+        @JsonProperty("tpmi_st_attest")
         public TPMISTAttest tpmiStAttest;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
@@ -54,7 +55,7 @@ class ClientDataTypeTest {
     }
 
     static class TestDTO {
-        @com.fasterxml.jackson.annotation.JsonProperty("client_data_type")
+        @JsonProperty("client_data_type")
         public ClientDataType clientDataType;
     }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
@@ -43,7 +43,7 @@ class ClientDataTypeTest {
     @Test
     void fromString_test() {
         TestDTO dto = jsonMapper.readValue("{\"client_data_type\":\"webauthn.create\"}", TestDTO.class);
-        assertThat(dto.client_data_type).isEqualTo(ClientDataType.WEBAUTHN_CREATE);
+        assertThat(dto.clientDataType).isEqualTo(ClientDataType.WEBAUTHN_CREATE);
     }
 
     @Test
@@ -54,7 +54,8 @@ class ClientDataTypeTest {
     }
 
     static class TestDTO {
-        public ClientDataType client_data_type;
+        @com.fasterxml.jackson.annotation.JsonProperty("client_data_type")
+        public ClientDataType clientDataType;
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.client;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
@@ -43,19 +42,18 @@ class ClientDataTypeTest {
     @SuppressWarnings("ConstantConditions")
     @Test
     void fromString_test() {
-        TestDTO dto = jsonMapper.readValue("{\"client_data_type\":\"webauthn.create\"}", TestDTO.class);
+        TestDTO dto = jsonMapper.readValue("{\"clientDataType\":\"webauthn.create\"}", TestDTO.class);
         assertThat(dto.clientDataType).isEqualTo(ClientDataType.WEBAUTHN_CREATE);
     }
 
     @Test
     void fromString_test_with_unknown_value() {
         assertThatCode(
-                () -> jsonMapper.readValue("{\"client_data_type\":\"unknown\"}", TestDTO.class)
+                () -> jsonMapper.readValue("{\"clientDataType\":\"unknown\"}", TestDTO.class)
         ).doesNotThrowAnyException();
     }
 
     static class TestDTO {
-        @JsonProperty("client_data_type")
         public ClientDataType clientDataType;
     }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Test for Origin
  */
-@SuppressWarnings("ConstantConditions")
+@SuppressWarnings({"ConstantConditions", "java:S117"})
 class OriginTest {
 
     private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWAIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWAIdentifierTest.java
@@ -16,6 +16,7 @@
 
 package com.webauthn4j.data.jws;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.SignatureAlgorithm;
 import org.junit.jupiter.api.Test;
@@ -93,7 +94,7 @@ class JWAIdentifierTest {
     }
 
     static class TestDTO {
-        @com.fasterxml.jackson.annotation.JsonProperty("jwa_id")
+        @JsonProperty("jwa_id")
         public JWAIdentifier jwaId;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWAIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWAIdentifierTest.java
@@ -69,7 +69,7 @@ class JWAIdentifierTest {
     @Test
     void fromString_test() {
         TestDTO dto = jsonMapper.readValue("{\"jwa_id\":\"ES256\"}", TestDTO.class);
-        assertThat(dto.jwa_id).isEqualTo(JWAIdentifier.ES256);
+        assertThat(dto.jwaId).isEqualTo(JWAIdentifier.ES256);
     }
 
     @Test
@@ -93,6 +93,7 @@ class JWAIdentifierTest {
     }
 
     static class TestDTO {
-        public JWAIdentifier jwa_id;
+        @com.fasterxml.jackson.annotation.JsonProperty("jwa_id")
+        public JWAIdentifier jwaId;
     }
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWAIdentifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWAIdentifierTest.java
@@ -16,7 +16,6 @@
 
 package com.webauthn4j.data.jws;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.SignatureAlgorithm;
 import org.junit.jupiter.api.Test;
@@ -69,14 +68,14 @@ class JWAIdentifierTest {
 
     @Test
     void fromString_test() {
-        TestDTO dto = jsonMapper.readValue("{\"jwa_id\":\"ES256\"}", TestDTO.class);
+        TestDTO dto = jsonMapper.readValue("{\"jwaId\":\"ES256\"}", TestDTO.class);
         assertThat(dto.jwaId).isEqualTo(JWAIdentifier.ES256);
     }
 
     @Test
     void fromString_test_with_invalid_value() {
         assertThrows(InvalidFormatException.class,
-                () -> jsonMapper.readValue("{\"jwa_id\":\"ES521\"}", TestDTO.class)
+                () -> jsonMapper.readValue("{\"jwaId\":\"ES521\"}", TestDTO.class)
         );
     }
 
@@ -94,7 +93,6 @@ class JWAIdentifierTest {
     }
 
     static class TestDTO {
-        @JsonProperty("jwa_id")
         public JWAIdentifier jwaId;
     }
 }


### PR DESCRIPTION
- OriginTest: add @SuppressWarnings("java:S117") for intentional snake_case local variables that represent URL patterns
- 10 TestDTO classes: rename snake_case fields to camelCase and update JSON test data keys to match