### PR TITLE
Add missing @Override annotations (S1161)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
@@ -134,6 +134,7 @@ public class AuthenticationParameters extends CoreAuthenticationParameters {
      * @return the credential record
      * @throws IllegalStateException if the internal authenticator is not an instance of {@link CredentialRecord}
      */
+    @Override
     public @NotNull CredentialRecord getCredentialRecord() {
         return (CredentialRecord) super.getCredentialRecord();
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
@@ -121,6 +121,7 @@ public class AuthenticationObject extends CoreAuthenticationObject {
      * @return the credential record
      * @throws IllegalStateException if the internal authenticator is not an instance of {@link CredentialRecord}
      */
+    @Override
     public @NotNull CredentialRecord getCredentialRecord() {
         return (CredentialRecord) super.getCredentialRecord();
     }


### PR DESCRIPTION
Add missing @Override annotations to getCredentialRecord() methods that override parent class methods.

- AuthenticationParameters.getCredentialRecord()
- AuthenticationObject.getCredentialRecord()