### PR TITLE
Use Month enum constants and AssertJ idioms in tests (S8694, S5838)

### DIFF
--- a/webauthn4j-core/src/test/java/com/webauthn4j/verifier/exception/MaliciousCounterValueExceptionTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/verifier/exception/MaliciousCounterValueExceptionTest.java
@@ -52,18 +52,18 @@ class MaliciousCounterValueExceptionTest {
                 () -> assertThat(exception2.getCause()).isNull(),
 
                 () -> assertThat(exception3.getMessage()).isEqualTo("dummy"),
-                () -> assertThat(exception3.getStoredCounter()).isEqualTo(0L),  // default
-                () -> assertThat(exception3.getPresentedCounter()).isEqualTo(0L),  // default
+                () -> assertThat(exception3.getStoredCounter()).isZero(),  // default
+                () -> assertThat(exception3.getPresentedCounter()).isZero(),  // default
                 () -> assertThat(exception3.getCause()).isEqualTo(cause),
 
                 () -> assertThat(exception4.getMessage()).isEqualTo("dummy"),
-                () -> assertThat(exception4.getStoredCounter()).isEqualTo(0L),
-                () -> assertThat(exception4.getPresentedCounter()).isEqualTo(0L),
+                () -> assertThat(exception4.getStoredCounter()).isZero(),
+                () -> assertThat(exception4.getPresentedCounter()).isZero(),
                 () -> assertThat(exception4.getCause()).isNull(),
 
                 () -> assertThat(exception5.getMessage()).isEqualTo(cause.toString()),
-                () -> assertThat(exception5.getStoredCounter()).isEqualTo(0L),
-                () -> assertThat(exception5.getPresentedCounter()).isEqualTo(0L),
+                () -> assertThat(exception5.getStoredCounter()).isZero(),
+                () -> assertThat(exception5.getPresentedCounter()).isZero(),
                 () -> assertThat(exception5.getCause()).isEqualTo(cause)
         );
     }

--- a/webauthn4j-metadata-async/src/test/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProviderTest.java
+++ b/webauthn4j-metadata-async/src/test/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProviderTest.java
@@ -12,6 +12,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -22,11 +23,11 @@ class CachingMetadataBLOBAsyncProviderTest {
 
     @Test
     void nextUpdate_is_past_date_test() throws ExecutionException, InterruptedException {
-        LocalDate nextUpdate = LocalDate.of(2020, 1, 2);
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 2);
         CachingMetadataBLOBAsyncProvider target = spy(CachingMetadataBLOBAsyncProvider.class);
         when(target.doProvide()).thenReturn(CompletableFuture.completedFuture(createMetadataBLOB(nextUpdate)));
-        LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
-        LocalDate secondTrialDay = LocalDate.of(2020, 1, 3);
+        LocalDate firstTrialDay = LocalDate.of(2020, Month.JANUARY, 1);
+        LocalDate secondTrialDay = LocalDate.of(2020, Month.JANUARY, 3);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
             mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide().toCompletableFuture().get();
@@ -38,11 +39,11 @@ class CachingMetadataBLOBAsyncProviderTest {
 
     @Test
     void nextUpdate_is_today_test(){
-        LocalDate nextUpdate = LocalDate.of(2020, 1, 2);
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 2);
         CachingMetadataBLOBAsyncProvider target = spy(CachingMetadataBLOBAsyncProvider.class);
         when(target.doProvide()).thenReturn(CompletableFuture.completedFuture(createMetadataBLOB(nextUpdate)));
-        LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
-        LocalDate secondTrialDay = LocalDate.of(2020, 1, 2);
+        LocalDate firstTrialDay = LocalDate.of(2020, Month.JANUARY, 1);
+        LocalDate secondTrialDay = LocalDate.of(2020, Month.JANUARY, 2);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
             mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();
@@ -54,11 +55,11 @@ class CachingMetadataBLOBAsyncProviderTest {
 
     @Test
     void nextUpdate_is_future_date_test(){
-        LocalDate nextUpdate = LocalDate.of(2020, 1, 3);
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 3);
         CachingMetadataBLOBAsyncProvider target = spy(CachingMetadataBLOBAsyncProvider.class);
         when(target.doProvide()).thenReturn(CompletableFuture.completedFuture(createMetadataBLOB(nextUpdate)));
-        LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
-        LocalDate secondTrialDay = LocalDate.of(2020, 1, 2);
+        LocalDate firstTrialDay = LocalDate.of(2020, Month.JANUARY, 1);
+        LocalDate secondTrialDay = LocalDate.of(2020, Month.JANUARY, 2);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
             mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/CachingMetadataBLOBProviderTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/CachingMetadataBLOBProviderTest.java
@@ -12,6 +12,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Collections;
 
 import static org.mockito.Mockito.*;
@@ -21,11 +22,11 @@ class CachingMetadataBLOBProviderTest {
 
     @Test
     void nextUpdate_is_past_date_test(){
-        LocalDate nextUpdate = LocalDate.of(2020, 1, 2);
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 2);
         CachingMetadataBLOBProvider target = spy(CachingMetadataBLOBProvider.class);
         when(target.doProvide()).thenReturn(createMetadataBLOB(nextUpdate));
-        LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
-        LocalDate secondTrialDay = LocalDate.of(2020, 1, 3);
+        LocalDate firstTrialDay = LocalDate.of(2020, Month.JANUARY, 1);
+        LocalDate secondTrialDay = LocalDate.of(2020, Month.JANUARY, 3);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
             mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();
@@ -37,11 +38,11 @@ class CachingMetadataBLOBProviderTest {
 
     @Test
     void nextUpdate_is_today_test(){
-        LocalDate nextUpdate = LocalDate.of(2020, 1, 2);
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 2);
         CachingMetadataBLOBProvider target = spy(CachingMetadataBLOBProvider.class);
         when(target.doProvide()).thenReturn(createMetadataBLOB(nextUpdate));
-        LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
-        LocalDate secondTrialDay = LocalDate.of(2020, 1, 2);
+        LocalDate firstTrialDay = LocalDate.of(2020, Month.JANUARY, 1);
+        LocalDate secondTrialDay = LocalDate.of(2020, Month.JANUARY, 2);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
             mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();
@@ -53,11 +54,11 @@ class CachingMetadataBLOBProviderTest {
 
     @Test
     void nextUpdate_is_future_date_test(){
-        LocalDate nextUpdate = LocalDate.of(2020, 1, 3);
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 3);
         CachingMetadataBLOBProvider target = spy(CachingMetadataBLOBProvider.class);
         when(target.doProvide()).thenReturn(createMetadataBLOB(nextUpdate));
-        LocalDate firstTrialDay = LocalDate.of(2020, 1, 1);
-        LocalDate secondTrialDay = LocalDate.of(2020, 1, 2);
+        LocalDate firstTrialDay = LocalDate.of(2020, Month.JANUARY, 1);
+        LocalDate secondTrialDay = LocalDate.of(2020, Month.JANUARY, 2);
         try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
             mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
             target.provide();


### PR DESCRIPTION
- Use Month enum constants instead of int literals in LocalDate.of() calls (S8694)
- Use AssertJ isZero() instead of isEqualTo(0L) (S5838)