### PR TITLE
Remove redundant SAM constructors (kotlin:S6626)

### DIFF
--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
@@ -5,7 +5,6 @@ import com.webauthn4j.credential.CredentialRecord
 import com.webauthn4j.credential.CredentialRecordImpl
 import com.webauthn4j.ctap.client.PublicKeyCredentialCreationContext
 import com.webauthn4j.ctap.client.PublicKeyCredentialRequestContext
-import com.webauthn4j.ctap.client.PublicKeyCredentialSelectionHandler
 import com.webauthn4j.data.*
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import com.webauthn4j.data.client.Origin
@@ -205,7 +204,7 @@ class StandardScenario internal constructor(
             }
             val context = PublicKeyCredentialRequestContext(
                 overrideOrigin ?: clientPlatform.origin,
-                publicKeyCredentialSelectionHandler = PublicKeyCredentialSelectionHandler { it.first() },
+                publicKeyCredentialSelectionHandler = { it.first() },
                 clientPINProvider = { clientPlatform.clientPINValue.toByteArray() }
             )
             val credential = clientPlatform.webAuthnClient.get(effectiveOptions, context)

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialSelectorSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialSelectorSpec.kt
@@ -4,7 +4,6 @@ import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
 import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting.*
 import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
 import com.webauthn4j.ctap.client.PublicKeyCredentialRequestContext
-import com.webauthn4j.ctap.client.PublicKeyCredentialSelectionHandler
 import com.webauthn4j.data.ResidentKeyRequirement
 import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
 import io.kotest.core.annotation.Tags
@@ -37,7 +36,7 @@ class CredentialSelectorSpec : BehaviorSpec({
                 val options = env.scenario.createAuthenticationOptions(allowCredentials = null)
                 val context = PublicKeyCredentialRequestContext(
                     env.clientPlatform.origin,
-                    publicKeyCredentialSelectionHandler = PublicKeyCredentialSelectionHandler {
+                    publicKeyCredentialSelectionHandler = {
                         candidateCount = it.size
                         it.first()
                     },

--- a/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishPlugin.kt
+++ b/maven-central-publish-plugin/src/main/kotlin/net/sharplab/gradle/mavencentral/MavenCentralPublishPlugin.kt
@@ -1,9 +1,7 @@
 package net.sharplab.gradle.mavencentral
 
-import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.publish.PublishingExtension
 
 /**
@@ -54,10 +52,10 @@ class MavenCentralPublishPlugin : Plugin<Project> {
                     val stagingDir = subproject.layout.buildDirectory.dir("maven-central-publish-staging")
 
                     subproject.extensions.configure(PublishingExtension::class.java) {
-                        repositories.maven(Action<MavenArtifactRepository> {
+                        repositories.maven {
                             name = "mavenCentralStaging"
                             url = stagingDir.get().asFile.toURI()
-                        })
+                        }
                     }
 
                     taskProvider.configure {


### PR DESCRIPTION
Remove redundant SAM constructor wrappers that Kotlin can infer automatically.

- `PublicKeyCredentialSelectionHandler { ... }` → `{ ... }` in CredentialSelectorSpec and StandardScenario
- `Action<MavenArtifactRepository> { ... }` → trailing lambda in MavenCentralPublishPlugin
- Remove now-unused imports