### PR TITLE
Add macOS to CI matrix and restrict testWithBouncyCastleFIPS to Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: [17, 21, 25]
-        os: [ubuntu-latest, windows-latest] # , macOS-latest (remove macOS as it is not stable for now)
+        include:
+          - java_version: 17
+            os: ubuntu-latest
+          - java_version: 21
+            os: ubuntu-latest
+          - java_version: 25
+            os: ubuntu-latest
+          - java_version: 25
+            os: windows-latest
+          - java_version: 25
+            os: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-gate-ci.yml
+++ b/.github/workflows/pr-gate-ci.yml
@@ -37,8 +37,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: [17, 21, 25]
-        os: [ubuntu-latest, windows-latest] # , macOS-latest (remove macOS as it is not stable for now)
+        include:
+          - java_version: 17
+            os: ubuntu-latest
+          - java_version: 21
+            os: ubuntu-latest
+          - java_version: 25
+            os: ubuntu-latest
+          - java_version: 25
+            os: windows-latest
+          - java_version: 25
+            os: macos-latest
 
     steps:
       - name: Checkout

--- a/webauthn4j-core/build.gradle.kts
+++ b/webauthn4j-core/build.gradle.kts
@@ -50,7 +50,7 @@ testing {
         }
         // Re-runs src/test/java tests with BouncyCastle FIPS as the primary JCA provider.
         // BC and BC-FIPS are mutually exclusive and cannot coexist on the same classpath.
-        // Skipped on Windows because the JENT entropy provider requires native code
+        // Runs only on Linux because the JENT entropy provider requires native code
         // that is only available on Intel/ARM Linux (see BC-FJA User Guide Section 2.4).
         register<JvmTestSuite>("testWithBouncyCastleFIPS") {
             dependencies {
@@ -72,7 +72,7 @@ testing {
                         description = "Runs tests with BouncyCastle FIPS as the primary JCA provider (Linux only)"
                         testClassesDirs = sourceSets["test"].output.classesDirs
                         classpath += sourceSets["test"].output
-                        onlyIf { !System.getProperty("os.name").lowercase().contains("windows") }
+                        onlyIf { System.getProperty("os.name").lowercase().contains("linux") }
                     }
                 }
             }


### PR DESCRIPTION
Add macOS to the CI test matrix with pruned JDK combinations: all JDK versions (17, 21, 25) on ubuntu, latest JDK (25) only on windows and macOS for OS-specific issue detection.

Restrict testWithBouncyCastleFIPS to Linux only. The JENT entropy provider requires native code available only on Intel/ARM Linux (see BC-FJA User Guide Section 2.4), so the previous Windows-only exclusion was insufficient — macOS also lacks JENT support, causing BC-FIPS module self-test failures.