### PR TITLE
Add OptionalDependenciesPlugin for Maven-style optional deps

### DIFF
--- a/optional-dependencies-plugin/README.md
+++ b/optional-dependencies-plugin/README.md
@@ -1,0 +1,64 @@
+# Optional Dependencies Plugin
+
+A Gradle plugin that adds support for Maven-style optional dependencies.
+
+## Overview
+
+Gradle has no built-in equivalent of Maven's `<optional>true</optional>`. This plugin bridges that
+gap by creating an `optional` configuration with the following behavior:
+
+- Dependencies declared as `optional` are available on compile and runtime classpaths during the build
+- They are **not** propagated transitively to consumers
+- When `maven-publish` is applied, they are automatically added to the generated POM with `<optional>true</optional>`
+
+## Configuration
+
+**settings.gradle.kts** (root project)
+
+```kotlin
+pluginManagement {
+    includeBuild("optional-dependencies-plugin")
+}
+```
+
+**build.gradle.kts** (subproject)
+
+```kotlin
+plugins {
+    id("com.webauthn4j.optional-dependencies")
+}
+
+dependencies {
+    optional("com.example:some-library:1.0")
+}
+```
+
+## How it works
+
+1. **Creates an `optional` configuration** with `canBeConsumed = false` and `canBeResolved = false`.
+   This makes it a pure dependency bucket that downstream projects cannot access.
+
+2. **Extends compile and runtime classpaths** so that optional dependencies are available during
+   compilation and testing, just like `implementation` dependencies.
+
+3. **Hooks into `maven-publish`** to add optional dependencies to the generated POM with
+   `<optional>true</optional>`. This ensures Maven consumers can see which dependencies are
+   optional and explicitly add them if needed.
+
+## Generated POM
+
+```xml
+<dependency>
+    <groupId>com.example</groupId>
+    <artifactId>some-library</artifactId>
+    <version>1.0</version>
+    <scope>compile</scope>
+    <optional>true</optional>
+</dependency>
+```
+
+## Requirements
+
+- Gradle 9.0+
+- `java` or `java-library` plugin (for classpath integration)
+- `maven-publish` plugin (for POM generation; optional — the plugin works without it)

--- a/optional-dependencies-plugin/build.gradle.kts
+++ b/optional-dependencies-plugin/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        register("optionalDependencies") {
+            id = "com.webauthn4j.optional-dependencies"
+            implementationClass = "com.webauthn4j.gradle.OptionalDependenciesPlugin"
+        }
+    }
+}

--- a/optional-dependencies-plugin/settings.gradle.kts
+++ b/optional-dependencies-plugin/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "optional-dependencies-plugin"

--- a/optional-dependencies-plugin/src/main/kotlin/com/webauthn4j/gradle/OptionalDependenciesPlugin.kt
+++ b/optional-dependencies-plugin/src/main/kotlin/com/webauthn4j/gradle/OptionalDependenciesPlugin.kt
@@ -1,0 +1,67 @@
+package com.webauthn4j.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+
+/**
+ * A Gradle plugin that adds support for Maven-style optional dependencies.
+ *
+ * Creates a new `optional` configuration that is part of the project's compile
+ * and runtime classpaths but does not affect the classpath of dependent projects.
+ * When the `maven-publish` plugin is applied, optional dependencies are automatically
+ * added to the generated POM with `<optional>true</optional>`.
+ */
+class OptionalDependenciesPlugin : Plugin<Project> {
+
+    companion object {
+        const val OPTIONAL_CONFIGURATION_NAME = "optional"
+    }
+
+    override fun apply(project: Project) {
+        val optional = project.configurations.create(OPTIONAL_CONFIGURATION_NAME).apply {
+            isCanBeConsumed = false
+            isCanBeResolved = false
+        }
+
+        project.plugins.withType(JavaPlugin::class.java) {
+            val sourceSets = project.extensions.getByType(JavaPluginExtension::class.java).sourceSets
+            sourceSets.all {
+                project.configurations.getByName(compileClasspathConfigurationName).extendsFrom(optional)
+                project.configurations.getByName(runtimeClasspathConfigurationName).extendsFrom(optional)
+            }
+        }
+
+        project.plugins.withType(MavenPublishPlugin::class.java) {
+            project.extensions.getByType(PublishingExtension::class.java)
+                .publications.withType(MavenPublication::class.java).configureEach {
+                    pom {
+                        withXml {
+                            addOptionalDependencies(this, optional)
+                        }
+                    }
+                }
+        }
+    }
+
+    private fun addOptionalDependencies(xml: org.gradle.api.XmlProvider, optional: Configuration) {
+        val root = xml.asNode()
+        @Suppress("UNCHECKED_CAST")
+        val depsNode = (root.get("dependencies") as? groovy.util.NodeList)
+            ?.firstOrNull() as? groovy.util.Node
+            ?: root.appendNode("dependencies")
+        for (dep in optional.dependencies) {
+            val depNode = depsNode.appendNode("dependency")
+            depNode.appendNode("groupId", dep.group)
+            depNode.appendNode("artifactId", dep.name)
+            depNode.appendNode("version", dep.version)
+            depNode.appendNode("scope", "compile")
+            depNode.appendNode("optional", "true")
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     includeBuild("maven-central-publish-plugin")
+    includeBuild("optional-dependencies-plugin")
     includeBuild("toolchain-pinning-plugin")
 }
 


### PR DESCRIPTION
Introduce a Gradle plugin project that creates an `optional` configuration. Dependencies declared as `optional` are available on compile/runtime classpaths but not propagated to consumers. When maven-publish is applied, they are added to the POM with <optional>true</optional>.