### PR TITLE
Remove unnecessary casts (java:S1905)

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/AuthenticationExtensionsAuthenticatorInputsDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/AuthenticationExtensionsAuthenticatorInputsDeserializer.java
@@ -23,7 +23,7 @@ public class AuthenticationExtensionsAuthenticatorInputsDeserializer extends Std
 
     @Override
     public AuthenticationExtensionsAuthenticatorInputs<?> deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         return new AuthenticationExtensionsAuthenticatorInputs<>(node, objectConverter);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/AuthenticationExtensionsAuthenticatorOutputsDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/AuthenticationExtensionsAuthenticatorOutputsDeserializer.java
@@ -23,7 +23,7 @@ public class AuthenticationExtensionsAuthenticatorOutputsDeserializer extends St
 
     @Override
     public AuthenticationExtensionsAuthenticatorOutputs<?> deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         return new AuthenticationExtensionsAuthenticatorOutputs<>(node, objectConverter);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/CredentialProtectionExtensionAuthenticatorInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/CredentialProtectionExtensionAuthenticatorInputDeserializer.java
@@ -23,7 +23,7 @@ public class CredentialProtectionExtensionAuthenticatorInputDeserializer extends
 
     @Override
     public CredentialProtectionExtensionAuthenticatorInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(CredentialProtectionExtensionAuthenticatorInput.KEY_CRED_PROTECT);
         if (value == null || value.isNull()) return null;
         CredentialProtectionPolicy policy = ctxt.readTreeAsValue(value, CredentialProtectionPolicy.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/CredentialProtectionExtensionAuthenticatorOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/CredentialProtectionExtensionAuthenticatorOutputDeserializer.java
@@ -23,7 +23,7 @@ public class CredentialProtectionExtensionAuthenticatorOutputDeserializer extend
 
     @Override
     public CredentialProtectionExtensionAuthenticatorOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(CredentialProtectionExtensionAuthenticatorOutput.KEY_CRED_PROTECT);
         if (value == null || value.isNull()) return null;
         CredentialProtectionPolicy policy = ctxt.readTreeAsValue(value, CredentialProtectionPolicy.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/HMACSecretAuthenticationExtensionAuthenticatorInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/HMACSecretAuthenticationExtensionAuthenticatorInputDeserializer.java
@@ -23,7 +23,7 @@ public class HMACSecretAuthenticationExtensionAuthenticatorInputDeserializer ext
 
     @Override
     public HMACSecretAuthenticationExtensionAuthenticatorInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(HMACSecretAuthenticationExtensionAuthenticatorInput.KEY_HMAC_SECRET);
         if (value == null || value.isNull()) return null;
         if (value.isBoolean()) return null;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/HMACSecretAuthenticationExtensionAuthenticatorOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/HMACSecretAuthenticationExtensionAuthenticatorOutputDeserializer.java
@@ -22,7 +22,7 @@ public class HMACSecretAuthenticationExtensionAuthenticatorOutputDeserializer ex
 
     @Override
     public HMACSecretAuthenticationExtensionAuthenticatorOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(HMACSecretAuthenticationExtensionAuthenticatorOutput.KEY_HMAC_SECRET);
         if (value == null || value.isNull()) return null;
         if (value.isBoolean()) return null;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/HMACSecretRegistrationExtensionAuthenticatorInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/HMACSecretRegistrationExtensionAuthenticatorInputDeserializer.java
@@ -22,7 +22,7 @@ public class HMACSecretRegistrationExtensionAuthenticatorInputDeserializer exten
 
     @Override
     public HMACSecretRegistrationExtensionAuthenticatorInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(HMACSecretRegistrationExtensionAuthenticatorInput.KEY_HMAC_SECRET);
         if (value == null || value.isNull()) return null;
         if (!value.isBoolean()) return null;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/HMACSecretRegistrationExtensionAuthenticatorOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/HMACSecretRegistrationExtensionAuthenticatorOutputDeserializer.java
@@ -22,7 +22,7 @@ public class HMACSecretRegistrationExtensionAuthenticatorOutputDeserializer exte
 
     @Override
     public HMACSecretRegistrationExtensionAuthenticatorOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(HMACSecretRegistrationExtensionAuthenticatorOutput.KEY_HMAC_SECRET);
         if (value == null || value.isNull()) return null;
         if (!value.isBoolean()) return null;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/UserVerificationMethodExtensionAuthenticatorInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/UserVerificationMethodExtensionAuthenticatorInputDeserializer.java
@@ -22,7 +22,7 @@ public class UserVerificationMethodExtensionAuthenticatorInputDeserializer exten
 
     @Override
     public UserVerificationMethodExtensionAuthenticatorInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(UserVerificationMethodExtensionAuthenticatorInput.KEY_UVM);
         if (value == null || value.isNull()) return null;
         return new UserVerificationMethodExtensionAuthenticatorInput(value.asBoolean());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/UserVerificationMethodExtensionAuthenticatorOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/cbor/UserVerificationMethodExtensionAuthenticatorOutputDeserializer.java
@@ -23,7 +23,7 @@ public class UserVerificationMethodExtensionAuthenticatorOutputDeserializer exte
 
     @Override
     public UserVerificationMethodExtensionAuthenticatorOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(UserVerificationMethodExtensionAuthenticatorOutput.KEY_UVM);
         if (value == null || value.isNull()) return null;
         UvmEntries uvmEntries = ctxt.readTreeAsValue(value, UvmEntries.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticationExtensionsClientInputsDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticationExtensionsClientInputsDeserializer.java
@@ -23,7 +23,7 @@ public class AuthenticationExtensionsClientInputsDeserializer extends StdDeseria
 
     @Override
     public AuthenticationExtensionsClientInputs<?> deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         return new AuthenticationExtensionsClientInputs<>(node, objectConverter);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticationExtensionsClientOutputsDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/AuthenticationExtensionsClientOutputsDeserializer.java
@@ -23,7 +23,7 @@ public class AuthenticationExtensionsClientOutputsDeserializer extends StdDeseri
 
     @Override
     public AuthenticationExtensionsClientOutputs<?> deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         return new AuthenticationExtensionsClientOutputs<>(node, objectConverter);
     }
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/CredentialPropertiesExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/CredentialPropertiesExtensionClientInputDeserializer.java
@@ -22,7 +22,7 @@ public class CredentialPropertiesExtensionClientInputDeserializer extends Extens
 
     @Override
     public CredentialPropertiesExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(CredentialPropertiesExtensionClientInput.KEY_CRED_PROPS);
         if (value == null || value.isNull()) return null;
         return new CredentialPropertiesExtensionClientInput(value.asBoolean());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/CredentialPropertiesExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/CredentialPropertiesExtensionClientOutputDeserializer.java
@@ -23,7 +23,7 @@ public class CredentialPropertiesExtensionClientOutputDeserializer extends Exten
 
     @Override
     public CredentialPropertiesExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(CredentialPropertiesExtensionClientOutput.KEY_CRED_PROPS);
         if (value == null || value.isNull()) return null;
         CredentialPropertiesOutput credProps = ctxt.readTreeAsValue(value, CredentialPropertiesOutput.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/CredentialProtectionExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/CredentialProtectionExtensionClientInputDeserializer.java
@@ -28,7 +28,7 @@ public class CredentialProtectionExtensionClientInputDeserializer extends Extens
 
     @Override
     public CredentialProtectionExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode policyNode = node.get(CredentialProtectionExtensionClientInput.KEY_CREDENTIAL_PROTECTION_POLICY);
         JsonNode enforceNode = node.get(CredentialProtectionExtensionClientInput.KEY_ENFORCE_CREDENTIAL_PROTECTION_POLICY);
         if (policyNode == null && enforceNode == null) return null;

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/FIDOAppIDExclusionExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/FIDOAppIDExclusionExtensionClientInputDeserializer.java
@@ -22,7 +22,7 @@ public class FIDOAppIDExclusionExtensionClientInputDeserializer extends Extensio
 
     @Override
     public FIDOAppIDExclusionExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(FIDOAppIDExclusionExtensionClientInput.KEY_APPID_EXCLUDE);
         if (value == null || value.isNull()) return null;
         return new FIDOAppIDExclusionExtensionClientInput(value.textValue());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/FIDOAppIDExclusionExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/FIDOAppIDExclusionExtensionClientOutputDeserializer.java
@@ -22,7 +22,7 @@ public class FIDOAppIDExclusionExtensionClientOutputDeserializer extends Extensi
 
     @Override
     public FIDOAppIDExclusionExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(FIDOAppIDExclusionExtensionClientOutput.KEY_APPID_EXCLUDE);
         if (value == null || value.isNull()) return null;
         return new FIDOAppIDExclusionExtensionClientOutput(value.asBoolean());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/FIDOAppIDExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/FIDOAppIDExtensionClientInputDeserializer.java
@@ -22,7 +22,7 @@ public class FIDOAppIDExtensionClientInputDeserializer extends ExtensionClientIn
 
     @Override
     public FIDOAppIDExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(FIDOAppIDExtensionClientInput.KEY_APPID);
         if (value == null || value.isNull()) return null;
         return new FIDOAppIDExtensionClientInput(value.textValue());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/FIDOAppIDExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/FIDOAppIDExtensionClientOutputDeserializer.java
@@ -22,7 +22,7 @@ public class FIDOAppIDExtensionClientOutputDeserializer extends ExtensionClientO
 
     @Override
     public FIDOAppIDExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(FIDOAppIDExtensionClientOutput.KEY_APPID);
         if (value == null || value.isNull()) return null;
         return new FIDOAppIDExtensionClientOutput(value.asBoolean());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/HMACSecretAuthenticationExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/HMACSecretAuthenticationExtensionClientInputDeserializer.java
@@ -23,7 +23,7 @@ public class HMACSecretAuthenticationExtensionClientInputDeserializer extends Ex
 
     @Override
     public HMACSecretAuthenticationExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(HMACSecretAuthenticationExtensionClientInput.KEY_HMAC_GET_SECRET);
         if (value == null || value.isNull()) return null;
         HMACGetSecretInput hmacGetSecret = ctxt.readTreeAsValue(value, HMACGetSecretInput.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/HMACSecretAuthenticationExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/HMACSecretAuthenticationExtensionClientOutputDeserializer.java
@@ -23,7 +23,7 @@ public class HMACSecretAuthenticationExtensionClientOutputDeserializer extends E
 
     @Override
     public HMACSecretAuthenticationExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(HMACSecretAuthenticationExtensionClientOutput.KEY_HMAC_GET_SECRET);
         if (value == null || value.isNull()) return null;
         HMACGetSecretOutput hmacGetSecret = ctxt.readTreeAsValue(value, HMACGetSecretOutput.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/HMACSecretRegistrationExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/HMACSecretRegistrationExtensionClientInputDeserializer.java
@@ -22,7 +22,7 @@ public class HMACSecretRegistrationExtensionClientInputDeserializer extends Exte
 
     @Override
     public HMACSecretRegistrationExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(HMACSecretRegistrationExtensionClientInput.KEY_HMAC_CREATE_SECRET);
         if (value == null || value.isNull()) return null;
         return new HMACSecretRegistrationExtensionClientInput(value.asBoolean());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/HMACSecretRegistrationExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/HMACSecretRegistrationExtensionClientOutputDeserializer.java
@@ -22,7 +22,7 @@ public class HMACSecretRegistrationExtensionClientOutputDeserializer extends Ext
 
     @Override
     public HMACSecretRegistrationExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(HMACSecretRegistrationExtensionClientOutput.KEY_HMAC_CREATE_SECRET);
         if (value == null || value.isNull()) return null;
         return new HMACSecretRegistrationExtensionClientOutput(value.asBoolean());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobExtensionClientInputDeserializer.java
@@ -39,7 +39,7 @@ public class LargeBlobExtensionClientInputDeserializer extends ExtensionClientIn
 
     @Override
     public LargeBlobExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode largeBlobNode = node.get(LargeBlobExtensionClientInput.KEY_LARGE_BLOB);
         if (largeBlobNode == null || largeBlobNode.isNull() || !largeBlobNode.isObject()) return null;
         AuthenticationExtensionsLargeBlobInputs inputs = ctxt.readTreeAsValue(largeBlobNode, AuthenticationExtensionsLargeBlobInputs.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/LargeBlobExtensionClientOutputDeserializer.java
@@ -39,7 +39,7 @@ public class LargeBlobExtensionClientOutputDeserializer extends ExtensionClientO
 
     @Override
     public LargeBlobExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode largeBlobNode = node.get(LargeBlobExtensionClientOutput.KEY_LARGE_BLOB);
         if (largeBlobNode == null || largeBlobNode.isNull() || !largeBlobNode.isObject()) return null;
         AuthenticationExtensionsLargeBlobOutputs outputs = ctxt.readTreeAsValue(largeBlobNode, AuthenticationExtensionsLargeBlobOutputs.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/UserVerificationMethodExtensionClientInputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/UserVerificationMethodExtensionClientInputDeserializer.java
@@ -22,7 +22,7 @@ public class UserVerificationMethodExtensionClientInputDeserializer extends Exte
 
     @Override
     public UserVerificationMethodExtensionClientInput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(UserVerificationMethodExtensionClientInput.KEY_UVM);
         if (value == null || value.isNull()) return null;
         return new UserVerificationMethodExtensionClientInput(value.asBoolean());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/UserVerificationMethodExtensionClientOutputDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/UserVerificationMethodExtensionClientOutputDeserializer.java
@@ -23,7 +23,7 @@ public class UserVerificationMethodExtensionClientOutputDeserializer extends Ext
 
     @Override
     public UserVerificationMethodExtensionClientOutput deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectNode node = (ObjectNode) p.readValueAsTree();
+        ObjectNode node = p.readValueAsTree();
         JsonNode value = node.get(UserVerificationMethodExtensionClientOutput.KEY_UVM);
         if (value == null || value.isNull()) return null;
         UvmEntries uvmEntries = ctxt.readTreeAsValue(value, UvmEntries.class);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/verifier/internal/BeanAssertUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/verifier/internal/BeanAssertUtil.java
@@ -47,6 +47,9 @@ public class BeanAssertUtil {
     // ========================================================================================================
 
 
+    // Cast to CoreRegistrationData is required for overload resolution to call the correct validate() overload.
+    // Without this cast, validate(RegistrationData) would call itself, causing infinite recursion.
+    @SuppressWarnings("java:S1905")
     public static void validate(@Nullable RegistrationData registrationData) {
         validate((CoreRegistrationData) registrationData);
         validateAuthenticationExtensionsClientOutputs(registrationData.getClientExtensions());
@@ -69,6 +72,9 @@ public class BeanAssertUtil {
         }
     }
 
+    // Cast to CoreAuthenticationData is required for overload resolution to call the correct validate() overload.
+    // Without this cast, validate(AuthenticationData) would call itself, causing infinite recursion.
+    @SuppressWarnings("java:S1905")
     public static void validate(@Nullable AuthenticationData authenticationData) {
         validate((CoreAuthenticationData) authenticationData);
         if (authenticationData.getCollectedClientData() == null) {


### PR DESCRIPTION
Remove unnecessary `(ObjectNode)` casts from `p.readValueAsTree()` calls in 27 deserializer files. Jackson 3.x's generic return type `<T extends TreeNode> T` makes the cast redundant via target-type inference.

Add `@SuppressWarnings("java:S1905")` to two methods in `BeanAssertUtil` where the upcast is intentionally used for overload resolution to avoid infinite recursion.