### PR TITLE
Suppress SonarCloud rule S3776 (cognitive complexity)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifier.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/COSEAlgorithmIdentifier.java
@@ -194,6 +194,7 @@ public class COSEAlgorithmIdentifier {
         return Objects.hash(value);
     }
 
+    @SuppressWarnings("java:S3776") // Cognitive complexity is acceptable for simple value-to-name mapping
     @Override
     public String toString() {
         if(value == RS1.value){

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/HMACSecretAuthenticationExtensionAuthenticatorInput.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/extension/authenticator/HMACSecretAuthenticationExtensionAuthenticatorInput.java
@@ -35,7 +35,7 @@ public class HMACSecretAuthenticationExtensionAuthenticatorInput extends SingleV
         return ID;
     }
 
-    @SuppressWarnings({"ConstantConditions", "java:S2583"})
+    @SuppressWarnings({"ConstantConditions", "java:S2583", "java:S3776"}) // Cognitive complexity is acceptable for sequential validation
     @Override
     public void validate() {
         // value can be null when deserialized by Jackson


### PR DESCRIPTION
Add @SuppressWarnings("java:S3776") with comments to methods where cognitive complexity slightly exceeds the threshold but refactoring would reduce readability.

- `COSEAlgorithmIdentifier.toString()`: simple value-to-name mapping via if-else chain (complexity 17, threshold 15)
- `HMACSecretAuthenticationExtensionAuthenticatorInput.validate()`: sequential validation logic (complexity 18, threshold 15)