### PR TITLE
Migrate from allprojects/subprojects to convention plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,17 +1,8 @@
-import com.webauthn4j.gradle.BuildUtils
 import com.webauthn4j.gradle.VersionUtils
 import org.asciidoctor.gradle.jvm.AsciidoctorTask
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import java.net.URI
-import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import java.nio.charset.StandardCharsets
 
 plugins {
-    id("java-library")
-    id("signing")
-    id("maven-publish")
-    id("jacoco")
-
     id("net.sharplab.maven-central-publish")
     id(libs.plugins.asciidoctor.get().pluginId) version libs.versions.asciidoctor
     id(libs.plugins.sonarqube.get().pluginId) version libs.versions.sonarqube
@@ -21,149 +12,11 @@ private val webAuthn4JVersion: String by project
 private val isSnapshot: Boolean = (findProperty("isSnapshot") as? String)?.toBoolean() ?: true
 private val effectiveVersion = VersionUtils.getEffectiveVersion(isSnapshot, webAuthn4JVersion)
 
-allprojects {
-    group = "com.webauthn4j"
-    version = effectiveVersion
+group = "com.webauthn4j"
+version = effectiveVersion
 
-    repositories {
-        mavenCentral()
-    }
-}
-
-subprojects {
-    apply(plugin = "java-library")
-    apply(plugin = "jacoco")
-
-    java {
-        // Use sourceCompatibility/targetCompatibility instead of options.release so that
-        // APIs introduced after JDK 17 (e.g. ML-DSA in JDK 24) remain accessible at compile
-        // time. --release would restrict the API surface to JDK 17. Users who call those newer
-        // APIs must run on a JDK that provides them.
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-
-        withSourcesJar()
-        withJavadocJar()
-    }
-
-    tasks.withType<JavaCompile>().configureEach {
-        options.compilerArgs.add("-Xlint:-module") // Suppress 'module not found' warning regarding 'exports to' directive on multi-module projects.
-        options.compilerArgs.add("-Werror") // Treat all warnings as errors
-    }
-
-    // Ensure reproducible builds: deterministic file order and fixed timestamps in archives.
-    // This is the default since Gradle 9.0, but stated explicitly for clarity and to prevent
-    // accidental regression if defaults change.
-    tasks.withType<AbstractArchiveTask>().configureEach {
-        isReproducibleFileOrder = true
-        isPreserveFileTimestamps = false
-    }
-
-    tasks.test {
-        useJUnitPlatform()
-        testLogging {
-            events("passed", "skipped", "failed") //, "standardOut", "standardError"
-            showExceptions = true
-            exceptionFormat = TestExceptionFormat.FULL
-            showCauses = true
-            showStackTraces = true
-
-            showStandardStreams = false
-        }
-    }
-
-    tasks.javadoc{
-        (options as StandardJavadocDocletOptions).apply {
-            charset("UTF-8")
-            encoding("UTF-8")
-            addStringOption("Xdoclint:all,-missing", "-quiet")
-        }
-    }
-
-    tasks.jacocoTestReport {
-        reports {
-            xml.required = true
-        }
-    }
-
-}
-
-configure(subprojects.filter { it.name.startsWith("webauthn4j-") }) {
-    apply(plugin = "signing")
-    apply(plugin = "maven-publish")
-
-    val githubUrl = "https://github.com/webauthn4j/webauthn4j"
-    val mavenCentralUser = BuildUtils.getVariable(project, "MAVEN_CENTRAL_USER", "mavenCentralUser")
-    val mavenCentralPassword = BuildUtils.getVariable(project, "MAVEN_CENTRAL_PASSWORD", "mavenCentralPassword")
-    val pgpSigningKey = BuildUtils.getVariable(project, "PGP_SIGNING_KEY", "pgpSigningKey")
-    val pgpSigningKeyPassphrase = BuildUtils.getVariable(project, "PGP_SIGNING_KEY_PASSPHRASE", "pgpSigningKeyPassphrase")
-
-    publishing {
-        publications{
-            create<MavenPublication>("standard") {
-                from(components["java"])
-
-                // "Resolved versions" strategy is used to define dependency version because WebAuthn4J use dependencyManagement (BOM) feature
-                // to define its dependency versions. Without "Resolved versions" strategy, version will not be exposed
-                // to dependencies.dependency.version in POM file, and it cause warning in the library consumer environment.
-                versionMapping {
-                    usage("java-api") {
-                        fromResolutionOf("runtimeClasspath")
-                    }
-                    usage("java-runtime") {
-                        fromResolutionResult()
-                    }
-                }
-
-                pom {
-                    name = project.name
-                    description.set(provider { project.description }) // use provider for lazy initialization
-                    url = githubUrl
-                    licenses {
-                        license {
-                            name = "The Apache Software License, Version 2.0"
-                            url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                            distribution = "repo"
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = "ynojima"
-                            name = "Yoshikazu Nojima"
-                            email = "mail@ynojima.net"
-                        }
-                    }
-                    scm {
-                        url = githubUrl
-                    }
-                }
-            }
-        }
-
-        repositories {
-            maven {
-                name = "snapshot"
-                url = URI("https://central.sonatype.com/repository/maven-snapshots/")
-                credentials {
-                    username = mavenCentralUser
-                    password = mavenCentralPassword
-                }
-            }
-        }
-
-        signing {
-            useInMemoryPgpKeys(pgpSigningKey, pgpSigningKeyPassphrase)
-            sign(publishing.publications["standard"])
-        }
-
-        tasks.withType(Sign::class.java).configureEach {
-            onlyIf { pgpSigningKey != null && pgpSigningKeyPassphrase != null }
-        }
-        tasks.named("publishStandardPublicationToSnapshotRepository") {
-            onlyIf { isSnapshot }
-        }
-
-    }
+repositories {
+    mavenCentral()
 }
 
 tasks.register("bumpPatchVersion"){

--- a/buildSrc/src/main/kotlin/webauthn4j.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/webauthn4j.java-conventions.gradle.kts
@@ -1,0 +1,69 @@
+import com.webauthn4j.gradle.VersionUtils
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
+
+plugins {
+    id("java-library")
+    id("jacoco")
+}
+
+val webAuthn4JVersion: String by project
+val isSnapshot: Boolean = (findProperty("isSnapshot") as? String)?.toBoolean() ?: true
+
+group = "com.webauthn4j"
+version = VersionUtils.getEffectiveVersion(isSnapshot, webAuthn4JVersion)
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    // Use sourceCompatibility/targetCompatibility instead of options.release so that
+    // APIs introduced after JDK 17 (e.g. ML-DSA in JDK 24) remain accessible at compile
+    // time. --release would restrict the API surface to JDK 17. Users who call those newer
+    // APIs must run on a JDK that provides them.
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:-module")
+    options.compilerArgs.add("-Werror")
+}
+
+// Ensure reproducible builds: deterministic file order and fixed timestamps in archives.
+// This is the default since Gradle 9.0, but stated explicitly for clarity and to prevent
+// accidental regression if defaults change.
+tasks.withType<AbstractArchiveTask>().configureEach {
+    isReproducibleFileOrder = true
+    isPreserveFileTimestamps = false
+}
+
+tasks.test {
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+        showExceptions = true
+        exceptionFormat = TestExceptionFormat.FULL
+        showCauses = true
+        showStackTraces = true
+        showStandardStreams = false
+    }
+}
+
+tasks.javadoc {
+    (options as StandardJavadocDocletOptions).apply {
+        charset("UTF-8")
+        encoding("UTF-8")
+        addStringOption("Xdoclint:all,-missing", "-quiet")
+    }
+}
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required = true
+    }
+}

--- a/buildSrc/src/main/kotlin/webauthn4j.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/webauthn4j.java-library-conventions.gradle.kts
@@ -1,0 +1,80 @@
+import com.webauthn4j.gradle.BuildUtils
+import java.net.URI
+
+plugins {
+    id("webauthn4j.java-conventions")
+    id("signing")
+    id("maven-publish")
+}
+
+val isSnapshot: Boolean = (findProperty("isSnapshot") as? String)?.toBoolean() ?: true
+
+val githubUrl = "https://github.com/webauthn4j/webauthn4j"
+val mavenCentralUser = BuildUtils.getVariable(project, "MAVEN_CENTRAL_USER", "mavenCentralUser")
+val mavenCentralPassword = BuildUtils.getVariable(project, "MAVEN_CENTRAL_PASSWORD", "mavenCentralPassword")
+val pgpSigningKey = BuildUtils.getVariable(project, "PGP_SIGNING_KEY", "pgpSigningKey")
+val pgpSigningKeyPassphrase = BuildUtils.getVariable(project, "PGP_SIGNING_KEY_PASSPHRASE", "pgpSigningKeyPassphrase")
+
+publishing {
+    publications {
+        create<MavenPublication>("standard") {
+            from(components["java"])
+
+            versionMapping {
+                usage("java-api") {
+                    fromResolutionOf("runtimeClasspath")
+                }
+                usage("java-runtime") {
+                    fromResolutionResult()
+                }
+            }
+
+            pom {
+                name = project.name
+                description.set(provider { project.description })
+                url = githubUrl
+                licenses {
+                    license {
+                        name = "The Apache Software License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution = "repo"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "ynojima"
+                        name = "Yoshikazu Nojima"
+                        email = "mail@ynojima.net"
+                    }
+                }
+                scm {
+                    url = githubUrl
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "snapshot"
+            url = URI("https://central.sonatype.com/repository/maven-snapshots/")
+            credentials {
+                username = mavenCentralUser
+                password = mavenCentralPassword
+            }
+        }
+    }
+}
+
+signing {
+    useInMemoryPgpKeys(pgpSigningKey, pgpSigningKeyPassphrase)
+    sign(publishing.publications["standard"])
+}
+
+tasks.withType(Sign::class.java).configureEach {
+    onlyIf { pgpSigningKey != null && pgpSigningKeyPassphrase != null }
+}
+
+tasks.named("publishStandardPublicationToSnapshotRepository") {
+    onlyIf { isSnapshot }
+}

--- a/integration-tests/fido-integration-bdd/build.gradle.kts
+++ b/integration-tests/fido-integration-bdd/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("webauthn4j.java-conventions")
     alias(libs.plugins.kotlin.jvm)
 }
 

--- a/integration-tests/fido-mds-integration/build.gradle.kts
+++ b/integration-tests/fido-mds-integration/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("webauthn4j.java-conventions")
+}
+
 description = "WebAuthn4J FIDO MDS Integration Tests"
 
 dependencies {

--- a/integration-tests/quarkus-security-webauthn/build.gradle.kts
+++ b/integration-tests/quarkus-security-webauthn/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java")
+    id("webauthn4j.java-conventions")
     alias(libs.plugins.quarkus)
 }
 

--- a/integration-tests/spring-security-passkeys/build.gradle.kts
+++ b/integration-tests/spring-security-passkeys/build.gradle.kts
@@ -15,9 +15,9 @@
  */
 
 plugins {
+    id("webauthn4j.java-conventions")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
-    id("java")
 }
 
 description = "WebAuthn4J Integration Test for Spring Security Passkey"

--- a/webauthn4j-appattest/build.gradle.kts
+++ b/webauthn4j-appattest/build.gradle.kts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id("webauthn4j.java-library-conventions")
+}
+
 description = "WebAuthn4J App Attest library"
 
 

--- a/webauthn4j-core-async/build.gradle.kts
+++ b/webauthn4j-core-async/build.gradle.kts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id("webauthn4j.java-library-conventions")
+}
+
 description = "WebAuthn4J Async library"
 
 

--- a/webauthn4j-core/build.gradle.kts
+++ b/webauthn4j-core/build.gradle.kts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id("webauthn4j.java-library-conventions")
+}
+
 description = "WebAuthn4J Core library"
 
 dependencies {

--- a/webauthn4j-metadata-async/build.gradle.kts
+++ b/webauthn4j-metadata-async/build.gradle.kts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id("webauthn4j.java-library-conventions")
+}
+
 description = "WebAuthn4J Metadata Async library"
 
 dependencies {

--- a/webauthn4j-metadata/build.gradle.kts
+++ b/webauthn4j-metadata/build.gradle.kts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id("webauthn4j.java-library-conventions")
+}
+
 description = "WebAuthn4J Metadata library"
 
 dependencies {

--- a/webauthn4j-test/build.gradle.kts
+++ b/webauthn4j-test/build.gradle.kts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id("webauthn4j.java-library-conventions")
+}
+
 description = "Package that contains testing classes for WebAuthn4J"
 
 dependencies {

--- a/webauthn4j-util/build.gradle.kts
+++ b/webauthn4j-util/build.gradle.kts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-apply(plugin = "java")
+plugins {
+    id("webauthn4j.java-library-conventions")
+}
 
-description = "Deprecated package. All classes are moved to webauthnrj-core"
+description = "Deprecated package. All classes are moved to webauthn4j-core"
 
 sonarqube {
     isSkipProject = true


### PR DESCRIPTION
Replace `allprojects{}`, `subprojects{}`, and `configure(subprojects.filter{})` blocks in the root `build.gradle.kts` with precompiled script plugins in `buildSrc/`, following Gradle's recommended convention plugins pattern.

## New convention plugins

- **`webauthn4j.java-conventions`** — shared Java build settings (java-library, jacoco, compiler flags, test configuration, reproducible archives, javadoc settings). Applied by all subprojects.
- **`webauthn4j.java-library-conventions`** — extends `java-conventions` with signing and Maven publishing configuration. Applied by `webauthn4j-*` library modules only.

## Changes

- Root `build.gradle.kts`: removed `allprojects{}`, `subprojects{}`, and `configure(filter)` blocks; root-only settings (sonarqube, asciidoctor, mavenCentralPublish, version tasks) remain
- Each subproject's `build.gradle.kts` now explicitly declares its convention plugin in the `plugins{}` block
- Removed redundant `apply(plugin = "java")` from `webauthn4j-util`
- Removed redundant `id("java")` from integration test modules that inherit `java-library` via the convention plugin