### PR TITLE
Remove redundant @Deprecated on overriding methods (java:S3038)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticationParameters.java
@@ -114,10 +114,6 @@ public class AuthenticationParameters extends CoreAuthenticationParameters {
         return (ServerProperty) super.getServerProperty();
     }
 
-    /**
-     * @deprecated Use {@link #getCredentialRecord()} instead. This method will be removed in a future version.
-     */
-    @Deprecated
     @Override
     public @NotNull Authenticator getAuthenticator() {
         return (Authenticator) super.getAuthenticator();

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/AuthenticationObject.java
@@ -92,19 +92,11 @@ public class AuthenticationObject extends CoreAuthenticationObject {
         return (AuthenticationParameters) super.getAuthenticationParameters();
     }
 
-    /**
-     * @deprecated Use {@code getAuthenticationParameters().getServerProperty()} instead.
-     */
-    @Deprecated
     @Override
     public @NotNull ServerProperty getServerProperty() {
         return (ServerProperty) super.getServerProperty();
     }
 
-    /**
-     * @deprecated Use {@link #getCredentialRecord()} instead. This method will be removed in a future version.
-     */
-    @Deprecated
     @Override
     public @NotNull Authenticator getAuthenticator() {
         return (Authenticator) super.getAuthenticator();

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationObject.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/RegistrationObject.java
@@ -149,10 +149,6 @@ public class RegistrationObject extends CoreRegistrationObject {
         return transports;
     }
 
-    /**
-     * @deprecated Use {@code getRegistrationParameters().getServerProperty()} instead.
-     */
-    @Deprecated
     @Override
     public @NotNull ServerProperty getServerProperty() {
         return (ServerProperty) super.getServerProperty();


### PR DESCRIPTION
Remove `@Deprecated` annotations and `@deprecated` Javadoc from overriding methods where the parent class already carries the annotation.

- `AuthenticationObject.getServerProperty()` / `getAuthenticator()`
- `AuthenticationParameters.getAuthenticator()`
- `RegistrationObject.getServerProperty()`