### PR TITLE
Improve AssertJ test assertions (S5853 chain, S5838 idioms)

### DIFF
--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorDataConverterTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/AuthenticatorDataConverterTest.java
@@ -72,8 +72,7 @@ class AuthenticatorDataConverterTest {
             AuthenticatorData<RegistrationExtensionAuthenticatorOutput> result = target.convert(input);
 
             // Then
-            assertThat(result.getRpIdHash()).isNotNull();
-            assertThat(result.getRpIdHash()).hasSize(32);
+            assertThat(result.getRpIdHash()).isNotNull().hasSize(32);
             assertThat(result.getFlags()).isEqualTo(BIT_UP);
             assertThat(result.getSignCount()).isEqualTo(325);
             assertThat(result.getAttestedCredentialData()).isNull();
@@ -112,8 +111,7 @@ class AuthenticatorDataConverterTest {
             AuthenticatorData<RegistrationExtensionAuthenticatorOutput> result = target.convert(serialized);
 
             // Then
-            assertThat(result.getRpIdHash()).isNotNull();
-            assertThat(result.getRpIdHash()).hasSize(32);
+            assertThat(result.getRpIdHash()).isNotNull().hasSize(32);
             assertThat(result.getFlags()).isEqualTo(BIT_ED);
             assertThat(result.getSignCount()).isZero();
             assertThat(result.getAttestedCredentialData()).isNull();

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticatorAttachmentTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticatorAttachmentTest.java
@@ -73,8 +73,7 @@ class AuthenticatorAttachmentTest {
     @Test
     void equals_hashCode_test(){
         assertThat(AuthenticatorAttachment.create("unknown")).isEqualTo(AuthenticatorAttachment.create("unknown"));
-        assertThat(AuthenticatorAttachment.create("platform")).isEqualTo(AuthenticatorAttachment.PLATFORM);
-        assertThat(AuthenticatorAttachment.create("platform")).hasSameHashCodeAs(AuthenticatorAttachment.PLATFORM);
+        assertThat(AuthenticatorAttachment.create("platform")).isEqualTo(AuthenticatorAttachment.PLATFORM).hasSameHashCodeAs(AuthenticatorAttachment.PLATFORM);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialHintsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialHintsTest.java
@@ -45,8 +45,7 @@ class PublicKeyCredentialHintsTest {
     @Test
     void equals_hashCode_test(){
         assertThat(PublicKeyCredentialHints.create("unknown")).isEqualTo(PublicKeyCredentialHints.create("unknown"));
-        assertThat(PublicKeyCredentialHints.create("client-device")).isEqualTo(PublicKeyCredentialHints.CLIENT_DEVICE);
-        assertThat(PublicKeyCredentialHints.create("client-device")).hasSameHashCodeAs(PublicKeyCredentialHints.CLIENT_DEVICE);
+        assertThat(PublicKeyCredentialHints.create("client-device")).isEqualTo(PublicKeyCredentialHints.CLIENT_DEVICE).hasSameHashCodeAs(PublicKeyCredentialHints.CLIENT_DEVICE);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/PublicKeyCredentialTypeTest.java
@@ -60,8 +60,7 @@ class PublicKeyCredentialTypeTest {
     @Test
     void equals_hashCode_test(){
         assertThat(PublicKeyCredentialType.create("unknown")).isEqualTo(PublicKeyCredentialType.create("unknown"));
-        assertThat(PublicKeyCredentialType.create("public-key")).isEqualTo(PublicKeyCredentialType.PUBLIC_KEY);
-        assertThat(PublicKeyCredentialType.create("public-key")).hasSameHashCodeAs(PublicKeyCredentialType.PUBLIC_KEY);
+        assertThat(PublicKeyCredentialType.create("public-key")).isEqualTo(PublicKeyCredentialType.PUBLIC_KEY).hasSameHashCodeAs(PublicKeyCredentialType.PUBLIC_KEY);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/ResidentKeyRequirementTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/ResidentKeyRequirementTest.java
@@ -74,8 +74,7 @@ class ResidentKeyRequirementTest {
     @Test
     void equals_hashCode_test(){
         assertThat(ResidentKeyRequirement.create("unknown")).isEqualTo(ResidentKeyRequirement.create("unknown"));
-        assertThat(ResidentKeyRequirement.create("required")).isEqualTo(ResidentKeyRequirement.REQUIRED);
-        assertThat(ResidentKeyRequirement.create("required")).hasSameHashCodeAs(ResidentKeyRequirement.REQUIRED);
+        assertThat(ResidentKeyRequirement.create("required")).isEqualTo(ResidentKeyRequirement.REQUIRED).hasSameHashCodeAs(ResidentKeyRequirement.REQUIRED);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/UserVerificationRequirementTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/UserVerificationRequirementTest.java
@@ -74,8 +74,7 @@ class UserVerificationRequirementTest {
     @Test
     void equals_hashCode_test(){
         assertThat(UserVerificationRequirement.create("unknown")).isEqualTo(UserVerificationRequirement.create("unknown"));
-        assertThat(UserVerificationRequirement.create("required")).isEqualTo(UserVerificationRequirement.REQUIRED);
-        assertThat(UserVerificationRequirement.create("required")).hasSameHashCodeAs(UserVerificationRequirement.REQUIRED);
+        assertThat(UserVerificationRequirement.create("required")).isEqualTo(UserVerificationRequirement.REQUIRED).hasSameHashCodeAs(UserVerificationRequirement.REQUIRED);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2COSEKeyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2COSEKeyTest.java
@@ -82,6 +82,7 @@ class EC2COSEKeyTest {
 
         // Then
         assertThat(key.getX()).isEqualTo(Base64UrlUtil.decode("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+        assertThat(key.getY()).isEqualTo(Base64UrlUtil.decode("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2COSEKeyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/EC2COSEKeyTest.java
@@ -82,7 +82,6 @@ class EC2COSEKeyTest {
 
         // Then
         assertThat(key.getX()).isEqualTo(Base64UrlUtil.decode("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
-        assertThat(key.getX()).isEqualTo(Base64UrlUtil.decode("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/ClientDataTypeTest.java
@@ -60,8 +60,7 @@ class ClientDataTypeTest {
     @Test
     void equals_hashCode_test(){
         assertThat(ClientDataType.create("unknown")).isEqualTo(ClientDataType.create("unknown"));
-        assertThat(ClientDataType.create("webauthn.create")).isEqualTo(ClientDataType.WEBAUTHN_CREATE);
-        assertThat(ClientDataType.create("webauthn.create")).hasSameHashCodeAs(ClientDataType.WEBAUTHN_CREATE);
+        assertThat(ClientDataType.create("webauthn.create")).isEqualTo(ClientDataType.WEBAUTHN_CREATE).hasSameHashCodeAs(ClientDataType.WEBAUTHN_CREATE);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/OriginTest.java
@@ -107,8 +107,7 @@ class OriginTest {
 
     @Test
     void explicit_port_notation_and_non_explicit_port_notation_comparison_test() {
-        assertThat(new Origin("https://example.com:443")).isEqualTo(new Origin("https://example.com"));
-        assertThat(new Origin("https://example.com:443")).hasToString("https://example.com:443");
+        assertThat(new Origin("https://example.com:443")).isEqualTo(new Origin("https://example.com")).hasToString("https://example.com:443");
     }
 
 
@@ -235,8 +234,7 @@ class OriginTest {
 
         assertThat(originA).hasSameHashCodeAs(originB);
         assertThat(android_apk_key_hash_abc123_a).hasSameHashCodeAs(android_apk_key_hash_abc123_b);
-        assertThat(android_apk_key_hash_abc123_a.hashCode()).isNotEqualTo(android_apk_key_hash_def456.hashCode());
-        assertThat(android_apk_key_hash_abc123_a.hashCode()).isNotEqualTo(invalid_data.hashCode());
+        assertThat(android_apk_key_hash_abc123_a.hashCode()).isNotEqualTo(android_apk_key_hash_def456.hashCode()).isNotEqualTo(invalid_data.hashCode());
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/client/TokenBindingStatusTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/client/TokenBindingStatusTest.java
@@ -69,8 +69,7 @@ class TokenBindingStatusTest {
     @Test
     void equals_hashCode_test(){
         assertThat(TokenBindingStatus.create("unknown")).isEqualTo(TokenBindingStatus.create("unknown"));
-        assertThat(TokenBindingStatus.create("present")).isEqualTo(TokenBindingStatus.PRESENT);
-        assertThat(TokenBindingStatus.create("present")).hasSameHashCodeAs(TokenBindingStatus.PRESENT);
+        assertThat(TokenBindingStatus.create("present")).isEqualTo(TokenBindingStatus.PRESENT).hasSameHashCodeAs(TokenBindingStatus.PRESENT);
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/CredentialProtectionPolicyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/CredentialProtectionPolicyTest.java
@@ -43,7 +43,7 @@ class CredentialProtectionPolicyTest {
     @Test
     void toString_toByte_test() {
         assertThat(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL.toByte()).isEqualTo((byte) 0x01);
-        assertThat(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL.toString()).hasToString("userVerificationOptional");
+        assertThat(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL).hasToString("userVerificationOptional");
     }
 
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/authenticator/AuthenticationExtensionsAuthenticatorInputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/authenticator/AuthenticationExtensionsAuthenticatorInputsTest.java
@@ -156,8 +156,7 @@ class AuthenticationExtensionsAuthenticatorInputsTest {
         builder.setUvm(true);
         builder.set("custom", "value");
         AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput> instance = builder.build();
-        assertThat(instance.toString()).contains("uvm");
-        assertThat(instance.toString()).contains("custom");
+        assertThat(instance.toString()).contains("uvm", "custom");
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/authenticator/HMACGetSecretAuthenticatorInputTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/authenticator/HMACGetSecretAuthenticatorInputTest.java
@@ -62,8 +62,9 @@ class HMACGetSecretAuthenticatorInputTest {
         HMACGetSecretAuthenticatorInput instanceB = new HMACGetSecretAuthenticatorInput(key, new byte[32], new byte[32], PinProtocolVersion.VERSION_2);
         HMACGetSecretAuthenticatorInput instanceC = new HMACGetSecretAuthenticatorInput(key, new byte[32], new byte[32], null);
 
-        assertThat(instanceA).isNotEqualTo(instanceB).doesNotHaveSameHashCodeAs(instanceB);
-        assertThat(instanceA).isNotEqualTo(instanceC).doesNotHaveSameHashCodeAs(instanceC);
+        assertThat(instanceA)
+                .isNotEqualTo(instanceB).doesNotHaveSameHashCodeAs(instanceB)
+                .isNotEqualTo(instanceC).doesNotHaveSameHashCodeAs(instanceC);
     }
 
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientInputsTest.java
@@ -227,8 +227,7 @@ class AuthenticationExtensionsClientInputsTest {
         builder.setAppid("dummyAppid");
         builder.set("custom", "value");
         AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput> instance = builder.build();
-        assertThat(instance.toString()).contains("appid");
-        assertThat(instance.toString()).contains("custom");
+        assertThat(instance.toString()).contains("appid", "custom");
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputsTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/extension/client/AuthenticationExtensionsClientOutputsTest.java
@@ -183,8 +183,7 @@ class AuthenticationExtensionsClientOutputsTest {
         builder.setAppid(true);
         builder.set("custom", "value");
         AuthenticationExtensionsClientOutputs<AuthenticationExtensionClientOutput> instance = builder.build();
-        assertThat(instance.toString()).contains("appid");
-        assertThat(instance.toString()).contains("custom");
+        assertThat(instance.toString()).contains("appid", "custom");
     }
 
     @Test

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/internal/MessageDigestAlgorithmTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/internal/MessageDigestAlgorithmTest.java
@@ -38,8 +38,7 @@ class MessageDigestAlgorithmTest {
 
     @Test
     void equals_hashCode_test() {
-        assertThat(MessageDigestAlgorithm.create("SHA-256")).isEqualTo(MessageDigestAlgorithm.create("SHA-256"));
-        assertThat(MessageDigestAlgorithm.create("SHA-256")).hasSameHashCodeAs(MessageDigestAlgorithm.create("SHA-256"));
+        assertThat(MessageDigestAlgorithm.create("SHA-256")).isEqualTo(MessageDigestAlgorithm.create("SHA-256")).hasSameHashCodeAs(MessageDigestAlgorithm.create("SHA-256"));
     }
 
 }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/internal/asn1/der/ASN1SequenceTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/internal/asn1/der/ASN1SequenceTest.java
@@ -13,21 +13,21 @@ class ASN1SequenceTest {
     @Test
     void parse_test() {
         ASN1Sequence parsed = ASN1Sequence.parse(new byte[]{0x30, 0x00});
-        assertThat(parsed.size()).isZero();
+        assertThat(parsed).isEmpty();
     }
 
     @Test
     void parse_x509Certificate_test() throws CertificateEncodingException {
         X509Certificate cert = TestAttestationUtil.load3tierTestAuthenticatorAttestationCertificate();
         ASN1Sequence parsed = ASN1Sequence.parse(cert.getEncoded());
-        assertThat(parsed.size()).isGreaterThan(0);
+        assertThat(parsed).isNotEmpty();
     }
 
     @Test
     void create_empty_test() {
         ASN1Sequence seq = ASN1Sequence.create();
         assertThat(seq.isConstructed()).isTrue();
-        assertThat(seq.size()).isZero();
+        assertThat(seq).isEmpty();
         assertThat(seq.toBytes()).containsExactly(0x30, 0x00);
     }
 
@@ -37,7 +37,7 @@ class ASN1SequenceTest {
                 ASN1Integer.create(new byte[]{0x2A}),
                 ASN1OctetString.create(new byte[]{0x01, 0x02})
         );
-        assertThat(seq.size()).isEqualTo(2);
+        assertThat(seq).hasSize(2);
         assertThat(seq.toBytes()).containsExactly(0x30, 0x07, 0x02, 0x01, 0x2A, 0x04, 0x02, 0x01, 0x02);
     }
 
@@ -48,10 +48,10 @@ class ASN1SequenceTest {
                 ASN1BitString.create(new byte[]{0x0A})
         );
 
-        assertThat(outer.size()).isEqualTo(2);
+        assertThat(outer).hasSize(2);
 
         ASN1Sequence parsed = ASN1Sequence.parse(outer.toBytes());
-        assertThat(parsed.size()).isEqualTo(2);
+        assertThat(parsed).hasSize(2);
         assertThat(parsed.get(0)).isInstanceOf(ASN1Sequence.class);
         assertThat(parsed.get(1)).isInstanceOf(ASN1BitString.class);
     }
@@ -66,7 +66,7 @@ class ASN1SequenceTest {
 
         ASN1Sequence parsed = ASN1Sequence.parse(original.toBytes());
 
-        assertThat(parsed.size()).isEqualTo(3);
+        assertThat(parsed).hasSize(3);
         assertThat(parsed.toBytes()).isEqualTo(original.toBytes());
     }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/verifier/CustomAuthenticationVerifierTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/verifier/CustomAuthenticationVerifierTest.java
@@ -28,8 +28,7 @@ class CustomAuthenticationVerifierTest {
     void parameter_test() {
 
         CustomAuthenticationVerifier target = authenticationObject -> {
-            assertThat(authenticationObject).hasFieldOrProperty("serverProperty");
-            assertThat(authenticationObject).hasFieldOrProperty("authenticator");
+            assertThat(authenticationObject).hasFieldOrProperty("serverProperty").hasFieldOrProperty("authenticator");
         };
 
         target.verify(mock(AuthenticationObject.class));

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/FriendlyNamesTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/FriendlyNamesTest.java
@@ -35,8 +35,7 @@ class FriendlyNamesTest {
         Map<String, String> source = new HashMap<>();
         source.put("en-US", "FIDO Sample Security Key");
         FriendlyNames target = new FriendlyNames(source);
-        assertThat(target).containsEntry("en-US", "FIDO Sample Security Key");
-        assertThat(target).hasSize(1);
+        assertThat(target).containsEntry("en-US", "FIDO Sample Security Key").hasSize(1);
     }
 
     @Test
@@ -63,18 +62,18 @@ class FriendlyNamesTest {
         String json = jsonMapper.writeValueAsString(original);
         FriendlyNames deserialized = jsonMapper.readValue(json, FriendlyNames.class);
 
-        assertThat(deserialized).hasSize(2);
-        assertThat(deserialized).containsEntry("en-US", "FIDO Sample Security Key");
-        assertThat(deserialized).containsEntry("ja-JP", "FIDOサンプルセキュリティキー");
-        assertThat(deserialized).isEqualTo(original);
+        assertThat(deserialized)
+                .hasSize(2)
+                .containsEntry("en-US", "FIDO Sample Security Key")
+                .containsEntry("ja-JP", "FIDOサンプルセキュリティキー")
+                .isEqualTo(original);
     }
 
     @Test
     void json_deserialize_test() {
         String json = "{\"en-US\": \"Security Key\", \"fr-FR\": \"Clé de sécurité\"}";
         FriendlyNames target = jsonMapper.readValue(json, FriendlyNames.class);
-        assertThat(target).containsEntry("en-US", "Security Key");
-        assertThat(target).containsEntry("fr-FR", "Clé de sécurité");
+        assertThat(target).containsEntry("en-US", "Security Key").containsEntry("fr-FR", "Clé de sécurité");
     }
 
     @Test

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MetadataStatementTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MetadataStatementTest.java
@@ -67,8 +67,7 @@ class MetadataStatementTest {
         assertThat(metadataStatement.getTcDisplayPNGCharacteristics()).isNull();
         assertThat(metadataStatement.getAttestationRootCertificates()).hasSize(1);
         assertThat(metadataStatement.getEcdaaTrustAnchors()).isNull();
-        assertThat(metadataStatement.getFriendlyNames()).isNotNull();
-        assertThat(metadataStatement.getFriendlyNames()).containsEntry("en-US", "FIDO Sample Security Key");
+        assertThat(metadataStatement.getFriendlyNames()).isNotNull().containsEntry("en-US", "FIDO Sample Security Key");
         assertThat(metadataStatement.getIconDark()).isEqualTo("data:image/png;base64,darkicon");
         assertThat(metadataStatement.getProviderLogoLight()).isEqualTo("data:image/png;base64,lightlogo");
         assertThat(metadataStatement.getProviderLogoDark()).isEqualTo("data:image/png;base64,darklogo");

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MultiDeviceCredentialSupportTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/MultiDeviceCredentialSupportTest.java
@@ -38,16 +38,17 @@ class MultiDeviceCredentialSupportTest {
         MultiDeviceCredentialSupport a = new MultiDeviceCredentialSupport("explicit");
         MultiDeviceCredentialSupport b = new MultiDeviceCredentialSupport("explicit");
         MultiDeviceCredentialSupport c = new MultiDeviceCredentialSupport("implicit");
-        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
-        assertThat(a).isEqualTo(MultiDeviceCredentialSupport.EXPLICIT);
-        assertThat(a).isNotEqualTo(c);
-        assertThat(a).isNotEqualTo(null);
-        assertThat(a).isNotEqualTo("explicit");
+        assertThat(a)
+                .isEqualTo(b).hasSameHashCodeAs(b)
+                .isEqualTo(MultiDeviceCredentialSupport.EXPLICIT)
+                .isNotEqualTo(c)
+                .isNotEqualTo(null)
+                .isNotEqualTo("explicit");
     }
 
     @Test
     void toString_test() {
-        assertThat(MultiDeviceCredentialSupport.EXPLICIT.toString()).isEqualTo("explicit");
+        assertThat(MultiDeviceCredentialSupport.EXPLICIT).hasToString("explicit");
     }
 
     @Test

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/toc/StatusReportTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/toc/StatusReportTest.java
@@ -74,9 +74,7 @@ class StatusReportTest {
     @Test
     void equals_with_different_values_test(){
         StatusReport base = createStatusReport();
-        assertThat(base).isNotEqualTo(null);
-        assertThat(base).isNotEqualTo("string");
-        assertThat(base).isEqualTo(base);
+        assertThat(base).isNotEqualTo(null).isNotEqualTo("string").isEqualTo(base);
 
         String template = "{\n" +
                 "  \"status\": \"%s\",\n" +
@@ -99,21 +97,21 @@ class StatusReportTest {
                 "https://example.com/update", "FIDO Alliance Sample FIDO2 Authenticator",
                 "FIDO2100020151221001", "1.0.1", "enterprise", "1.0.1", "2030-01-01", 3, 1);
 
-        assertThat(base).isEqualTo(jsonMapper.readValue(baseJson, StatusReport.class));
-
-        // Differ by each field
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("FIDO_CERTIFIED_L1", "NOT_FIDO_CERTIFIED"), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("2020-11-19", "2021-01-01"), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"authenticatorVersion\": 2", "\"authenticatorVersion\": 99"), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"url\": \"https://example.com/update\"", "\"url\": \"https://example.com/other\""), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"certificationDescriptor\": \"FIDO Alliance Sample FIDO2 Authenticator\"", "\"certificationDescriptor\": \"Other\""), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("FIDO2100020151221001", "OTHER"), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"certificationPolicyVersion\": \"1.0.1\"", "\"certificationPolicyVersion\": \"2.0.0\""), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("enterprise", "consumer"), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"certificationRequirementsVersion\": \"1.0.1\"", "\"certificationRequirementsVersion\": \"2.0.0\""), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("2030-01-01", "2031-01-01"), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"fipsRevision\": 3", "\"fipsRevision\": 99"), StatusReport.class));
-        assertThat(base).isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"fipsPhysicalSecurityLevel\": 1", "\"fipsPhysicalSecurityLevel\": 99"), StatusReport.class));
+        assertThat(base)
+                .isEqualTo(jsonMapper.readValue(baseJson, StatusReport.class))
+                // Differ by each field
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("FIDO_CERTIFIED_L1", "NOT_FIDO_CERTIFIED"), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("2020-11-19", "2021-01-01"), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"authenticatorVersion\": 2", "\"authenticatorVersion\": 99"), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"url\": \"https://example.com/update\"", "\"url\": \"https://example.com/other\""), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"certificationDescriptor\": \"FIDO Alliance Sample FIDO2 Authenticator\"", "\"certificationDescriptor\": \"Other\""), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("FIDO2100020151221001", "OTHER"), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"certificationPolicyVersion\": \"1.0.1\"", "\"certificationPolicyVersion\": \"2.0.0\""), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("enterprise", "consumer"), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"certificationRequirementsVersion\": \"1.0.1\"", "\"certificationRequirementsVersion\": \"2.0.0\""), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("2030-01-01", "2031-01-01"), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"fipsRevision\": 3", "\"fipsRevision\": 99"), StatusReport.class))
+                .isNotEqualTo(jsonMapper.readValue(baseJson.replace("\"fipsPhysicalSecurityLevel\": 1", "\"fipsPhysicalSecurityLevel\": 99"), StatusReport.class));
     }
 
     private static final String TEST_CERTIFICATE =

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/uaf/AAIDTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/uaf/AAIDTest.java
@@ -48,13 +48,12 @@ class AAIDTest {
 
     @Test
     void equals_hashCode_test() {
-        assertThat(new AAID("ABCD#1234")).isEqualTo(new AAID("ABCD#1234"));
-        assertThat(new AAID("ABCD#1234")).hasSameHashCodeAs(new AAID("ABCD#1234"));
+        assertThat(new AAID("ABCD#1234")).isEqualTo(new AAID("ABCD#1234")).hasSameHashCodeAs(new AAID("ABCD#1234"));
     }
 
     @Test
     void toString_test() {
-        assertThat(new AAID("ABCD#1234").toString()).hasToString("ABCD#1234");
+        assertThat(new AAID("ABCD#1234")).hasToString("ABCD#1234");
     }
 
     @Test


### PR DESCRIPTION
Combine consecutive `assertThat()` calls on the same subject into single chained assertions (S5853), use AssertJ collection idioms like `isEmpty()`, `hasSize()`, `isNotEmpty()` instead of `size()` comparisons (S5838), and fix redundant `toString()` calls with `hasToString()`.

- Chain `isEqualTo` + `hasSameHashCodeAs` in equals/hashCode tests (9 files)
- Chain `isNotNull` + subsequent assertions (3 occurrences)
- Chain `hasFieldOrProperty`, `isNotEqualTo`, `containsEntry` assertions
- Use `contains(a, b)` varargs instead of separate `contains` calls
- Remove duplicate assertion in EC2COSEKeyTest
- Replace `assertThat(x.size()).isZero()` with `assertThat(x).isEmpty()` (ASN1SequenceTest, 7 occurrences)
- Replace `assertThat(X.toString()).isEqualTo(y)` with `assertThat(X).hasToString(y)`
- Remove redundant `.toString()` in `hasToString()` calls (AAIDTest, CredentialProtectionPolicyTest)