### PR TITLE
Remove unused local variables

### DIFF
--- a/webauthn4j-appattest/src/test/java/com/webauthn4j/appattest/DeviceCheckManagerTest.java
+++ b/webauthn4j-appattest/src/test/java/com/webauthn4j/appattest/DeviceCheckManagerTest.java
@@ -102,7 +102,7 @@ class DeviceCheckManagerTest {
             mocked.when(Instant::now).thenReturn(timestamp);
 
             // When Apple App Attest Root Certificate is not set, throws CertificateException
-            DCAttestationData dcAttestationData = deviceCheckManager.validate(dcAttestationRequest, dcAttestationParameters);
+            deviceCheckManager.validate(dcAttestationRequest, dcAttestationParameters);
         }
     }
 

--- a/webauthn4j-core/src/test/java/integration/scenario/fido/FIDOAuthenticatorCoreRegistrationValidationTest.java
+++ b/webauthn4j-core/src/test/java/integration/scenario/fido/FIDOAuthenticatorCoreRegistrationValidationTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Set;
 
 @SuppressWarnings("ConstantConditions")
 class FIDOAuthenticatorCoreRegistrationValidationTest {
@@ -105,7 +104,6 @@ class FIDOAuthenticatorCoreRegistrationValidationTest {
         PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput> credential = clientPlatform.create(credentialCreationOptions);
         AuthenticatorAttestationResponse registrationRequest = credential.getResponse();
         AttestationObject attestationObject = attestationObjectConverter.convert(registrationRequest.getAttestationObject());
-        Set<AuthenticatorTransport> transports = Collections.emptySet();
         ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
         CoreRegistrationData coreRegistrationData
                 = new CoreRegistrationData(


### PR DESCRIPTION
Remove unused local variable assignments in test files.

- `DeviceCheckManagerTest`: drop unused `dcAttestationData` variable, keep the `validate()` call
- `FIDOAuthenticatorCoreRegistrationValidationTest`: remove unused `transports` variable and its import