### PR TITLE
Remove seed-based ECUtil.createKeyPair methods

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ kotest = "5.9.1"
 
 kotlinx-coroutines = "1.11.0"
 
-webauthn4j-ctap = "0.2.0.RELEASE"
+webauthn4j-ctap = "0.2.1.RELEASE"
 
 webauthn4j-spring-security = "0.12.0.RELEASE"
 

--- a/webauthn4j-core/src/main/java/com/webauthn4j/util/ECUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/util/ECUtil.java
@@ -18,7 +18,6 @@ package com.webauthn4j.util;
 
 import com.webauthn4j.util.exception.UnexpectedCheckedException;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -53,7 +52,7 @@ public class ECUtil {
     }
 
     public static @NotNull KeyPair createKeyPair() {
-        return createKeyPair((byte[]) null);
+        return createKeyPair(P_256_SPEC);
     }
 
     public static @NotNull PublicKey createPublicKey(@NotNull ECPublicKeySpec ecPublicKeySpec) {
@@ -82,30 +81,14 @@ public class ECUtil {
         }
     }
 
-    public static @NotNull KeyPair createKeyPair(@Nullable byte[] seed, @NotNull ECParameterSpec ecParameterSpec) {
+    public static @NotNull KeyPair createKeyPair(@NotNull ECParameterSpec ecParameterSpec) {
         KeyPairGenerator keyPairGenerator = createKeyPairGenerator();
-        SecureRandom random;
         try {
-            if (seed != null) {
-                random = SecureRandom.getInstance("SHA1PRNG"); // to make it deterministic
-                random.setSeed(seed);
-            }
-            else {
-                random = secureRandom;
-            }
-            keyPairGenerator.initialize(ecParameterSpec, random);
+            keyPairGenerator.initialize(ecParameterSpec, secureRandom);
             return keyPairGenerator.generateKeyPair();
-        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+        } catch (InvalidAlgorithmParameterException e) {
             throw new UnexpectedCheckedException(e);
         }
-    }
-
-    public static @NotNull KeyPair createKeyPair(@Nullable byte[] seed) {
-        return createKeyPair(seed, ECUtil.P_256_SPEC);
-    }
-
-    public static @NotNull KeyPair createKeyPair(@NotNull ECParameterSpec ecParameterSpec) {
-        return createKeyPair(null, ecParameterSpec);
     }
 
     public static @NotNull PublicKey createPublicKeyFromUncompressed(@NotNull byte[] publicKey) {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/util/ECUtilTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/util/ECUtilTest.java
@@ -42,12 +42,5 @@ class ECUtilTest {
         assertThat(keyPair).isNotNull();
     }
 
-    @Test
-    void createKeyPair_test_with_seed() {
-        byte[] seed = new byte[]{0x01, 0x23, 0x45};
-        KeyPair keyPairA = ECUtil.createKeyPair(seed);
-        KeyPair keyPairB = ECUtil.createKeyPair(seed);
-        assertThat(keyPairA.getPrivate().getEncoded()).isEqualTo(keyPairB.getPrivate().getEncoded());
-    }
 
 }


### PR DESCRIPTION
Remove `createKeyPair(byte[] seed)` and `createKeyPair(byte[] seed, ECParameterSpec)` which depend on the SUN provider-specific `SHA1PRNG` SecureRandom algorithm. The only caller (`FIDOU2FAuthenticator`) was migrated to key wrapping in #1475.