### PR TITLE
Add test-with-security-provider Gradle plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ pluginManagement {
     includeBuild("maven-central-publish-plugin")
     includeBuild("optional-dependencies-plugin")
     includeBuild("toolchain-pinning-plugin")
+    includeBuild("test-with-security-provider-plugin")
 }
 
 plugins {

--- a/test-with-security-provider-plugin/README.md
+++ b/test-with-security-provider-plugin/README.md
@@ -1,0 +1,105 @@
+# test-with-security-provider Plugin
+
+A Gradle plugin that configures JCA security providers for test execution, enabling tests to run under different security provider configurations (e.g., BouncyCastle, BouncyCastle FIPS).
+
+## How It Works
+
+The plugin combines two mechanisms to reconfigure JCA security providers for test JVMs:
+
+1. **`java.security.properties`** (provider registration) — A dynamically generated properties file registers the desired providers. The JVM loads and instantiates them at startup, avoiding JPMS access restrictions that would occur with reflective instantiation.
+
+2. **Java agent `premain`** (provider removal) — A Java agent runs before the test application starts and removes any providers not in the configured list via `Security.removeProvider()`.
+
+This two-step approach is necessary because:
+- Adding providers requires the JVM to instantiate provider classes (some of which are in restricted JDK modules), which only `java.security.properties` can do safely.
+- Removing providers requires programmatic access, which only the agent can do before any test class loading occurs.
+
+The plugin jar itself serves as the Java agent (it contains the `Premain-Class` manifest entry).
+
+## Usage
+
+### 1. Include the plugin
+
+In `settings.gradle.kts`:
+
+```kotlin
+pluginManagement {
+    includeBuild("test-with-security-provider-plugin")
+}
+```
+
+### 2. Apply the plugin and configure
+
+In your module's `build.gradle.kts`:
+
+```kotlin
+plugins {
+    id("com.webauthn4j.test-with-security-provider")
+}
+
+// Register test suites (via JVM Test Suite Plugin or plain Test tasks)
+testing {
+    suites {
+        register<JvmTestSuite>("testWithBouncyCastle") {
+            targets {
+                all {
+                    testTask.configure {
+                        testClassesDirs = sourceSets["test"].output.classesDirs
+                        classpath = sourceSets["test"].runtimeClasspath
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Configure security providers for the test suites
+testWithSecurityProvider {
+    configurations {
+        register("testWithBouncyCastle") {
+            // Provider class names in priority order
+            providers.set(listOf(
+                "org.bouncycastle.jce.provider.BouncyCastleProvider",
+                "sun.security.provider.Sun"
+            ))
+        }
+    }
+}
+```
+
+The configuration name must match the test task name.
+
+### 3. Additional security properties
+
+Use `securityProperties` to set Java security properties (e.g., `securerandom.strongAlgorithms`):
+
+```kotlin
+register("testWithBouncyCastleFIPS") {
+    providers.set(listOf(
+        "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider",
+        "org.bouncycastle.entropy.provider.BouncyCastleEntropyProvider"
+    ))
+    securityProperties.put("securerandom.strongAlgorithms", "ENTROPY:BCRNG")
+}
+```
+
+Security properties are passed to the test JVM as system properties with the `webauthn4j.test.security.` prefix and applied by the agent via `Security.setProperty()`.
+
+## Architecture
+
+```
+Gradle build phase                    Test JVM startup
+┌──────────────────────┐              ┌─────────────────────────────────┐
+│ Plugin apply:        │              │ 1. JVM starts                   │
+│                      │              │                                 │
+│ 1. Create extension  │              │ 2. java.security.properties     │
+│ 2. Generate .security│── file ──→   │    registers desired providers  │
+│    file              │              │    (JVM instantiates them)      │
+│ 3. Configure test    │              │                                 │
+│    task:             │              │ 3. Agent premain runs:          │
+│    - -javaagent      │── jvmArg ──→ │    - Removes unwanted providers │
+│    - system props    │── props ──→  │    - Sets security properties   │
+│                      │              │                                 │
+│                      │              │ 4. Tests execute                │
+└──────────────────────┘              └─────────────────────────────────┘
+```

--- a/test-with-security-provider-plugin/build.gradle.kts
+++ b/test-with-security-provider-plugin/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    `kotlin-dsl`
+    `java-library`
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        register("testWithSecurityProvider") {
+            id = "com.webauthn4j.test-with-security-provider"
+            implementationClass = "com.webauthn4j.gradle.TestWithSecurityProviderPlugin"
+        }
+    }
+}
+
+tasks.jar {
+    manifest {
+        attributes("Premain-Class" to "com.webauthn4j.gradle.agent.SecurityProviderAgent")
+    }
+}

--- a/test-with-security-provider-plugin/settings.gradle.kts
+++ b/test-with-security-provider-plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "test-with-security-provider-plugin"

--- a/test-with-security-provider-plugin/src/main/java/com/webauthn4j/gradle/agent/SecurityProviderAgent.java
+++ b/test-with-security-provider-plugin/src/main/java/com/webauthn4j/gradle/agent/SecurityProviderAgent.java
@@ -1,0 +1,31 @@
+package com.webauthn4j.gradle.agent;
+
+import java.lang.instrument.Instrumentation;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Set;
+
+public class SecurityProviderAgent {
+
+    public static void premain(String args, Instrumentation inst) {
+        String providerList = System.getProperty("webauthn4j.test.securityProviders");
+        if (providerList == null) {
+            return;
+        }
+
+        Set<String> keepClasses = Set.of(providerList.split(","));
+        for (Provider p : Security.getProviders()) {
+            if (!keepClasses.contains(p.getClass().getName())) {
+                Security.removeProvider(p.getName());
+            }
+        }
+
+        String prefix = "webauthn4j.test.security.";
+        for (String key : System.getProperties().stringPropertyNames()) {
+            if (key.startsWith(prefix)) {
+                String securityKey = key.substring(prefix.length());
+                Security.setProperty(securityKey, System.getProperty(key));
+            }
+        }
+    }
+}

--- a/test-with-security-provider-plugin/src/main/kotlin/com/webauthn4j/gradle/SecurityProviderConfiguration.kt
+++ b/test-with-security-provider-plugin/src/main/kotlin/com/webauthn4j/gradle/SecurityProviderConfiguration.kt
@@ -1,0 +1,11 @@
+package com.webauthn4j.gradle
+
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+
+abstract class SecurityProviderConfiguration(val name: String) {
+    /** Provider class names to register (in priority order) */
+    abstract val providers: ListProperty<String>
+    /** Additional security properties to set */
+    abstract val securityProperties: MapProperty<String, String>
+}

--- a/test-with-security-provider-plugin/src/main/kotlin/com/webauthn4j/gradle/TestWithSecurityProviderExtension.kt
+++ b/test-with-security-provider-plugin/src/main/kotlin/com/webauthn4j/gradle/TestWithSecurityProviderExtension.kt
@@ -1,0 +1,7 @@
+package com.webauthn4j.gradle
+
+import org.gradle.api.NamedDomainObjectContainer
+
+abstract class TestWithSecurityProviderExtension {
+    abstract val configurations: NamedDomainObjectContainer<SecurityProviderConfiguration>
+}

--- a/test-with-security-provider-plugin/src/main/kotlin/com/webauthn4j/gradle/TestWithSecurityProviderPlugin.kt
+++ b/test-with-security-provider-plugin/src/main/kotlin/com/webauthn4j/gradle/TestWithSecurityProviderPlugin.kt
@@ -1,0 +1,57 @@
+package com.webauthn4j.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import java.io.File
+
+class TestWithSecurityProviderPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        val extension = project.extensions.create(
+            "testWithSecurityProvider",
+            TestWithSecurityProviderExtension::class.java
+        )
+
+        val agentJar = resolveAgentJar()
+        val generatedDir = project.layout.buildDirectory.dir("generated-security")
+
+        project.afterEvaluate {
+            extension.configurations.forEach { config ->
+                val securityFile = generatedDir.get().file("${config.name}.security").asFile
+                generateSecurityProperties(securityFile, config)
+
+                val providerClasses = config.providers.get()
+                    .map { it.split(" ").first() }
+                    .joinToString(",")
+
+                project.tasks.named(config.name, Test::class.java).configure {
+                    jvmArgs("-javaagent:${agentJar.absolutePath}")
+                    systemProperty("java.security.properties",
+                        securityFile.absolutePath)
+                    systemProperty("webauthn4j.test.securityProviders", providerClasses)
+                    config.securityProperties.get().forEach { (key, value) ->
+                        systemProperty("webauthn4j.test.security.$key", value)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun generateSecurityProperties(file: File, config: SecurityProviderConfiguration) {
+        file.parentFile.mkdirs()
+        val lines = config.providers.get().mapIndexed { i, provider ->
+            "security.provider.${i + 1}=$provider"
+        }
+        file.writeText(lines.joinToString("\n") + "\n")
+    }
+
+    private fun resolveAgentJar(): File {
+        val pluginJar = TestWithSecurityProviderPlugin::class.java
+            .protectionDomain
+            .codeSource
+            .location
+            .toURI()
+        return File(pluginJar)
+    }
+}


### PR DESCRIPTION
Add a Gradle plugin that configures JCA security providers for test execution, enabling tests to run under different security provider configurations (e.g., BouncyCastle, BouncyCastle FIPS).

The plugin combines two mechanisms:
- **`java.security.properties`** registers desired providers at JVM startup, avoiding JPMS restrictions on reflective instantiation of JDK-internal provider classes
- **Java agent `premain`** removes unwanted providers before any test class loading occurs

The plugin jar itself serves as the Java agent. See `test-with-security-provider-plugin/README.md` for detailed architecture and usage documentation.