### PR TITLE
Exclude integration-tests subprojects from Maven Central publish targets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -175,7 +175,7 @@ sonarqube {
     }
 }
 
-val publishedSubprojects = subprojects.filter { it.name.startsWith("webauthn4j-") }
+val publishedSubprojects = subprojects.filter { it.name.startsWith("webauthn4j-") && !it.path.startsWith(":integration-tests:") }
 
 mavenCentralPublish {
     targetProjects = publishedSubprojects


### PR DESCRIPTION
The `publishedSubprojects` filter in `build.gradle.kts` selects all subprojects whose name starts with `webauthn4j-`. This inadvertently included `:integration-tests:webauthn4j-spring-security`, which does not apply the `maven-publish` plugin, causing the release workflow to fail with:

> Task with name 'publishAllPublicationsToMavenCentralStagingRepository' not found in project ':integration-tests:webauthn4j-spring-security'

Add a condition to exclude subprojects under `:integration-tests:` from the publish target list.