### PR TITLE
Remove unnecessary transient modifiers (S2065)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/AbstractCtapCanonicalCborSerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/AbstractCtapCanonicalCborSerializer.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractCtapCanonicalCborSerializer<T> extends StdSerializer<T> {
 
-    private final transient List<FieldSerializationRule<T, ?>> rules;
+    private final List<FieldSerializationRule<T, ?>> rules;
 
     protected AbstractCtapCanonicalCborSerializer(@NotNull Class<T> t, @NotNull List<FieldSerializationRule<T, ?>> rules) {
         super(t);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AbstractImmutableMap.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AbstractImmutableMap.java
@@ -26,7 +26,7 @@ import java.util.*;
 public abstract class AbstractImmutableMap<K, V> extends AbstractMap<K, V> {
 
     private final HashMap<K, V> map;
-    private transient Set<Entry<K, V>> cachedEntrySet;
+    private Set<Entry<K, V>> cachedEntrySet;
 
     @JsonCreator
     protected AbstractImmutableMap(@NotNull Map<K, V> map) {

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/NoneAttestationStatement.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/NoneAttestationStatement.java
@@ -33,7 +33,7 @@ public class NoneAttestationStatement implements AttestationStatement {
     public static final String FORMAT = "none";
 
     @JsonIgnore
-    private final transient Map<String, Object> unknownProperties = new HashMap<>();
+    private final Map<String, Object> unknownProperties = new HashMap<>();
 
     @JsonIgnore
     @Override

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWS.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWS.java
@@ -32,7 +32,7 @@ import java.security.interfaces.ECPublicKey;
 
 public class JWS<T> {
 
-    private final transient Logger logger;
+    private final Logger logger;
 
     private final JWSHeader header;
     private final T payload;


### PR DESCRIPTION
Remove transient modifiers from fields in classes that do not implement Serializable.

- NoneAttestationStatement
- AbstractCtapCanonicalCborSerializer
- JWS
- AbstractImmutableMap