### PR TITLE
Extract duplicated string literals into constants (S1192)

### DIFF
--- a/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCRegistrationObject.java
+++ b/webauthn4j-appattest/src/main/java/com/webauthn4j/appattest/verifier/DCRegistrationObject.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 
 public class DCRegistrationObject extends CoreRegistrationObject {
 
+    private static final String KEY_ID_NULL_CHECK_MESSAGE = "keyId must not be null";
     private final byte[] keyId;
 
     public DCRegistrationObject(
@@ -41,7 +42,7 @@ public class DCRegistrationObject extends CoreRegistrationObject {
             @NotNull Instant timestamp) {
         super(attestationObject, attestationObjectBytes, clientDataHash, dcAttestationParameters, timestamp);
 
-        AssertUtil.notNull(keyId, "keyId must not be null");
+        AssertUtil.notNull(keyId, KEY_ID_NULL_CHECK_MESSAGE);
 
         this.keyId = ArrayUtil.clone(keyId);
     }
@@ -68,7 +69,7 @@ public class DCRegistrationObject extends CoreRegistrationObject {
             @NotNull Instant timestamp) {
         super(attestationObject, attestationObjectBytes, clientDataHash, serverProperty, timestamp);
 
-        AssertUtil.notNull(keyId, "keyId must not be null");
+        AssertUtil.notNull(keyId, KEY_ID_NULL_CHECK_MESSAGE);
 
         this.keyId = ArrayUtil.clone(keyId);
     }
@@ -85,7 +86,7 @@ public class DCRegistrationObject extends CoreRegistrationObject {
             @NotNull CoreServerProperty serverProperty) {
         super(attestationObject, attestationObjectBytes, clientDataHash, serverProperty);
 
-        AssertUtil.notNull(keyId, "keyId must not be null");
+        AssertUtil.notNull(keyId, KEY_ID_NULL_CHECK_MESSAGE);
 
         this.keyId = ArrayUtil.clone(keyId);
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/server/ServerProperty.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/server/ServerProperty.java
@@ -51,6 +51,7 @@ public class ServerProperty extends CoreServerProperty {
     }
 
     public static class Builder {
+        private static final String VALUE_NULL_CHECK_MESSAGE = "value must not be null";
         private OriginPredicate originPredicate;
         private String rpId;
         private Challenge challenge;
@@ -66,7 +67,7 @@ public class ServerProperty extends CoreServerProperty {
          * @return the builder instance for method chaining
          */
         public Builder origin(@NotNull Origin value) {
-            AssertUtil.notNull(value, "value must not be null");
+            AssertUtil.notNull(value, VALUE_NULL_CHECK_MESSAGE);
             this.originPredicate = new SimpleOriginPredicate(value);
             return this;
         }
@@ -79,7 +80,7 @@ public class ServerProperty extends CoreServerProperty {
          * @return the builder instance for method chaining
          */
         public Builder origins(@NotNull Set<Origin> value) {
-            AssertUtil.notNull(value, "value must not be null");
+            AssertUtil.notNull(value, VALUE_NULL_CHECK_MESSAGE);
             AssertUtil.notEmpty(value, "value must not be empty");
             this.originPredicate = new SimpleOriginPredicate(value);
             return this;
@@ -94,7 +95,7 @@ public class ServerProperty extends CoreServerProperty {
          * @return the builder instance for method chaining
          */
         public Builder originPredicate(@NotNull OriginPredicate value) {
-            AssertUtil.notNull(value, "value must not be null");
+            AssertUtil.notNull(value, VALUE_NULL_CHECK_MESSAGE);
             this.originPredicate = value;
             return this;
         }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/util/Base64UrlUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/util/Base64UrlUtil.java
@@ -25,6 +25,7 @@ import java.util.Base64;
  */
 public class Base64UrlUtil {
 
+    private static final String SOURCE_NULL_CHECK_MESSAGE = "source must not be null";
     private static final java.util.Base64.Decoder decoder = Base64.getUrlDecoder();
     private static final java.util.Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
 
@@ -32,22 +33,22 @@ public class Base64UrlUtil {
     }
 
     public static @NotNull byte[] decode(@NotNull String source) {
-        AssertUtil.notNull(source, "source must not be null");
+        AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
         return decoder.decode(source);
     }
 
     public static @NotNull byte[] decode(@NotNull byte[] source) {
-        AssertUtil.notNull(source, "source must not be null");
+        AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
         return decoder.decode(source);
     }
 
     public static @NotNull byte[] encode(@NotNull byte[] source) {
-        AssertUtil.notNull(source, "source must not be null");
+        AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
         return encoder.encode(source);
     }
 
     public static @NotNull String encodeToString(@NotNull byte[] source) {
-        AssertUtil.notNull(source, "source must not be null");
+        AssertUtil.notNull(source, SOURCE_NULL_CHECK_MESSAGE);
         return encoder.encodeToString(source);
     }
 }


### PR DESCRIPTION
Extract duplicated assertion message string literals into `private static final String` constants, following the existing project pattern (e.g., `AttestationObjectConverter`, `JWSFactory`, `EdDSACOSEKey`).

- `Base64UrlUtil`: extract `"source must not be null"` (4 occurrences)
- `ServerProperty.Builder`: extract `"value must not be null"` (3 occurrences)
- `DCRegistrationObject`: extract `"keyId must not be null"` (3 occurrences)