### PR TITLE
Add private constructor to CompletionStageUtil

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/util/CompletionStageUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/util/CompletionStageUtil.java
@@ -6,6 +6,9 @@ import java.util.function.Supplier;
 
 public class CompletionStageUtil {
 
+    private CompletionStageUtil() {
+    }
+
     public static <U> CompletionStage<U> supply(Supplier<U> supplier) {
         try{
             U result = supplier.get();


### PR DESCRIPTION
Add a private no-arg constructor to `CompletionStageUtil` to prevent instantiation, matching the pattern used by `AssertUtil` and other utility classes.