### PR TITLE
Add input validation to TPMTPublicDeserializer

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/TPMTPublicDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/TPMTPublicDeserializer.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.converter.jackson.deserializer.cbor;
 
 import com.webauthn4j.data.attestation.statement.*;
+import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.util.UnsignedNumberUtil;
 import com.webauthn4j.util.exception.NotImplementedException;
 import org.jetbrains.annotations.NotNull;
@@ -25,6 +26,7 @@ import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.deser.std.StdDeserializer;
 import tools.jackson.databind.exc.InvalidFormatException;
 
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
 /**
@@ -47,22 +49,28 @@ public class TPMTPublicDeserializer extends StdDeserializer<TPMTPublic> {
     }
 
     @NotNull TPMTPublic deserialize(@NotNull byte[] value) {
-        ByteBuffer buffer = ByteBuffer.wrap(value);
+        AssertUtil.notNull(value, "value must not be null");
+        try {
+            ByteBuffer buffer = ByteBuffer.wrap(value);
 
-        int typeValue = UnsignedNumberUtil.getUnsignedShort(buffer);
-        TPMIAlgPublic type = TPMIAlgPublic.create(typeValue);
-        TPMIAlgHash nameAlgValue = TPMIAlgHash.create(UnsignedNumberUtil.getUnsignedShort(buffer));
-        TPMAObject objectAttributes = extractTPMAObject(buffer);
-        int authPolicySize = UnsignedNumberUtil.getUnsignedShort(buffer);
-        byte[] authPolicy = new byte[authPolicySize];
-        buffer.get(authPolicy);
-        TPMUPublicParms parameters = extractTPMUPublicParms(type, buffer);
-        TPMUPublicId unique = extractTPMUPublicId(type, buffer);
-        if (buffer.remaining() > 0) {
-            throw new IllegalArgumentException("input byte array contains surplus data");
+            int typeValue = UnsignedNumberUtil.getUnsignedShort(buffer);
+            TPMIAlgPublic type = TPMIAlgPublic.create(typeValue);
+            TPMIAlgHash nameAlgValue = TPMIAlgHash.create(UnsignedNumberUtil.getUnsignedShort(buffer));
+            TPMAObject objectAttributes = extractTPMAObject(buffer);
+            int authPolicySize = UnsignedNumberUtil.getUnsignedShort(buffer);
+            byte[] authPolicy = new byte[authPolicySize];
+            buffer.get(authPolicy);
+            TPMUPublicParms parameters = extractTPMUPublicParms(type, buffer);
+            TPMUPublicId unique = extractTPMUPublicId(type, buffer);
+            if (buffer.remaining() > 0) {
+                throw new IllegalArgumentException("input byte array contains surplus data");
+            }
+
+            return new TPMTPublic(type, nameAlgValue, objectAttributes, authPolicy, parameters, unique);
         }
-
-        return new TPMTPublic(type, nameAlgValue, objectAttributes, authPolicy, parameters, unique);
+        catch (BufferUnderflowException e) {
+            throw new IllegalArgumentException("input byte array is too short", e);
+        }
     }
 
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/cbor/TPMTPublicDeserializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/deserializer/cbor/TPMTPublicDeserializerTest.java
@@ -19,7 +19,6 @@ package com.webauthn4j.converter.jackson.deserializer.cbor;
 
 import com.webauthn4j.data.attestation.statement.TPMTPublic;
 import com.webauthn4j.util.Base64Util;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +44,6 @@ class TPMTPublicDeserializerTest {
         assertThat(value.getBytes()).isEqualTo(inputBytes);
     }
 
-    @Disabled
     @Test
     void shouldThrowExceptionForInvalidInput() {
         // Given
@@ -57,7 +55,6 @@ class TPMTPublicDeserializerTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Disabled
     @Test
     void shouldThrowExceptionForNullInput() {
         // Given


### PR DESCRIPTION
Add null check and catch `BufferUnderflowException` in `TPMTPublicDeserializer.deserialize(byte[])` so that invalid inputs throw `IllegalArgumentException` instead of leaking implementation details (`NullPointerException`, `BufferUnderflowException`).

Enable the previously `@Disabled` tests that verify this behavior.