### PR TITLE
Fix parsing of large vendorPrototypeConfigCommands values and introduce value types for AuthenticatorGetInfo fields

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnJSONModule.java
@@ -74,6 +74,7 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addDeserializer(TPMIAlgHash.class, new TPMIAlgHashDeserializer());
         this.addDeserializer(TPMIAlgPublic.class, new TPMIAlgPublicDeserializer());
         this.addDeserializer(TPMISTAttest.class, new TPMISTAttestDeserializer());
+        this.addDeserializer(VendorCommandId.class, new VendorCommandIdDeserializer());
 
         this.addDeserializer(byte[].class, new ByteArrayBase64UrlDeserializer());
 
@@ -128,6 +129,7 @@ public class WebAuthnJSONModule extends SimpleModule {
         this.addSerializer(new TPMIAlgHashSerializer());
         this.addSerializer(new TPMIAlgPublicSerializer());
         this.addSerializer(new TPMISTAttestSerializer());
+        this.addSerializer(new VendorCommandIdSerializer());
 
         this.addSerializer(new ByteArrayBase64UrlSerializer());
 
@@ -156,6 +158,7 @@ public class WebAuthnJSONModule extends SimpleModule {
         ModuleNotRegisteredGuardClearingMixin.setIfAbsent(context, TPMIAlgHash.class);
         ModuleNotRegisteredGuardClearingMixin.setIfAbsent(context, TPMIAlgPublic.class);
         ModuleNotRegisteredGuardClearingMixin.setIfAbsent(context, TPMISTAttest.class);
+        ModuleNotRegisteredGuardClearingMixin.setIfAbsent(context, VendorCommandId.class);
     }
 
 }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/VendorCommandIdDeserializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/deserializer/json/VendorCommandIdDeserializer.java
@@ -1,0 +1,24 @@
+package com.webauthn4j.converter.jackson.deserializer.json;
+
+import com.webauthn4j.data.VendorCommandId;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.exc.InvalidFormatException;
+
+public class VendorCommandIdDeserializer extends StdDeserializer<VendorCommandId> {
+
+    public VendorCommandIdDeserializer() {
+        super(VendorCommandId.class);
+    }
+
+    @Override
+    public VendorCommandId deserialize(@NotNull JsonParser p, @NotNull DeserializationContext ctxt) {
+        if (p.currentToken() != JsonToken.VALUE_NUMBER_INT) {
+            throw InvalidFormatException.from(p, "Expected an integer value for VendorCommandId", p.getText(), VendorCommandId.class);
+        }
+        return VendorCommandId.create(p.getBigIntegerValue());
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/VendorCommandIdSerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/json/VendorCommandIdSerializer.java
@@ -1,0 +1,19 @@
+package com.webauthn4j.converter.jackson.serializer.json;
+
+import com.webauthn4j.data.VendorCommandId;
+import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+public class VendorCommandIdSerializer extends StdSerializer<VendorCommandId> {
+
+    public VendorCommandIdSerializer() {
+        super(VendorCommandId.class);
+    }
+
+    @Override
+    public void serialize(@NotNull VendorCommandId value, @NotNull JsonGenerator gen, @NotNull SerializationContext ctxt) {
+        gen.writeNumber(value.asBigInteger());
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticatorConfigSubCommand.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/AuthenticatorConfigSubCommand.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public class AuthenticatorConfigSubCommand {
+
+    public static final AuthenticatorConfigSubCommand ENABLE_ENTERPRISE_ATTESTATION = new AuthenticatorConfigSubCommand(0x01);
+    public static final AuthenticatorConfigSubCommand TOGGLE_ALWAYS_UV = new AuthenticatorConfigSubCommand(0x02);
+    public static final AuthenticatorConfigSubCommand SET_MIN_PIN_LENGTH = new AuthenticatorConfigSubCommand(0x03);
+    public static final AuthenticatorConfigSubCommand ENABLE_LONG_TOUCH_FOR_RESET = new AuthenticatorConfigSubCommand(0x04);
+    public static final AuthenticatorConfigSubCommand VENDOR_PROTOTYPE = new AuthenticatorConfigSubCommand(0xFF);
+
+    private final int value;
+
+    public AuthenticatorConfigSubCommand(int value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static @NotNull AuthenticatorConfigSubCommand create(int value) {
+        return new AuthenticatorConfigSubCommand(value);
+    }
+
+    @JsonValue
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticatorConfigSubCommand that = (AuthenticatorConfigSubCommand) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/CertificationType.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/CertificationType.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public class CertificationType {
+
+    public static final CertificationType FIPS_CMVP_2 = new CertificationType("FIPS-CMVP-2");
+    public static final CertificationType FIPS_CMVP_3 = new CertificationType("FIPS-CMVP-3");
+    public static final CertificationType FIPS_CMVP_2_PHY = new CertificationType("FIPS-CMVP-2-PHY");
+    public static final CertificationType FIPS_CMVP_3_PHY = new CertificationType("FIPS-CMVP-3-PHY");
+    public static final CertificationType CC_EAL = new CertificationType("CC-EAL");
+    public static final CertificationType FIDO = new CertificationType("FIDO");
+    public static final CertificationType CCN_CPSTIC = new CertificationType("CCN-CPSTIC");
+
+    private final String value;
+
+    public CertificationType(@NotNull String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static @NotNull CertificationType create(@NotNull String value) {
+        return new CertificationType(value);
+    }
+
+    @JsonValue
+    public @NotNull String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CertificationType that = (CertificationType) o;
+        return value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/VendorCommandId.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/VendorCommandId.java
@@ -37,10 +37,6 @@ public class VendorCommandId {
         this.value = value;
     }
 
-    public static @NotNull VendorCommandId create(long value) {
-        return new VendorCommandId(value);
-    }
-
     public static @NotNull VendorCommandId create(@NotNull BigInteger value) {
         return new VendorCommandId(value.longValue());
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/VendorCommandId.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/VendorCommandId.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import com.webauthn4j.converter.jackson.ModuleNotRegisteredGuardDeserializer;
+import com.webauthn4j.converter.jackson.ModuleNotRegisteredGuardSerializer;
+import com.webauthn4j.util.UnsignedNumberUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+@JsonSerialize(using = ModuleNotRegisteredGuardSerializer.class)
+@JsonDeserialize(using = ModuleNotRegisteredGuardDeserializer.class)
+public class VendorCommandId {
+
+    private final long value;
+
+    public VendorCommandId(long value) {
+        this.value = value;
+    }
+
+    public static @NotNull VendorCommandId create(long value) {
+        return new VendorCommandId(value);
+    }
+
+    public static @NotNull VendorCommandId create(@NotNull BigInteger value) {
+        return new VendorCommandId(value.longValue());
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    public @NotNull BigInteger asBigInteger() {
+        return UnsignedNumberUtil.toUnsignedBigInteger(value);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VendorCommandId that = (VendorCommandId) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return asBigInteger().toString();
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/util/UnsignedNumberUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/util/UnsignedNumberUtil.java
@@ -101,6 +101,13 @@ public class UnsignedNumberUtil {
         return buffer;
     }
 
+    public static @NotNull BigInteger toUnsignedBigInteger(long value) {
+        if (value >= 0) {
+            return BigInteger.valueOf(value);
+        }
+        return new BigInteger(1, ByteBuffer.allocate(8).putLong(value).array());
+    }
+
     public static boolean isWithinUnsignedByte(int value) {
         return value <= UNSIGNED_BYTE_MAX && value >= 0;
     }

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticatorConfigSubCommandTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/AuthenticatorConfigSubCommandTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.exc.InvalidFormatException;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class AuthenticatorConfigSubCommandTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void constants_test() {
+        assertAll(
+                () -> assertThat(AuthenticatorConfigSubCommand.ENABLE_ENTERPRISE_ATTESTATION.getValue()).isEqualTo(0x01),
+                () -> assertThat(AuthenticatorConfigSubCommand.TOGGLE_ALWAYS_UV.getValue()).isEqualTo(0x02),
+                () -> assertThat(AuthenticatorConfigSubCommand.SET_MIN_PIN_LENGTH.getValue()).isEqualTo(0x03),
+                () -> assertThat(AuthenticatorConfigSubCommand.ENABLE_LONG_TOUCH_FOR_RESET.getValue()).isEqualTo(0x04),
+                () -> assertThat(AuthenticatorConfigSubCommand.VENDOR_PROTOTYPE.getValue()).isEqualTo(0xFF)
+        );
+    }
+
+    @Test
+    void create_test() {
+        AuthenticatorConfigSubCommand subCommand = AuthenticatorConfigSubCommand.create(0x10);
+        assertThat(subCommand.getValue()).isEqualTo(0x10);
+    }
+
+    @Test
+    void equals_hashCode_test() {
+        AuthenticatorConfigSubCommand instanceA = AuthenticatorConfigSubCommand.create(0x01);
+        AuthenticatorConfigSubCommand instanceB = new AuthenticatorConfigSubCommand(0x01);
+        AuthenticatorConfigSubCommand instanceC = AuthenticatorConfigSubCommand.create(0x02);
+
+        assertThat(instanceA)
+                .isEqualTo(AuthenticatorConfigSubCommand.ENABLE_ENTERPRISE_ATTESTATION)
+                .isEqualTo(instanceB)
+                .hasSameHashCodeAs(instanceB);
+
+        assertThat(instanceA).isNotEqualTo(instanceC);
+        assertThat(instanceA).isNotEqualTo(null);
+        assertThat(instanceA).isNotEqualTo("string");
+    }
+
+    @Test
+    void toString_test() {
+        assertThat(AuthenticatorConfigSubCommand.ENABLE_ENTERPRISE_ATTESTATION).hasToString("1");
+        assertThat(AuthenticatorConfigSubCommand.VENDOR_PROTOTYPE).hasToString("255");
+    }
+
+    @Test
+    void deserialize_test() {
+        TestDTO dto = jsonMapper.readValue("{\"subCommand\":3}", TestDTO.class);
+        assertThat(dto.subCommand).isEqualTo(AuthenticatorConfigSubCommand.SET_MIN_PIN_LENGTH);
+    }
+
+    @Test
+    void deserialize_test_with_invalid_value() {
+        assertThatThrownBy(
+                () -> jsonMapper.readValue("{\"subCommand\":\"invalid\"}", TestDTO.class)
+        ).isInstanceOf(InvalidFormatException.class);
+    }
+
+    static class TestDTO {
+        @SuppressWarnings("WeakerAccess")
+        public AuthenticatorConfigSubCommand subCommand;
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/CertificationTypeTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/CertificationTypeTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class CertificationTypeTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void constants_test() {
+        assertAll(
+                () -> assertThat(CertificationType.FIPS_CMVP_2.getValue()).isEqualTo("FIPS-CMVP-2"),
+                () -> assertThat(CertificationType.FIPS_CMVP_3.getValue()).isEqualTo("FIPS-CMVP-3"),
+                () -> assertThat(CertificationType.FIPS_CMVP_2_PHY.getValue()).isEqualTo("FIPS-CMVP-2-PHY"),
+                () -> assertThat(CertificationType.FIPS_CMVP_3_PHY.getValue()).isEqualTo("FIPS-CMVP-3-PHY"),
+                () -> assertThat(CertificationType.CC_EAL.getValue()).isEqualTo("CC-EAL"),
+                () -> assertThat(CertificationType.FIDO.getValue()).isEqualTo("FIDO"),
+                () -> assertThat(CertificationType.CCN_CPSTIC.getValue()).isEqualTo("CCN-CPSTIC")
+        );
+    }
+
+    @Test
+    void create_test() {
+        CertificationType type = CertificationType.create("FIDO");
+        assertThat(type).isEqualTo(CertificationType.FIDO);
+    }
+
+    @Test
+    void create_unknown_value_test() {
+        assertDoesNotThrow(() -> CertificationType.create("UNKNOWN"));
+    }
+
+    @Test
+    void equals_hashCode_test() {
+        CertificationType instanceA = CertificationType.create("FIDO");
+        CertificationType instanceB = new CertificationType("FIDO");
+        CertificationType instanceC = CertificationType.create("CC-EAL");
+
+        assertThat(instanceA)
+                .isEqualTo(CertificationType.FIDO)
+                .isEqualTo(instanceB)
+                .hasSameHashCodeAs(instanceB);
+
+        assertThat(instanceA).isNotEqualTo(instanceC);
+        assertThat(instanceA).isNotEqualTo(null);
+        assertThat(instanceA).isNotEqualTo("string");
+    }
+
+    @Test
+    void toString_test() {
+        assertThat(CertificationType.FIDO).hasToString("FIDO");
+        assertThat(CertificationType.CC_EAL).hasToString("CC-EAL");
+    }
+
+    @Test
+    void deserialize_map_test() {
+        TestDTO dto = jsonMapper.readValue("""
+                {"certifications": {"FIDO": 2, "FIPS-CMVP-2": 3, "CC-EAL": 5}}
+                """, TestDTO.class);
+        assertThat(dto.certifications)
+                .containsEntry(CertificationType.FIDO, 2)
+                .containsEntry(CertificationType.FIPS_CMVP_2, 3)
+                .containsEntry(CertificationType.CC_EAL, 5)
+                .hasSize(3);
+    }
+
+    @Test
+    void deserialize_map_with_unknown_key_test() {
+        TestDTO dto = jsonMapper.readValue("""
+                {"certifications": {"UNKNOWN-CERT": 1}}
+                """, TestDTO.class);
+        assertThat(dto.certifications)
+                .containsKey(new CertificationType("UNKNOWN-CERT"));
+    }
+
+    static class TestDTO {
+        @SuppressWarnings("WeakerAccess")
+        public Map<CertificationType, Integer> certifications;
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/VendorCommandIdTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/VendorCommandIdTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.data;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.exc.MismatchedInputException;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class VendorCommandIdTest {
+
+    private final JsonMapper jsonMapper = new ObjectConverter().getJsonMapper();
+
+    @Test
+    void constructor_test() {
+        VendorCommandId id = new VendorCommandId(42L);
+        assertThat(id.getValue()).isEqualTo(42L);
+    }
+
+    @Test
+    void create_from_bigInteger_test() {
+        VendorCommandId id = VendorCommandId.create(BigInteger.valueOf(42));
+        assertThat(id.getValue()).isEqualTo(42L);
+    }
+
+    @Test
+    void asBigInteger_test() {
+        assertThat(new VendorCommandId(42).asBigInteger()).isEqualTo(BigInteger.valueOf(42));
+    }
+
+    @Test
+    void asBigInteger_with_large_unsigned_value_test() {
+        // -2 as long corresponds to 2^64 - 2 (UNSIGNED_LONG_MAX - 1) when interpreted as unsigned
+        VendorCommandId id = new VendorCommandId(-2);
+        assertThat(id.asBigInteger()).isEqualTo(new BigInteger("18446744073709551614"));
+    }
+
+    @Test
+    void equals_hashCode_test() {
+        VendorCommandId instanceA = new VendorCommandId(1L);
+        VendorCommandId instanceB = new VendorCommandId(1L);
+        VendorCommandId instanceC = new VendorCommandId(2L);
+
+        assertThat(instanceA)
+                .isEqualTo(instanceB)
+                .hasSameHashCodeAs(instanceB);
+
+        assertThat(instanceA).isNotEqualTo(instanceC);
+        assertThat(instanceA).isNotEqualTo(null);
+        assertThat(instanceA).isNotEqualTo("string");
+    }
+
+    @Test
+    void toString_test() {
+        assertThat(new VendorCommandId(42)).hasToString("42");
+    }
+
+    @Test
+    void toString_with_large_unsigned_value_test() {
+        VendorCommandId id = new VendorCommandId(-2);
+        assertThat(id).hasToString("18446744073709551614");
+    }
+
+    @Test
+    void serialize_test() {
+        TestDTO dto = new TestDTO();
+        dto.commandId = new VendorCommandId(42);
+        String json = jsonMapper.writeValueAsString(dto);
+        assertThat(json).contains("\"commandId\":42");
+    }
+
+    @Test
+    void serialize_test_with_large_unsigned_value() {
+        TestDTO dto = new TestDTO();
+        // -2 as long corresponds to 2^64 - 2 when interpreted as unsigned
+        dto.commandId = new VendorCommandId(-2);
+        String json = jsonMapper.writeValueAsString(dto);
+        assertThat(json).contains("\"commandId\":18446744073709551614");
+    }
+
+    @Test
+    void deserialize_test() {
+        TestDTO dto = jsonMapper.readValue("{\"commandId\":42}", TestDTO.class);
+        assertThat(dto.commandId).isEqualTo(new VendorCommandId(42));
+    }
+
+    @Test
+    void deserialize_test_with_large_unsigned_value() {
+        // 2^64 - 2 (UNSIGNED_LONG_MAX - 1)
+        TestDTO dto = jsonMapper.readValue("{\"commandId\":18446744073709551614}", TestDTO.class);
+        assertThat(dto.commandId.asBigInteger()).isEqualTo(new BigInteger("18446744073709551614"));
+    }
+
+    @Test
+    void deserialize_test_with_invalid_value() {
+        assertThatThrownBy(
+                () -> jsonMapper.readValue("{\"commandId\":\"invalid\"}", TestDTO.class)
+        ).isInstanceOf(MismatchedInputException.class);
+    }
+
+    static class TestDTO {
+        @SuppressWarnings("WeakerAccess")
+        public VendorCommandId commandId;
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/util/UnsignedNumberUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/util/UnsignedNumberUtilTest.java
@@ -197,4 +197,17 @@ class UnsignedNumberUtilTest {
         );
     }
 
+    @Test
+    void toUnsignedBigInteger_test() {
+        assertAll(
+                () -> assertThat(UnsignedNumberUtil.toUnsignedBigInteger(0L)).isEqualTo(BigInteger.ZERO),
+                () -> assertThat(UnsignedNumberUtil.toUnsignedBigInteger(1L)).isEqualTo(BigInteger.ONE),
+                () -> assertThat(UnsignedNumberUtil.toUnsignedBigInteger(Long.MAX_VALUE)).isEqualTo(BigInteger.valueOf(Long.MAX_VALUE)),
+                // -1L as unsigned = 2^64 - 1 = UNSIGNED_LONG_MAX
+                () -> assertThat(UnsignedNumberUtil.toUnsignedBigInteger(-1L)).isEqualTo(UnsignedNumberUtil.UNSIGNED_LONG_MAX),
+                // Long.MIN_VALUE as unsigned = 2^63
+                () -> assertThat(UnsignedNumberUtil.toUnsignedBigInteger(Long.MIN_VALUE)).isEqualTo(new BigInteger("9223372036854775808"))
+        );
+    }
+
 }

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.webauthn4j.data.AuthenticatorConfigSubCommand;
 import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.PinProtocolVersion;
 import com.webauthn4j.data.PublicKeyCredentialParameters;
@@ -163,7 +164,7 @@ public class AuthenticatorGetInfo {
 
     @JsonProperty("authenticatorConfigCommands")
     @Nullable
-    private final List<Integer> authenticatorConfigCommands;
+    private final List<AuthenticatorConfigSubCommand> authenticatorConfigCommands;
 
     @JsonCreator
     public AuthenticatorGetInfo(
@@ -197,7 +198,7 @@ public class AuthenticatorGetInfo {
             @JsonProperty("pinComplexityPolicyURL") @Nullable String pinComplexityPolicyURL,
             @JsonProperty("maxPINLength") @Nullable Integer maxPINLength,
             @JsonProperty("encCredStoreState") @Nullable String encCredStoreState,
-            @JsonProperty("authenticatorConfigCommands") @Nullable List<Integer> authenticatorConfigCommands) {
+            @JsonProperty("authenticatorConfigCommands") @Nullable List<AuthenticatorConfigSubCommand> authenticatorConfigCommands) {
         this.versions = versions;
         this.extensions = extensions;
         this.aaguid = aaguid;
@@ -368,7 +369,7 @@ public class AuthenticatorGetInfo {
         return encCredStoreState;
     }
 
-    public @Nullable List<Integer> getAuthenticatorConfigCommands() {
+    public @Nullable List<AuthenticatorConfigSubCommand> getAuthenticatorConfigCommands() {
         return authenticatorConfigCommands;
     }
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
@@ -26,6 +26,7 @@ import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.PinProtocolVersion;
 import com.webauthn4j.data.PublicKeyCredentialParameters;
 import com.webauthn4j.data.UserVerificationMethod;
+import com.webauthn4j.data.VendorCommandId;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.metadata.converter.jackson.deserializer.MetadataAAGUIDRelaxedDeserializer;
 import org.jetbrains.annotations.NotNull;
@@ -124,7 +125,7 @@ public class AuthenticatorGetInfo {
 
     @JsonProperty("vendorPrototypeConfigCommands")
     @Nullable
-    private final List<Integer> vendorPrototypeConfigCommands;
+    private final List<VendorCommandId> vendorPrototypeConfigCommands;
 
     @JsonProperty("attestationFormats")
     @Nullable
@@ -188,7 +189,7 @@ public class AuthenticatorGetInfo {
             @JsonProperty("uvModality") @Nullable Set<UserVerificationMethod> uvModality,
             @JsonProperty("certifications") @Nullable Map<String, Object> certifications,
             @JsonProperty("remainingDiscoverableCredentials") @Nullable Integer remainingDiscoverableCredentials,
-            @JsonProperty("vendorPrototypeConfigCommands") @Nullable List<Integer> vendorPrototypeConfigCommands,
+            @JsonProperty("vendorPrototypeConfigCommands") @Nullable List<VendorCommandId> vendorPrototypeConfigCommands,
             @JsonProperty("attestationFormats") @Nullable List<String> attestationFormats,
             @JsonProperty("uvCountSinceLastPinEntry") @Nullable Integer uvCountSinceLastPinEntry,
             @JsonProperty("longTouchForReset") @Nullable Boolean longTouchForReset,
@@ -329,7 +330,7 @@ public class AuthenticatorGetInfo {
         return remainingDiscoverableCredentials;
     }
 
-    public @Nullable List<Integer> getVendorPrototypeConfigCommands() {
+    public @Nullable List<VendorCommandId> getVendorPrototypeConfigCommands() {
         return vendorPrototypeConfigCommands;
     }
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfo.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.webauthn4j.data.AuthenticatorConfigSubCommand;
 import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.CertificationType;
 import com.webauthn4j.data.PinProtocolVersion;
 import com.webauthn4j.data.PublicKeyCredentialParameters;
 import com.webauthn4j.data.UserVerificationMethod;
@@ -117,7 +118,7 @@ public class AuthenticatorGetInfo {
 
     @JsonProperty("certifications")
     @Nullable
-    private final Map<String, Object> certifications;
+    private final Map<CertificationType, Integer> certifications;
 
     @JsonProperty("remainingDiscoverableCredentials")
     @Nullable
@@ -187,7 +188,7 @@ public class AuthenticatorGetInfo {
             @JsonProperty("maxRPIDsForSetMinPINLength") @Nullable Integer maxRPIDsForSetMinPINLength,
             @JsonProperty("preferredPlatformUvAttempts") @Nullable Integer preferredPlatformUvAttempts,
             @JsonProperty("uvModality") @Nullable Set<UserVerificationMethod> uvModality,
-            @JsonProperty("certifications") @Nullable Map<String, Object> certifications,
+            @JsonProperty("certifications") @Nullable Map<CertificationType, Integer> certifications,
             @JsonProperty("remainingDiscoverableCredentials") @Nullable Integer remainingDiscoverableCredentials,
             @JsonProperty("vendorPrototypeConfigCommands") @Nullable List<VendorCommandId> vendorPrototypeConfigCommands,
             @JsonProperty("attestationFormats") @Nullable List<String> attestationFormats,
@@ -322,7 +323,7 @@ public class AuthenticatorGetInfo {
         return uvModality;
     }
 
-    public @Nullable Map<String, Object> getCertifications() {
+    public @Nullable Map<CertificationType, Integer> getCertifications() {
         return certifications;
     }
 

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
@@ -21,6 +21,7 @@ import com.webauthn4j.data.AuthenticatorConfigSubCommand;
 import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.PinProtocolVersion;
 import com.webauthn4j.data.UserVerificationMethod;
+import com.webauthn4j.data.VendorCommandId;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule;
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,7 @@ class AuthenticatorGetInfoTest {
         assertThat(info.getUvModality()).containsExactly(UserVerificationMethod.FINGERPRINT_INTERNAL);
         assertThat(info.getCertifications()).containsKey("FIDO");
         assertThat(info.getRemainingDiscoverableCredentials()).isEqualTo(25);
-        assertThat(info.getVendorPrototypeConfigCommands()).containsExactly(1, 2);
+        assertThat(info.getVendorPrototypeConfigCommands()).containsExactly(new VendorCommandId(1), new VendorCommandId(2));
         assertThat(info.getAttestationFormats()).containsExactly("packed", "fido-u2f");
         assertThat(info.getUvCountSinceLastPinEntry()).isEqualTo(3);
         assertThat(info.getLongTouchForReset()).isTrue();
@@ -320,6 +321,46 @@ class AuthenticatorGetInfoTest {
                 .isNotEqualTo(c)
                 .isNotEqualTo(null)
                 .isNotEqualTo("string");
+    }
+
+    // ==================== Edge cases ====================
+
+    @Test
+    void authenticatorGetInfo_with_large_vendorPrototypeConfigCommands_test() {
+        // 18446744073709551614 = 2^64 - 2 (UNSIGNED_LONG_MAX - 1)
+        // 9223372036854775808  = 2^63     (Long.MAX_VALUE + 1)
+        String json = """
+                {
+                    "versions": ["FIDO_2_0"],
+                    "aaguid": "0132d110bf4e4208a403ab4f5f12efe5",
+                    "vendorPrototypeConfigCommands": [18446744073709551614, 9223372036854775808]
+                }
+                """;
+        AuthenticatorGetInfo info = jsonMapper.readValue(json, AuthenticatorGetInfo.class);
+        assertThat(info.getVendorPrototypeConfigCommands()).hasSize(2);
+        assertThat(info.getVendorPrototypeConfigCommands().get(0).asBigInteger())
+                .isEqualTo(new java.math.BigInteger("18446744073709551614"));
+        assertThat(info.getVendorPrototypeConfigCommands().get(1).asBigInteger())
+                .isEqualTo(new java.math.BigInteger("9223372036854775808"));
+    }
+
+    @Test
+    void authenticatorGetInfo_vendorPrototypeConfigCommands_roundTrip_test() {
+        String json = """
+                {
+                    "versions": ["FIDO_2_0"],
+                    "aaguid": "0132d110bf4e4208a403ab4f5f12efe5",
+                    "vendorPrototypeConfigCommands": [18446744073709551614, 42]
+                }
+                """;
+        AuthenticatorGetInfo info = jsonMapper.readValue(json, AuthenticatorGetInfo.class);
+        String reserialized = jsonMapper.writeValueAsString(info);
+        assertThat(reserialized).contains("18446744073709551614");
+        assertThat(reserialized).contains("42");
+
+        AuthenticatorGetInfo roundTripped = jsonMapper.readValue(reserialized, AuthenticatorGetInfo.class);
+        assertThat(roundTripped.getVendorPrototypeConfigCommands())
+                .isEqualTo(info.getVendorPrototypeConfigCommands());
     }
 
     // ==================== Test data ====================

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
@@ -19,6 +19,7 @@ package com.webauthn4j.metadata.data.statement;
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.AuthenticatorConfigSubCommand;
 import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.CertificationType;
 import com.webauthn4j.data.PinProtocolVersion;
 import com.webauthn4j.data.UserVerificationMethod;
 import com.webauthn4j.data.VendorCommandId;
@@ -58,7 +59,8 @@ class AuthenticatorGetInfoTest {
         assertThat(info.getMaxRPIDsForSetMinPINLength()).isEqualTo(3);
         assertThat(info.getPreferredPlatformUvAttempts()).isEqualTo(5);
         assertThat(info.getUvModality()).containsExactly(UserVerificationMethod.FINGERPRINT_INTERNAL);
-        assertThat(info.getCertifications()).containsKey("FIDO");
+        assertThat(info.getCertifications()).containsKey(CertificationType.FIDO);
+        assertThat(info.getCertifications()).containsEntry(CertificationType.FIDO, 1);
         assertThat(info.getRemainingDiscoverableCredentials()).isEqualTo(25);
         assertThat(info.getVendorPrototypeConfigCommands()).containsExactly(new VendorCommandId(1), new VendorCommandId(2));
         assertThat(info.getAttestationFormats()).containsExactly("packed", "fido-u2f");

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/data/statement/AuthenticatorGetInfoTest.java
@@ -17,6 +17,7 @@
 package com.webauthn4j.metadata.data.statement;
 
 import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.AuthenticatorConfigSubCommand;
 import com.webauthn4j.data.AuthenticatorTransport;
 import com.webauthn4j.data.PinProtocolVersion;
 import com.webauthn4j.data.UserVerificationMethod;
@@ -68,7 +69,7 @@ class AuthenticatorGetInfoTest {
         assertThat(info.getPinComplexityPolicyURL()).isEqualTo("https://example.com/policy");
         assertThat(info.getMaxPINLength()).isEqualTo(64);
         assertThat(info.getEncCredStoreState()).isEqualTo("state123");
-        assertThat(info.getAuthenticatorConfigCommands()).containsExactly(3, 4);
+        assertThat(info.getAuthenticatorConfigCommands()).containsExactly(AuthenticatorConfigSubCommand.SET_MIN_PIN_LENGTH, AuthenticatorConfigSubCommand.ENABLE_LONG_TOUCH_FOR_RESET);
     }
 
     @Test


### PR DESCRIPTION
Fix metadata parsing failure when `vendorPrototypeConfigCommands` contains unsigned 64-bit integer values exceeding `Integer.MAX_VALUE` (e.g. `18446744073709551614`). The field was typed as `List<Integer>`, which cannot hold such values. Closes #1462

Since this is already a breaking change to `AuthenticatorGetInfo`, also introduced value types for other fields that were using raw primitives:

- `authenticatorConfigCommands`: `List<Integer>` → `List<AuthenticatorConfigSubCommand>`
- `certifications`: `Map<String, Object>` → `Map<CertificationType, Integer>`

## Impact of breaking changes

Code that directly accesses `getAuthenticatorConfigCommands()`, `getVendorPrototypeConfigCommands()`, or `getCertifications()` on `AuthenticatorGetInfo` in `webauthn4j-metadata` will need to be updated. These fields were only added in 0.31.7.RELEASE (Jun 9, 2026), so the impact should be limited.