### PR TITLE
Add gradle:gradle to trusted PGP key for dependency verification

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -75,7 +75,10 @@
          <trusted-key id="1A55F091AD28C07F831FA44D7905DE25C78AD456" group="com.google.protobuf" name="protobuf-bom" />
          <trusted-key id="1A75005E142192223D6A7C3B76E0008D166740A8" group="org.mongodb" name="mongodb-driver-bom" />
          <trusted-key id="1AA8CF92D409A73393D0B736BFF2EE42C8282E76" group="org.apache.activemq" name="activemq-bom" />
-         <trusted-key id="1BD97A6A154E7810EE0BC832E2F38302C8075E3D" group="org.gradle.kotlin" name="gradle-kotlin-dsl-plugins" />
+         <trusted-key id="1BD97A6A154E7810EE0BC832E2F38302C8075E3D">
+            <trusting group="gradle" name="gradle" />
+            <trusting group="org.gradle.kotlin" name="gradle-kotlin-dsl-plugins" />
+         </trusted-key>
          <trusted-key id="1D04A424F505394DBED15D451D0690E353BE126D" group="net.minidev" />
          <trusted-key id="1D217F8475EEE9F19AB8DD6B793FD5751A0F0780" group="^com[.]squareup($|([.].*))" regex="true" />
          <trusted-key id="1E5484A9D4D13B03F5CF48C533400B6692739665" group="io.vertx" name="vertx-dependencies" />


### PR DESCRIPTION
Gradle distributions are signed with the same PGP key as org.gradle.kotlin:gradle-kotlin-dsl-plugins, but the gradle:gradle group was not listed as a trusted artifact for that key. This causes dependency verification to fail when IntelliJ downloads the Gradle source ZIP.

Add gradle:gradle to the existing trusted-key entry.