### PR TITLE
Improve fido-integration-bdd DSL and add security verification tests

### DIFF
--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
@@ -1,5 +1,6 @@
 package com.webauthn4j.test.integration.environment
 
+import com.webauthn4j.converter.CollectedClientDataConverter
 import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.credential.CredentialRecord
 import com.webauthn4j.credential.CredentialRecordImpl
@@ -7,6 +8,7 @@ import com.webauthn4j.ctap.client.PublicKeyCredentialCreationContext
 import com.webauthn4j.ctap.client.PublicKeyCredentialRequestContext
 import com.webauthn4j.data.*
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
+import com.webauthn4j.data.client.CollectedClientData
 import com.webauthn4j.data.client.Origin
 import com.webauthn4j.data.client.challenge.Challenge
 import com.webauthn4j.data.client.challenge.DefaultChallenge
@@ -176,12 +178,20 @@ class StandardScenario internal constructor(
                 userVerificationRequired: Boolean? = null,
                 userPresenceRequired: Boolean? = null,
                 attestationObject: ByteArray? = null,
-                clientDataJSON: ByteArray? = null,
+                clientData: ((CollectedClientData) -> CollectedClientData)? = null,
             ): RegistrationResult {
                 val rp = scenario.relyingParty
+                val originalClientDataJSON = credential.response!!.clientDataJSON
+                val effectiveClientDataJSON = if (clientData != null) {
+                    val converter = CollectedClientDataConverter(scenario.objectConverter)
+                    val original = converter.convert(originalClientDataJSON)!!
+                    converter.convertToBytes(clientData(original))
+                } else {
+                    originalClientDataJSON
+                }
                 val registrationRequest = RegistrationRequest(
                     attestationObject ?: credential.response!!.attestationObject,
-                    clientDataJSON ?: credential.response!!.clientDataJSON,
+                    effectiveClientDataJSON,
                     scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
                     credential.response!!.transports.map { it.value }.toSet()
                 )
@@ -272,16 +282,24 @@ class StandardScenario internal constructor(
                 userPresenceRequired: Boolean? = null,
                 signature: ByteArray? = null,
                 authenticatorData: ByteArray? = null,
-                clientDataJSON: ByteArray? = null,
+                clientData: ((CollectedClientData) -> CollectedClientData)? = null,
             ): AuthenticationResult {
                 val rp = scenario.relyingParty
                 val credentialRecord = rp.lookupCredential(credential.rawId)
                     ?: error("No credential found for ID. Did you register first?")
 
+                val originalClientDataJSON = credential.response!!.clientDataJSON
+                val effectiveClientDataJSON = if (clientData != null) {
+                    val converter = CollectedClientDataConverter(scenario.objectConverter)
+                    val original = converter.convert(originalClientDataJSON)!!
+                    converter.convertToBytes(clientData(original))
+                } else {
+                    originalClientDataJSON
+                }
                 val request = AuthenticationRequest(
                     credential.rawId, ByteArray(32),
                     authenticatorData ?: credential.response!!.authenticatorData,
-                    clientDataJSON ?: credential.response!!.clientDataJSON,
+                    effectiveClientDataJSON,
                     scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
                     signature ?: credential.response!!.signature
                 )

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
@@ -10,7 +10,10 @@ import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import com.webauthn4j.data.client.Origin
 import com.webauthn4j.data.client.challenge.Challenge
 import com.webauthn4j.data.client.challenge.DefaultChallenge
+import com.webauthn4j.data.extension.client.AuthenticationExtensionClientInput
+import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientInputs
 import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput
+import com.webauthn4j.data.extension.client.RegistrationExtensionClientInput
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput
 import com.webauthn4j.server.ServerProperty
 
@@ -35,9 +38,17 @@ class StandardScenario internal constructor(
         pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
         excludeCredentials: List<PublicKeyCredentialDescriptor>? = null,
         authenticatorAttachment: AuthenticatorAttachment? = null,
+        residentKeyRequirement: ResidentKeyRequirement? = null,
+        userVerificationRequirement: UserVerificationRequirement? = null,
+        attestation: AttestationConveyancePreference? = null,
+        extensions: AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput>? = null,
+        timeout: Long? = null,
+        hints: List<PublicKeyCredentialHints>? = null,
+        attestationFormats: List<String>? = null,
     ): RegistrationOptionsCreated {
         val rp = relyingParty
         val challenge = DefaultChallenge()
+        val effectiveResidentKeyRequirement = residentKeyRequirement ?: rp.residentKeyRequirement
         val options = PublicKeyCredentialCreationOptions(
             PublicKeyCredentialRpEntity(rp.rpId, rp.rpName),
             PublicKeyCredentialUserEntity(ByteArray(32), "user@example.com", "Test User"),
@@ -45,16 +56,18 @@ class StandardScenario internal constructor(
             pubKeyCredParams ?: listOf(
                 PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256)
             ),
-            null,
+            timeout,
             excludeCredentials ?: emptyList(),
             AuthenticatorSelectionCriteria(
                 authenticatorAttachment,
-                rp.residentKeyRequirement == ResidentKeyRequirement.REQUIRED,
-                rp.residentKeyRequirement,
-                rp.userVerificationRequirement
+                effectiveResidentKeyRequirement == ResidentKeyRequirement.REQUIRED,
+                effectiveResidentKeyRequirement,
+                userVerificationRequirement ?: rp.userVerificationRequirement
             ),
-            rp.attestation,
-            null
+            hints,
+            attestation ?: rp.attestation,
+            attestationFormats,
+            extensions
         )
         return RegistrationOptionsCreated(options, challenge, this)
     }
@@ -72,12 +85,15 @@ class StandardScenario internal constructor(
     fun createAuthenticationOptions(
         allowCredentials: List<PublicKeyCredentialDescriptor>? = null,
         userVerificationRequirement: UserVerificationRequirement? = null,
+        extensions: AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput>? = null,
+        timeout: Long? = null,
+        hints: List<PublicKeyCredentialHints>? = null,
     ): AuthenticationOptionsCreated {
         val rp = relyingParty
         val challenge = DefaultChallenge()
         val options = PublicKeyCredentialRequestOptions(
-            challenge, null, rp.rpId, allowCredentials,
-            userVerificationRequirement ?: rp.userVerificationRequirement, null
+            challenge, timeout, rp.rpId, allowCredentials,
+            userVerificationRequirement ?: rp.userVerificationRequirement, hints, extensions
         )
         return AuthenticationOptionsCreated(options, challenge, this)
     }
@@ -100,35 +116,37 @@ class StandardScenario internal constructor(
     ) {
         /**
          * Send to client platform: calls WebAuthnClient.create().
-         * @param overrideChallenge If set, replaces the challenge (simulates challenge fixation attack).
-         * @param overrideOrigin If set, replaces the origin (simulates cross-origin attack).
+         * @param challenge If set, replaces the challenge (simulates challenge fixation attack).
+         * @param origin If set, replaces the origin (simulates cross-origin attack).
          */
         suspend fun createCredential(
             clientPlatform: ClientPlatform = scenario.defaultClientPlatform,
-            overrideChallenge: Challenge? = null,
-            overrideOrigin: Origin? = null,
+            challenge: Challenge? = null,
+            origin: Origin? = null,
         ): RegistrationCredentialCreated {
-            val effectiveOptions = if (overrideChallenge != null) {
+            val effectiveOptions = if (challenge != null) {
                 PublicKeyCredentialCreationOptions(
                     publicKeyCredentialCreationOptions.rp,
                     publicKeyCredentialCreationOptions.user,
-                    overrideChallenge,
+                    challenge,
                     publicKeyCredentialCreationOptions.pubKeyCredParams,
                     publicKeyCredentialCreationOptions.timeout,
                     publicKeyCredentialCreationOptions.excludeCredentials,
                     publicKeyCredentialCreationOptions.authenticatorSelection,
+                    publicKeyCredentialCreationOptions.hints,
                     publicKeyCredentialCreationOptions.attestation,
+                    publicKeyCredentialCreationOptions.attestationFormats,
                     publicKeyCredentialCreationOptions.extensions
                 )
             } else {
                 publicKeyCredentialCreationOptions
             }
             val context = PublicKeyCredentialCreationContext(
-                overrideOrigin ?: clientPlatform.origin,
+                origin ?: clientPlatform.origin,
                 clientPINProvider = { clientPlatform.clientPINValue.toByteArray() }
             )
             val credential = clientPlatform.webAuthnClient.create(effectiveOptions, context)
-            return RegistrationCredentialCreated(credential, challenge, scenario)
+            return RegistrationCredentialCreated(credential, this.challenge, scenario)
         }
     }
 
@@ -142,11 +160,15 @@ class StandardScenario internal constructor(
         fun verifyOnServer(
             rpId: String? = null,
             pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
+            userVerificationRequired: Boolean? = null,
+            userPresenceRequired: Boolean? = null,
+            attestationObject: ByteArray? = null,
+            clientDataJSON: ByteArray? = null,
         ): RegistrationResult {
             val rp = scenario.relyingParty
             val registrationRequest = RegistrationRequest(
-                credential.response!!.attestationObject,
-                credential.response!!.clientDataJSON,
+                attestationObject ?: credential.response!!.attestationObject,
+                clientDataJSON ?: credential.response!!.clientDataJSON,
                 scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
                 credential.response!!.transports.map { it.value }.toSet()
             )
@@ -156,7 +178,9 @@ class StandardScenario internal constructor(
                 .challenge(this.challenge)
                 .build()
             val params = RegistrationParameters(
-                serverProperty, pubKeyCredParams, rp.userVerificationRequired, rp.userPresenceRequired
+                serverProperty, pubKeyCredParams,
+                userVerificationRequired ?: rp.userVerificationRequired,
+                userPresenceRequired ?: rp.userPresenceRequired
             )
             val data = rp.webAuthnManager.verify(registrationRequest, params)
             val record = CredentialRecordImpl(
@@ -182,33 +206,34 @@ class StandardScenario internal constructor(
     ) {
         /**
          * Send to client platform: calls WebAuthnClient.get().
-         * @param overrideChallenge If set, replaces the challenge (simulates challenge fixation attack).
-         * @param overrideOrigin If set, replaces the origin (simulates cross-origin attack).
+         * @param challenge If set, replaces the challenge (simulates challenge fixation attack).
+         * @param origin If set, replaces the origin (simulates cross-origin attack).
          */
         suspend fun getAssertion(
             clientPlatform: ClientPlatform = scenario.defaultClientPlatform,
-            overrideChallenge: Challenge? = null,
-            overrideOrigin: Origin? = null,
+            challenge: Challenge? = null,
+            origin: Origin? = null,
         ): AuthenticationAssertionCreated {
-            val effectiveOptions = if (overrideChallenge != null) {
+            val effectiveOptions = if (challenge != null) {
                 PublicKeyCredentialRequestOptions(
-                    overrideChallenge,
+                    challenge,
                     publicKeyCredentialRequestOptions.timeout,
                     publicKeyCredentialRequestOptions.rpId,
                     publicKeyCredentialRequestOptions.allowCredentials,
                     publicKeyCredentialRequestOptions.userVerification,
+                    publicKeyCredentialRequestOptions.hints,
                     publicKeyCredentialRequestOptions.extensions
                 )
             } else {
                 publicKeyCredentialRequestOptions
             }
             val context = PublicKeyCredentialRequestContext(
-                overrideOrigin ?: clientPlatform.origin,
+                origin ?: clientPlatform.origin,
                 publicKeyCredentialSelectionHandler = { it.first() },
                 clientPINProvider = { clientPlatform.clientPINValue.toByteArray() }
             )
             val credential = clientPlatform.webAuthnClient.get(effectiveOptions, context)
-            return AuthenticationAssertionCreated(credential, challenge, scenario)
+            return AuthenticationAssertionCreated(credential, this.challenge, scenario)
         }
     }
 
@@ -223,6 +248,10 @@ class StandardScenario internal constructor(
             rpId: String? = null,
             userVerificationRequired: Boolean? = null,
             allowCredentials: List<ByteArray>? = null,
+            userPresenceRequired: Boolean? = null,
+            signature: ByteArray? = null,
+            authenticatorData: ByteArray? = null,
+            clientDataJSON: ByteArray? = null,
         ): AuthenticationResult {
             val rp = scenario.relyingParty
             val credentialRecord = rp.lookupCredential(credential.rawId)
@@ -230,10 +259,10 @@ class StandardScenario internal constructor(
 
             val request = AuthenticationRequest(
                 credential.rawId, ByteArray(32),
-                credential.response!!.authenticatorData,
-                credential.response!!.clientDataJSON,
+                authenticatorData ?: credential.response!!.authenticatorData,
+                clientDataJSON ?: credential.response!!.clientDataJSON,
                 scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
-                credential.response!!.signature
+                signature ?: credential.response!!.signature
             )
             val serverProperty = ServerProperty.builder()
                 .origin(rp.origin)
@@ -242,7 +271,8 @@ class StandardScenario internal constructor(
                 .build()
             val params = AuthenticationParameters(
                 serverProperty, credentialRecord, allowCredentials,
-                userVerificationRequired ?: rp.userVerificationRequired, rp.userPresenceRequired
+                userVerificationRequired ?: rp.userVerificationRequired,
+                userPresenceRequired ?: rp.userPresenceRequired
             )
             val data = rp.webAuthnManager.verify(request, params)
             return AuthenticationResult(credential, data)

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
@@ -1,5 +1,6 @@
 package com.webauthn4j.test.integration.environment
 
+import com.webauthn4j.converter.AuthenticatorDataConverter
 import com.webauthn4j.converter.CollectedClientDataConverter
 import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.credential.CredentialRecord
@@ -7,11 +8,13 @@ import com.webauthn4j.credential.CredentialRecordImpl
 import com.webauthn4j.ctap.client.PublicKeyCredentialCreationContext
 import com.webauthn4j.ctap.client.PublicKeyCredentialRequestContext
 import com.webauthn4j.data.*
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import com.webauthn4j.data.client.CollectedClientData
 import com.webauthn4j.data.client.Origin
 import com.webauthn4j.data.client.challenge.Challenge
 import com.webauthn4j.data.client.challenge.DefaultChallenge
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput
 import com.webauthn4j.data.extension.client.AuthenticationExtensionClientInput
 import com.webauthn4j.data.extension.client.AuthenticationExtensionsClientInputs
 import com.webauthn4j.data.extension.client.AuthenticationExtensionClientOutput
@@ -281,13 +284,21 @@ class StandardScenario internal constructor(
                 allowCredentials: List<ByteArray>? = null,
                 userPresenceRequired: Boolean? = null,
                 signature: ByteArray? = null,
-                authenticatorData: ByteArray? = null,
+                authenticatorData: ((AuthenticatorData<AuthenticationExtensionAuthenticatorOutput>) -> AuthenticatorData<AuthenticationExtensionAuthenticatorOutput>)? = null,
                 clientData: ((CollectedClientData) -> CollectedClientData)? = null,
             ): AuthenticationResult {
                 val rp = scenario.relyingParty
                 val credentialRecord = rp.lookupCredential(credential.rawId)
                     ?: error("No credential found for ID. Did you register first?")
 
+                val originalAuthenticatorData = credential.response!!.authenticatorData
+                val effectiveAuthenticatorData = if (authenticatorData != null) {
+                    val converter = AuthenticatorDataConverter(scenario.objectConverter)
+                    val original = converter.convert<AuthenticationExtensionAuthenticatorOutput>(originalAuthenticatorData)
+                    converter.convert(authenticatorData(original))
+                } else {
+                    originalAuthenticatorData
+                }
                 val originalClientDataJSON = credential.response!!.clientDataJSON
                 val effectiveClientDataJSON = if (clientData != null) {
                     val converter = CollectedClientDataConverter(scenario.objectConverter)
@@ -298,7 +309,7 @@ class StandardScenario internal constructor(
                 }
                 val request = AuthenticationRequest(
                     credential.rawId, ByteArray(32),
-                    authenticatorData ?: credential.response!!.authenticatorData,
+                    effectiveAuthenticatorData,
                     effectiveClientDataJSON,
                     scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
                     signature ?: credential.response!!.signature

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
@@ -21,88 +21,94 @@ import com.webauthn4j.server.ServerProperty
  * Standard WebAuthn scenario that orchestrates the registration/authentication
  * protocol flow between a [RelyingParty] and a [ClientPlatform].
  *
- * Each flow is decomposed into step objects representing protocol states:
- * - Registration: [RegistrationOptionsCreated] → [RegistrationCredentialCreated] → [RegistrationResult]
- * - Authentication: [AuthenticationOptionsCreated] → [AuthenticationAssertionCreated] → [AuthenticationResult]
+ * Each flow is decomposed into step objects representing protocol states,
+ * with actor-scoped accessors ([server] / [clientPlatform][RegistrationOptionsCreated.clientPlatform])
+ * that make it clear which entity performs each step:
+ *
+ * ```
+ * scenario.server.createRegistrationOptions()
+ *     .clientPlatform.createCredential()
+ *     .server.verify()
+ * ```
  */
 class StandardScenario internal constructor(
     val relyingParty: RelyingParty,
     val defaultClientPlatform: ClientPlatform,
     private val objectConverter: ObjectConverter,
 ) {
-    // ============================================================
-    // Registration Flow
-    // ============================================================
-
-    fun createRegistrationOptions(
-        pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
-        excludeCredentials: List<PublicKeyCredentialDescriptor>? = null,
-        authenticatorAttachment: AuthenticatorAttachment? = null,
-        residentKeyRequirement: ResidentKeyRequirement? = null,
-        userVerificationRequirement: UserVerificationRequirement? = null,
-        attestation: AttestationConveyancePreference? = null,
-        extensions: AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput>? = null,
-        timeout: Long? = null,
-        hints: List<PublicKeyCredentialHints>? = null,
-        attestationFormats: List<String>? = null,
-    ): RegistrationOptionsCreated {
-        val rp = relyingParty
-        val challenge = DefaultChallenge()
-        val effectiveResidentKeyRequirement = residentKeyRequirement ?: rp.residentKeyRequirement
-        val options = PublicKeyCredentialCreationOptions(
-            PublicKeyCredentialRpEntity(rp.rpId, rp.rpName),
-            PublicKeyCredentialUserEntity(ByteArray(32), "user@example.com", "Test User"),
-            challenge,
-            pubKeyCredParams ?: listOf(
-                PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256)
-            ),
-            timeout,
-            excludeCredentials ?: emptyList(),
-            AuthenticatorSelectionCriteria(
-                authenticatorAttachment,
-                effectiveResidentKeyRequirement == ResidentKeyRequirement.REQUIRED,
-                effectiveResidentKeyRequirement,
-                userVerificationRequirement ?: rp.userVerificationRequirement
-            ),
-            hints,
-            attestation ?: rp.attestation,
-            attestationFormats,
-            extensions
-        )
-        return RegistrationOptionsCreated(options, challenge, this)
-    }
+    val server = ServerActions()
 
     /** Convenience: full registration flow with all defaults. */
     suspend fun register(): RegistrationResult =
-        createRegistrationOptions()
-            .createCredential(defaultClientPlatform)
-            .verifyOnServer()
-
-    // ============================================================
-    // Authentication Flow
-    // ============================================================
-
-    fun createAuthenticationOptions(
-        allowCredentials: List<PublicKeyCredentialDescriptor>? = null,
-        userVerificationRequirement: UserVerificationRequirement? = null,
-        extensions: AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput>? = null,
-        timeout: Long? = null,
-        hints: List<PublicKeyCredentialHints>? = null,
-    ): AuthenticationOptionsCreated {
-        val rp = relyingParty
-        val challenge = DefaultChallenge()
-        val options = PublicKeyCredentialRequestOptions(
-            challenge, timeout, rp.rpId, allowCredentials,
-            userVerificationRequirement ?: rp.userVerificationRequirement, hints, extensions
-        )
-        return AuthenticationOptionsCreated(options, challenge, this)
-    }
+        server.createRegistrationOptions()
+            .clientPlatform.createCredential()
+            .server.verify()
 
     /** Convenience: full authentication flow with all defaults. */
     suspend fun authenticate(): AuthenticationResult =
-        createAuthenticationOptions()
-            .getAssertion()
-            .verifyOnServer()
+        server.createAuthenticationOptions()
+            .clientPlatform.getAssertion()
+            .server.verify()
+
+    // ============================================================
+    // Server Actions (top-level)
+    // ============================================================
+
+    inner class ServerActions {
+        fun createRegistrationOptions(
+            pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
+            excludeCredentials: List<PublicKeyCredentialDescriptor>? = null,
+            authenticatorAttachment: AuthenticatorAttachment? = null,
+            residentKeyRequirement: ResidentKeyRequirement? = null,
+            userVerificationRequirement: UserVerificationRequirement? = null,
+            attestation: AttestationConveyancePreference? = null,
+            extensions: AuthenticationExtensionsClientInputs<RegistrationExtensionClientInput>? = null,
+            timeout: Long? = null,
+            hints: List<PublicKeyCredentialHints>? = null,
+            attestationFormats: List<String>? = null,
+        ): RegistrationOptionsCreated {
+            val rp = relyingParty
+            val challenge = DefaultChallenge()
+            val effectiveResidentKeyRequirement = residentKeyRequirement ?: rp.residentKeyRequirement
+            val options = PublicKeyCredentialCreationOptions(
+                PublicKeyCredentialRpEntity(rp.rpId, rp.rpName),
+                PublicKeyCredentialUserEntity(ByteArray(32), "user@example.com", "Test User"),
+                challenge,
+                pubKeyCredParams ?: listOf(
+                    PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256)
+                ),
+                timeout,
+                excludeCredentials ?: emptyList(),
+                AuthenticatorSelectionCriteria(
+                    authenticatorAttachment,
+                    effectiveResidentKeyRequirement == ResidentKeyRequirement.REQUIRED,
+                    effectiveResidentKeyRequirement,
+                    userVerificationRequirement ?: rp.userVerificationRequirement
+                ),
+                hints,
+                attestation ?: rp.attestation,
+                attestationFormats,
+                extensions
+            )
+            return RegistrationOptionsCreated(options, challenge, this@StandardScenario)
+        }
+
+        fun createAuthenticationOptions(
+            allowCredentials: List<PublicKeyCredentialDescriptor>? = null,
+            userVerificationRequirement: UserVerificationRequirement? = null,
+            extensions: AuthenticationExtensionsClientInputs<AuthenticationExtensionClientInput>? = null,
+            timeout: Long? = null,
+            hints: List<PublicKeyCredentialHints>? = null,
+        ): AuthenticationOptionsCreated {
+            val rp = relyingParty
+            val challenge = DefaultChallenge()
+            val options = PublicKeyCredentialRequestOptions(
+                challenge, timeout, rp.rpId, allowCredentials,
+                userVerificationRequirement ?: rp.userVerificationRequirement, hints, extensions
+            )
+            return AuthenticationOptionsCreated(options, challenge, this@StandardScenario)
+        }
+    }
 
     // ============================================================
     // Step Objects — Registration
@@ -114,39 +120,43 @@ class StandardScenario internal constructor(
         internal val challenge: Challenge,
         internal val scenario: StandardScenario,
     ) {
-        /**
-         * Send to client platform: calls WebAuthnClient.create().
-         * @param challenge If set, replaces the challenge (simulates challenge fixation attack).
-         * @param origin If set, replaces the origin (simulates cross-origin attack).
-         */
-        suspend fun createCredential(
-            clientPlatform: ClientPlatform = scenario.defaultClientPlatform,
-            challenge: Challenge? = null,
-            origin: Origin? = null,
-        ): RegistrationCredentialCreated {
-            val effectiveOptions = if (challenge != null) {
-                PublicKeyCredentialCreationOptions(
-                    publicKeyCredentialCreationOptions.rp,
-                    publicKeyCredentialCreationOptions.user,
-                    challenge,
-                    publicKeyCredentialCreationOptions.pubKeyCredParams,
-                    publicKeyCredentialCreationOptions.timeout,
-                    publicKeyCredentialCreationOptions.excludeCredentials,
-                    publicKeyCredentialCreationOptions.authenticatorSelection,
-                    publicKeyCredentialCreationOptions.hints,
-                    publicKeyCredentialCreationOptions.attestation,
-                    publicKeyCredentialCreationOptions.attestationFormats,
-                    publicKeyCredentialCreationOptions.extensions
+        val clientPlatform = ClientPlatformActions()
+
+        inner class ClientPlatformActions {
+            /**
+             * Send to client platform: calls WebAuthnClient.create().
+             * @param challenge If set, replaces the challenge (simulates challenge fixation attack).
+             * @param origin If set, replaces the origin (simulates cross-origin attack).
+             */
+            suspend fun createCredential(
+                clientPlatform: ClientPlatform = scenario.defaultClientPlatform,
+                challenge: Challenge? = null,
+                origin: Origin? = null,
+            ): RegistrationCredentialCreated {
+                val effectiveOptions = if (challenge != null) {
+                    PublicKeyCredentialCreationOptions(
+                        publicKeyCredentialCreationOptions.rp,
+                        publicKeyCredentialCreationOptions.user,
+                        challenge,
+                        publicKeyCredentialCreationOptions.pubKeyCredParams,
+                        publicKeyCredentialCreationOptions.timeout,
+                        publicKeyCredentialCreationOptions.excludeCredentials,
+                        publicKeyCredentialCreationOptions.authenticatorSelection,
+                        publicKeyCredentialCreationOptions.hints,
+                        publicKeyCredentialCreationOptions.attestation,
+                        publicKeyCredentialCreationOptions.attestationFormats,
+                        publicKeyCredentialCreationOptions.extensions
+                    )
+                } else {
+                    publicKeyCredentialCreationOptions
+                }
+                val context = PublicKeyCredentialCreationContext(
+                    origin ?: clientPlatform.origin,
+                    clientPINProvider = { clientPlatform.clientPINValue.toByteArray() }
                 )
-            } else {
-                publicKeyCredentialCreationOptions
+                val credential = clientPlatform.webAuthnClient.create(effectiveOptions, context)
+                return RegistrationCredentialCreated(credential, this@RegistrationOptionsCreated.challenge, scenario)
             }
-            val context = PublicKeyCredentialCreationContext(
-                origin ?: clientPlatform.origin,
-                clientPINProvider = { clientPlatform.clientPINValue.toByteArray() }
-            )
-            val credential = clientPlatform.webAuthnClient.create(effectiveOptions, context)
-            return RegistrationCredentialCreated(credential, this.challenge, scenario)
         }
     }
 
@@ -156,41 +166,45 @@ class StandardScenario internal constructor(
         private val challenge: Challenge,
         private val scenario: StandardScenario,
     ) {
-        /** Server verifies the registration response. */
-        fun verifyOnServer(
-            rpId: String? = null,
-            pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
-            userVerificationRequired: Boolean? = null,
-            userPresenceRequired: Boolean? = null,
-            attestationObject: ByteArray? = null,
-            clientDataJSON: ByteArray? = null,
-        ): RegistrationResult {
-            val rp = scenario.relyingParty
-            val registrationRequest = RegistrationRequest(
-                attestationObject ?: credential.response!!.attestationObject,
-                clientDataJSON ?: credential.response!!.clientDataJSON,
-                scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
-                credential.response!!.transports.map { it.value }.toSet()
-            )
-            val serverProperty = ServerProperty.builder()
-                .origin(rp.origin)
-                .rpId(rpId ?: rp.rpId)
-                .challenge(this.challenge)
-                .build()
-            val params = RegistrationParameters(
-                serverProperty, pubKeyCredParams,
-                userVerificationRequired ?: rp.userVerificationRequired,
-                userPresenceRequired ?: rp.userPresenceRequired
-            )
-            val data = rp.webAuthnManager.verify(registrationRequest, params)
-            val record = CredentialRecordImpl(
-                data.attestationObject!!, data.collectedClientData, data.clientExtensions, data.transports
-            )
+        val server = ServerActions()
 
-            // Store credential in RP for later authentication lookup
-            rp.storeCredential(credential.rawId, record)
+        inner class ServerActions {
+            /** Server verifies the registration response. */
+            fun verify(
+                rpId: String? = null,
+                pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
+                userVerificationRequired: Boolean? = null,
+                userPresenceRequired: Boolean? = null,
+                attestationObject: ByteArray? = null,
+                clientDataJSON: ByteArray? = null,
+            ): RegistrationResult {
+                val rp = scenario.relyingParty
+                val registrationRequest = RegistrationRequest(
+                    attestationObject ?: credential.response!!.attestationObject,
+                    clientDataJSON ?: credential.response!!.clientDataJSON,
+                    scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
+                    credential.response!!.transports.map { it.value }.toSet()
+                )
+                val serverProperty = ServerProperty.builder()
+                    .origin(rp.origin)
+                    .rpId(rpId ?: rp.rpId)
+                    .challenge(challenge)
+                    .build()
+                val params = RegistrationParameters(
+                    serverProperty, pubKeyCredParams,
+                    userVerificationRequired ?: rp.userVerificationRequired,
+                    userPresenceRequired ?: rp.userPresenceRequired
+                )
+                val data = rp.webAuthnManager.verify(registrationRequest, params)
+                val record = CredentialRecordImpl(
+                    data.attestationObject!!, data.collectedClientData, data.clientExtensions, data.transports
+                )
 
-            return RegistrationResult(credential, data, record)
+                // Store credential in RP for later authentication lookup
+                rp.storeCredential(credential.rawId, record)
+
+                return RegistrationResult(credential, data, record)
+            }
         }
     }
 
@@ -204,36 +218,40 @@ class StandardScenario internal constructor(
         private val challenge: Challenge,
         private val scenario: StandardScenario,
     ) {
-        /**
-         * Send to client platform: calls WebAuthnClient.get().
-         * @param challenge If set, replaces the challenge (simulates challenge fixation attack).
-         * @param origin If set, replaces the origin (simulates cross-origin attack).
-         */
-        suspend fun getAssertion(
-            clientPlatform: ClientPlatform = scenario.defaultClientPlatform,
-            challenge: Challenge? = null,
-            origin: Origin? = null,
-        ): AuthenticationAssertionCreated {
-            val effectiveOptions = if (challenge != null) {
-                PublicKeyCredentialRequestOptions(
-                    challenge,
-                    publicKeyCredentialRequestOptions.timeout,
-                    publicKeyCredentialRequestOptions.rpId,
-                    publicKeyCredentialRequestOptions.allowCredentials,
-                    publicKeyCredentialRequestOptions.userVerification,
-                    publicKeyCredentialRequestOptions.hints,
-                    publicKeyCredentialRequestOptions.extensions
+        val clientPlatform = ClientPlatformActions()
+
+        inner class ClientPlatformActions {
+            /**
+             * Send to client platform: calls WebAuthnClient.get().
+             * @param challenge If set, replaces the challenge (simulates challenge fixation attack).
+             * @param origin If set, replaces the origin (simulates cross-origin attack).
+             */
+            suspend fun getAssertion(
+                clientPlatform: ClientPlatform = scenario.defaultClientPlatform,
+                challenge: Challenge? = null,
+                origin: Origin? = null,
+            ): AuthenticationAssertionCreated {
+                val effectiveOptions = if (challenge != null) {
+                    PublicKeyCredentialRequestOptions(
+                        challenge,
+                        publicKeyCredentialRequestOptions.timeout,
+                        publicKeyCredentialRequestOptions.rpId,
+                        publicKeyCredentialRequestOptions.allowCredentials,
+                        publicKeyCredentialRequestOptions.userVerification,
+                        publicKeyCredentialRequestOptions.hints,
+                        publicKeyCredentialRequestOptions.extensions
+                    )
+                } else {
+                    publicKeyCredentialRequestOptions
+                }
+                val context = PublicKeyCredentialRequestContext(
+                    origin ?: clientPlatform.origin,
+                    publicKeyCredentialSelectionHandler = { it.first() },
+                    clientPINProvider = { clientPlatform.clientPINValue.toByteArray() }
                 )
-            } else {
-                publicKeyCredentialRequestOptions
+                val credential = clientPlatform.webAuthnClient.get(effectiveOptions, context)
+                return AuthenticationAssertionCreated(credential, this@AuthenticationOptionsCreated.challenge, scenario)
             }
-            val context = PublicKeyCredentialRequestContext(
-                origin ?: clientPlatform.origin,
-                publicKeyCredentialSelectionHandler = { it.first() },
-                clientPINProvider = { clientPlatform.clientPINValue.toByteArray() }
-            )
-            val credential = clientPlatform.webAuthnClient.get(effectiveOptions, context)
-            return AuthenticationAssertionCreated(credential, this.challenge, scenario)
         }
     }
 
@@ -243,39 +261,43 @@ class StandardScenario internal constructor(
         private val challenge: Challenge,
         private val scenario: StandardScenario,
     ) {
-        /** Server verifies the authentication response. */
-        fun verifyOnServer(
-            rpId: String? = null,
-            userVerificationRequired: Boolean? = null,
-            allowCredentials: List<ByteArray>? = null,
-            userPresenceRequired: Boolean? = null,
-            signature: ByteArray? = null,
-            authenticatorData: ByteArray? = null,
-            clientDataJSON: ByteArray? = null,
-        ): AuthenticationResult {
-            val rp = scenario.relyingParty
-            val credentialRecord = rp.lookupCredential(credential.rawId)
-                ?: error("No credential found for ID. Did you register first?")
+        val server = ServerActions()
 
-            val request = AuthenticationRequest(
-                credential.rawId, ByteArray(32),
-                authenticatorData ?: credential.response!!.authenticatorData,
-                clientDataJSON ?: credential.response!!.clientDataJSON,
-                scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
-                signature ?: credential.response!!.signature
-            )
-            val serverProperty = ServerProperty.builder()
-                .origin(rp.origin)
-                .rpId(rpId ?: rp.rpId)
-                .challenge(this.challenge)
-                .build()
-            val params = AuthenticationParameters(
-                serverProperty, credentialRecord, allowCredentials,
-                userVerificationRequired ?: rp.userVerificationRequired,
-                userPresenceRequired ?: rp.userPresenceRequired
-            )
-            val data = rp.webAuthnManager.verify(request, params)
-            return AuthenticationResult(credential, data)
+        inner class ServerActions {
+            /** Server verifies the authentication response. */
+            fun verify(
+                rpId: String? = null,
+                userVerificationRequired: Boolean? = null,
+                allowCredentials: List<ByteArray>? = null,
+                userPresenceRequired: Boolean? = null,
+                signature: ByteArray? = null,
+                authenticatorData: ByteArray? = null,
+                clientDataJSON: ByteArray? = null,
+            ): AuthenticationResult {
+                val rp = scenario.relyingParty
+                val credentialRecord = rp.lookupCredential(credential.rawId)
+                    ?: error("No credential found for ID. Did you register first?")
+
+                val request = AuthenticationRequest(
+                    credential.rawId, ByteArray(32),
+                    authenticatorData ?: credential.response!!.authenticatorData,
+                    clientDataJSON ?: credential.response!!.clientDataJSON,
+                    scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
+                    signature ?: credential.response!!.signature
+                )
+                val serverProperty = ServerProperty.builder()
+                    .origin(rp.origin)
+                    .rpId(rpId ?: rp.rpId)
+                    .challenge(challenge)
+                    .build()
+                val params = AuthenticationParameters(
+                    serverProperty, credentialRecord, allowCredentials,
+                    userVerificationRequired ?: rp.userVerificationRequired,
+                    userPresenceRequired ?: rp.userPresenceRequired
+                )
+                val data = rp.webAuthnManager.verify(request, params)
+                return AuthenticationResult(credential, data)
+            }
         }
     }
 

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
@@ -1,5 +1,6 @@
 package com.webauthn4j.test.integration.environment
 
+import com.webauthn4j.converter.AttestationObjectConverter
 import com.webauthn4j.converter.AuthenticatorDataConverter
 import com.webauthn4j.converter.CollectedClientDataConverter
 import com.webauthn4j.converter.util.ObjectConverter
@@ -8,6 +9,7 @@ import com.webauthn4j.credential.CredentialRecordImpl
 import com.webauthn4j.ctap.client.PublicKeyCredentialCreationContext
 import com.webauthn4j.ctap.client.PublicKeyCredentialRequestContext
 import com.webauthn4j.data.*
+import com.webauthn4j.data.attestation.AttestationObject
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import com.webauthn4j.data.client.CollectedClientData
@@ -180,10 +182,18 @@ class StandardScenario internal constructor(
                 pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
                 userVerificationRequired: Boolean? = null,
                 userPresenceRequired: Boolean? = null,
-                attestationObject: ByteArray? = null,
+                attestationObject: ((AttestationObject) -> AttestationObject)? = null,
                 clientData: ((CollectedClientData) -> CollectedClientData)? = null,
             ): RegistrationResult {
                 val rp = scenario.relyingParty
+                val originalAttestationObject = credential.response!!.attestationObject
+                val effectiveAttestationObject = if (attestationObject != null) {
+                    val converter = AttestationObjectConverter(scenario.objectConverter)
+                    val original = converter.convert(originalAttestationObject)!!
+                    converter.convertToBytes(attestationObject(original))
+                } else {
+                    originalAttestationObject
+                }
                 val originalClientDataJSON = credential.response!!.clientDataJSON
                 val effectiveClientDataJSON = if (clientData != null) {
                     val converter = CollectedClientDataConverter(scenario.objectConverter)
@@ -193,7 +203,7 @@ class StandardScenario internal constructor(
                     originalClientDataJSON
                 }
                 val registrationRequest = RegistrationRequest(
-                    attestationObject ?: credential.response!!.attestationObject,
+                    effectiveAttestationObject,
                     effectiveClientDataJSON,
                     scenario.objectConverter.jsonMapper.writeValueAsString(credential.clientExtensionResults),
                     credential.response!!.transports.map { it.value }.toSet()

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/WebAuthnTestEnvironment.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/WebAuthnTestEnvironment.kt
@@ -1,7 +1,16 @@
 package com.webauthn4j.test.integration.environment
 
+import com.webauthn4j.WebAuthnManager
 import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.ctap.authenticator.attestation.PackedBasicAttestationStatementProvider
 import com.webauthn4j.ctap.client.CtapClient
+import com.webauthn4j.data.AttestationConveyancePreference
+import com.webauthn4j.data.SignatureAlgorithm
+import com.webauthn4j.test.TestAttestationUtil
+import com.webauthn4j.verifier.attestation.statement.packed.PackedAttestationStatementVerifier
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.DefaultCertPathTrustworthinessVerifier
+import com.webauthn4j.verifier.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessVerifier
+import java.security.KeyPair
 import com.webauthn4j.ctap.client.CtapService
 import com.webauthn4j.ctap.client.WebAuthnClient
 import com.webauthn4j.ctap.client.transport.InProcessAdaptor
@@ -29,9 +38,39 @@ class WebAuthnTestEnvironment internal constructor(
             return dsl.build()
         }
 
-        fun createDefault(): WebAuthnTestEnvironment = create {
+        fun forTestsWithoutAttestationVerification(): WebAuthnTestEnvironment = create {
             clientPlatform { authenticator() }
             relyingParty()
+        }
+
+        fun forTestsWithAttestationVerification(): WebAuthnTestEnvironment {
+            val attestationKeyPair = KeyPair(
+                TestAttestationUtil.load3tierTestAuthenticatorAttestationPublicKey(),
+                TestAttestationUtil.load3tierTestAuthenticatorAttestationPrivateKey()
+            )
+            val intermediateCAPrivateKey = TestAttestationUtil.load3tierTestIntermediateCAPrivateKey()
+            val intermediateCACert = TestAttestationUtil.load3tierTestIntermediateCACertificate()
+            val trustAnchorRepository = TestAttestationUtil.createTrustAnchorRepositoryWith3tierTestRootCACertificate()
+
+            return create {
+                clientPlatform {
+                    authenticator {
+                        attestationStatementProvider = PackedBasicAttestationStatementProvider(
+                            "CN=Test Authenticator, OU=Authenticator Attestation, O=Test, C=US",
+                            attestationKeyPair, intermediateCAPrivateKey,
+                            SignatureAlgorithm.ES256, listOf(intermediateCACert), ObjectConverter()
+                        )
+                    }
+                }
+                relyingParty {
+                    attestation = AttestationConveyancePreference.DIRECT
+                    webAuthnManager = WebAuthnManager(
+                        listOf(PackedAttestationStatementVerifier()),
+                        DefaultCertPathTrustworthinessVerifier(trustAnchorRepository),
+                        DefaultSelfAttestationTrustworthinessVerifier()
+                    )
+                }
+            }
         }
     }
 }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AlgorithmSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AlgorithmSpec.kt
@@ -54,8 +54,9 @@ class AlgorithmSpec : BehaviorSpec({
             When("registering a credential") {
                 if (case.success) {
                     Then("registration should succeed with ${case.expectedKeyType!!.simpleName}") {
-                        val reg = env.scenario.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
-                            .createCredential().verifyOnServer()
+                        val reg = env.scenario.server.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
+                            .clientPlatform.createCredential()
+                            .server.verify()
                         val coseKey = reg.registrationData.attestationObject!!.authenticatorData
                             .attestedCredentialData.shouldNotBeNull().coseKey
                         coseKey!!::class shouldBe case.expectedKeyType
@@ -63,8 +64,9 @@ class AlgorithmSpec : BehaviorSpec({
                 } else {
                     Then("CTAP2_ERR_UNSUPPORTED_ALGORITHM should be thrown") {
                         val ex = shouldThrow<CtapErrorException> {
-                            env.scenario.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
-                                .createCredential().verifyOnServer()
+                            env.scenario.server.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
+                                .clientPlatform.createCredential()
+                                .server.verify()
                         }
                         ex.message.shouldContain("CTAP2_ERR_UNSUPPORTED_ALGORITHM")
                     }
@@ -112,16 +114,16 @@ class AlgorithmSpec : BehaviorSpec({
             When("registering and verifying on server") {
                 if (case.success) {
                     Then("the server should accept the credential") {
-                        env.scenario.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
-                            .createCredential()
-                            .verifyOnServer(pubKeyCredParams = serverPubKeyCredParams)
+                        env.scenario.server.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
+                            .clientPlatform.createCredential()
+                            .server.verify(pubKeyCredParams = serverPubKeyCredParams)
                     }
                 } else {
                     Then("NotAllowedAlgorithmException should be thrown") {
                         shouldThrow<NotAllowedAlgorithmException> {
-                            env.scenario.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
-                                .createCredential()
-                                .verifyOnServer(pubKeyCredParams = serverPubKeyCredParams)
+                            env.scenario.server.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
+                                .clientPlatform.createCredential()
+                                .server.verify(pubKeyCredParams = serverPubKeyCredParams)
                         }
                     }
                 }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AllowCredentialsSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AllowCredentialsSpec.kt
@@ -17,9 +17,9 @@ class AllowCredentialsSpec : BehaviorSpec({
 
         When("authenticating") {
             Then("the server should accept any credential") {
-                env.scenario.createAuthenticationOptions()
-                    .getAssertion()
-                    .verifyOnServer(allowCredentials = null)
+                env.scenario.server.createAuthenticationOptions()
+                    .clientPlatform.getAssertion()
+                    .server.verify(allowCredentials = null)
             }
         }
     }
@@ -33,9 +33,9 @@ class AllowCredentialsSpec : BehaviorSpec({
                 val clientAllow = listOf(
                     PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, reg1.credential.rawId, null)
                 )
-                env.scenario.createAuthenticationOptions(allowCredentials = clientAllow)
-                    .getAssertion()
-                    .verifyOnServer(
+                env.scenario.server.createAuthenticationOptions(allowCredentials = clientAllow)
+                    .clientPlatform.getAssertion()
+                    .server.verify(
                         allowCredentials = listOf(reg1.credential.rawId, ByteArray(32))
                     )
             }
@@ -49,9 +49,9 @@ class AllowCredentialsSpec : BehaviorSpec({
         When("authenticating with empty list") {
             Then("NotAllowedCredentialIdException should be thrown") {
                 shouldThrow<NotAllowedCredentialIdException> {
-                    env.scenario.createAuthenticationOptions()
-                        .getAssertion()
-                        .verifyOnServer(allowCredentials = emptyList())
+                    env.scenario.server.createAuthenticationOptions()
+                        .clientPlatform.getAssertion()
+                        .server.verify(allowCredentials = emptyList())
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AllowCredentialsSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AllowCredentialsSpec.kt
@@ -12,7 +12,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 class AllowCredentialsSpec : BehaviorSpec({
 
     Given("server verification with allowCredentials=null (accept any credential)") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         env.scenario.register()
 
         When("authenticating") {
@@ -25,7 +25,7 @@ class AllowCredentialsSpec : BehaviorSpec({
     }
 
     Given("server verification with allowCredentials containing multiple credential IDs") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         val reg1 = env.scenario.register()
 
         When("authenticating with both IDs in server allowCredentials") {
@@ -43,7 +43,7 @@ class AllowCredentialsSpec : BehaviorSpec({
     }
 
     Given("server verification with empty allowCredentials list") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         env.scenario.register()
 
         When("authenticating with empty list") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttachmentSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttachmentSpec.kt
@@ -22,9 +22,11 @@ class AttachmentSpec : BehaviorSpec({
 
         When("registering a credential") {
             Then("registration should succeed") {
-                env.scenario.createRegistrationOptions(
+                env.scenario.server.createRegistrationOptions(
                     authenticatorAttachment = AuthenticatorAttachment.PLATFORM
-                ).createCredential().verifyOnServer()
+                )
+                    .clientPlatform.createCredential()
+                    .server.verify()
             }
         }
     }
@@ -40,9 +42,11 @@ class AttachmentSpec : BehaviorSpec({
         When("attempting to register") {
             Then("WebAuthnClientException should be thrown") {
                 val ex = shouldThrow<WebAuthnClientException> {
-                    env.scenario.createRegistrationOptions(
+                    env.scenario.server.createRegistrationOptions(
                         authenticatorAttachment = AuthenticatorAttachment.PLATFORM
-                    ).createCredential().verifyOnServer()
+                    )
+                        .clientPlatform.createCredential()
+                        .server.verify()
                 }
                 ex.message.shouldContain("Matching authenticator doesn't exist")
             }
@@ -60,9 +64,11 @@ class AttachmentSpec : BehaviorSpec({
         When("attempting to register") {
             Then("WebAuthnClientException should be thrown") {
                 val ex = shouldThrow<WebAuthnClientException> {
-                    env.scenario.createRegistrationOptions(
+                    env.scenario.server.createRegistrationOptions(
                         authenticatorAttachment = AuthenticatorAttachment.CROSS_PLATFORM
-                    ).createCredential().verifyOnServer()
+                    )
+                        .clientPlatform.createCredential()
+                        .server.verify()
                 }
                 ex.message.shouldContain("Matching authenticator doesn't exist")
             }
@@ -79,9 +85,11 @@ class AttachmentSpec : BehaviorSpec({
 
         When("registering a credential") {
             Then("registration should succeed") {
-                env.scenario.createRegistrationOptions(
+                env.scenario.server.createRegistrationOptions(
                     authenticatorAttachment = AuthenticatorAttachment.CROSS_PLATFORM
-                ).createCredential().verifyOnServer()
+                )
+                    .clientPlatform.createCredential()
+                    .server.verify()
             }
         }
     }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationSignatureSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationSignatureSpec.kt
@@ -1,0 +1,34 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.attestation.AttestationObject
+import com.webauthn4j.data.attestation.statement.PackedAttestationStatement
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.BadSignatureException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Parameter")
+class AttestationSignatureSpec : BehaviorSpec({
+
+    Given("a test environment with attestation verification") {
+        val env = WebAuthnTestEnvironment.forTestsWithAttestationVerification()
+
+        When("registering with a tampered attestation signature") {
+            val credentialCreated = env.scenario.server.createRegistrationOptions()
+                .clientPlatform.createCredential()
+
+            Then("BadSignatureException should be thrown") {
+                shouldThrow<BadSignatureException> {
+                    credentialCreated.server.verify(
+                        attestationObject = {
+                            val stmt = it.attestationStatement as PackedAttestationStatement
+                            val tamperedSig = ByteArray(stmt.sig.size) { i -> stmt.sig[i].toInt().inv().toByte() }
+                            AttestationObject(it.authenticatorData, PackedAttestationStatement(stmt.alg, tamperedSig, stmt.x5c))
+                        }
+                    )
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AuthenticatorDataSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AuthenticatorDataSpec.kt
@@ -12,7 +12,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 class AuthenticatorDataSpec : BehaviorSpec({
 
     Given("a registered credential") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         env.scenario.register()
 
         When("authenticating with rpIdHash replaced to a different RP") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AuthenticatorDataSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AuthenticatorDataSpec.kt
@@ -1,0 +1,36 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.util.MessageDigestUtil
+import com.webauthn4j.verifier.exception.BadRpIdException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Parameter")
+class AuthenticatorDataSpec : BehaviorSpec({
+
+    Given("a registered credential") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        env.scenario.register()
+
+        When("authenticating with rpIdHash replaced to a different RP") {
+            val evilRpIdHash = MessageDigestUtil.createSHA256()
+                .digest("evil.example.com".toByteArray())
+
+            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+                .clientPlatform.getAssertion()
+
+            Then("BadRpIdException should be thrown") {
+                shouldThrow<BadRpIdException> {
+                    assertionCreated.server.verify(
+                        authenticatorData = {
+                            AuthenticatorData(evilRpIdHash, it.flags, it.signCount)
+                        }
+                    )
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/BackupStateSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/BackupStateSpec.kt
@@ -17,7 +17,7 @@ class BackupStateSpec : BehaviorSpec({
     // --- Single-device credential (BE=0) ---
 
     Given("a single-device credential (BE=0)") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         val reg = env.scenario.register()
 
         When("checking flags after registration") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
@@ -18,12 +18,12 @@ class ChallengeSpec : BehaviorSpec({
         val env = WebAuthnTestEnvironment.createDefault()
 
         When("the credential is created with an attacker's fixed challenge instead of the server's") {
-            val credentialCreated = env.scenario.createRegistrationOptions()
-                .createCredential(challenge = fixedChallenge)
+            val credentialCreated = env.scenario.server.createRegistrationOptions()
+                .clientPlatform.createCredential(challenge = fixedChallenge)
 
             Then("BadChallengeException should be thrown") {
                 shouldThrow<BadChallengeException> {
-                    credentialCreated.verifyOnServer()
+                    credentialCreated.server.verify()
                 }
             }
         }
@@ -34,12 +34,12 @@ class ChallengeSpec : BehaviorSpec({
         env.scenario.register()
 
         When("the assertion is created with an attacker's fixed challenge instead of the server's") {
-            val assertionCreated = env.scenario.createAuthenticationOptions()
-                .getAssertion(challenge = fixedChallenge)
+            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+                .clientPlatform.getAssertion(challenge = fixedChallenge)
 
             Then("BadChallengeException should be thrown") {
                 shouldThrow<BadChallengeException> {
-                    assertionCreated.verifyOnServer()
+                    assertionCreated.server.verify()
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
@@ -15,7 +15,7 @@ class ChallengeSpec : BehaviorSpec({
     val fixedChallenge = DefaultChallenge(ByteArray(32) { 0x41 })
 
     Given("a registration with a tampered challenge (challenge fixation attack)") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
         When("the credential is created with an attacker's fixed challenge instead of the server's") {
             val credentialCreated = env.scenario.server.createRegistrationOptions()
@@ -30,7 +30,7 @@ class ChallengeSpec : BehaviorSpec({
     }
 
     Given("an authentication with a tampered challenge (challenge fixation attack)") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         env.scenario.register()
 
         When("the assertion is created with an attacker's fixed challenge instead of the server's") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
@@ -19,7 +19,7 @@ class ChallengeSpec : BehaviorSpec({
 
         When("the credential is created with an attacker's fixed challenge instead of the server's") {
             val credentialCreated = env.scenario.createRegistrationOptions()
-                .createCredential(overrideChallenge = fixedChallenge)
+                .createCredential(challenge = fixedChallenge)
 
             Then("BadChallengeException should be thrown") {
                 shouldThrow<BadChallengeException> {
@@ -35,7 +35,7 @@ class ChallengeSpec : BehaviorSpec({
 
         When("the assertion is created with an attacker's fixed challenge instead of the server's") {
             val assertionCreated = env.scenario.createAuthenticationOptions()
-                .getAssertion(overrideChallenge = fixedChallenge)
+                .getAssertion(challenge = fixedChallenge)
 
             Then("BadChallengeException should be thrown") {
                 shouldThrow<BadChallengeException> {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ClientDataTypeSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ClientDataTypeSpec.kt
@@ -1,0 +1,51 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.data.client.ClientDataType
+import com.webauthn4j.data.client.CollectedClientData
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.InconsistentClientDataTypeException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Parameter")
+class ClientDataTypeSpec : BehaviorSpec({
+
+    Given("a registered credential") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        env.scenario.register()
+
+        When("authenticating with clientData type 'webauthn.create' instead of 'webauthn.get'") {
+            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+                .clientPlatform.getAssertion()
+
+            Then("InconsistentClientDataTypeException should be thrown") {
+                shouldThrow<InconsistentClientDataTypeException> {
+                    assertionCreated.server.verify(
+                        clientData = { it.withType(ClientDataType.WEBAUTHN_CREATE) }
+                    )
+                }
+            }
+        }
+    }
+
+    Given("a default test environment") {
+        val env = WebAuthnTestEnvironment.createDefault()
+
+        When("registering with clientData type 'webauthn.get' instead of 'webauthn.create'") {
+            val credentialCreated = env.scenario.server.createRegistrationOptions()
+                .clientPlatform.createCredential()
+
+            Then("InconsistentClientDataTypeException should be thrown") {
+                shouldThrow<InconsistentClientDataTypeException> {
+                    credentialCreated.server.verify(
+                        clientData = { it.withType(ClientDataType.WEBAUTHN_GET) }
+                    )
+                }
+            }
+        }
+    }
+})
+
+private fun CollectedClientData.withType(type: ClientDataType): CollectedClientData =
+    CollectedClientData(type, challenge, origin, crossOrigin, topOrigin, tokenBinding)

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ClientDataTypeSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ClientDataTypeSpec.kt
@@ -12,7 +12,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 class ClientDataTypeSpec : BehaviorSpec({
 
     Given("a registered credential") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         env.scenario.register()
 
         When("authenticating with clientData type 'webauthn.create' instead of 'webauthn.get'") {
@@ -30,7 +30,7 @@ class ClientDataTypeSpec : BehaviorSpec({
     }
 
     Given("a default test environment") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
         When("registering with clientData type 'webauthn.get' instead of 'webauthn.create'") {
             val credentialCreated = env.scenario.server.createRegistrationOptions()

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CounterSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CounterSpec.kt
@@ -15,7 +15,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 class CounterSpec : BehaviorSpec({
 
     Given("a registered credential with counter enabled") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         val registration = env.scenario.register()
 
         When("authenticating multiple times") {
@@ -42,7 +42,7 @@ class CounterSpec : BehaviorSpec({
     //  A true authenticator clone test would require deep-copying ResidentUserCredential objects
     //  from the AuthenticatorPropertyStore, which is not supported by the current API.
     Given("clone detection with counter rollback") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
         When("the server's stored counter is higher than the authenticator's counter") {
             val registration = env.scenario.register()

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CounterSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CounterSpec.kt
@@ -22,14 +22,14 @@ class CounterSpec : BehaviorSpec({
             val allowCredentials = listOf(
                 PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, registration.credential.rawId, null)
             )
-            val auth1 = env.scenario.createAuthenticationOptions(allowCredentials = allowCredentials)
-                .getAssertion()
-                .verifyOnServer()
+            val auth1 = env.scenario.server.createAuthenticationOptions(allowCredentials = allowCredentials)
+                .clientPlatform.getAssertion()
+                .server.verify()
             val counter1 = auth1.authenticationData.authenticatorData.shouldNotBeNull().signCount
 
-            val auth2 = env.scenario.createAuthenticationOptions(allowCredentials = allowCredentials)
-                .getAssertion()
-                .verifyOnServer()
+            val auth2 = env.scenario.server.createAuthenticationOptions(allowCredentials = allowCredentials)
+                .clientPlatform.getAssertion()
+                .server.verify()
             val counter2 = auth2.authenticationData.authenticatorData.shouldNotBeNull().signCount
 
             Then("the counter should increment with each authentication") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialIdSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialIdSpec.kt
@@ -36,9 +36,9 @@ class CredentialIdSpec : BehaviorSpec({
             )
 
             Then("the credential should be found in the server's store") {
-                env.scenario.createAuthenticationOptions(allowCredentials = allowCredentials)
-                    .getAssertion()
-                    .verifyOnServer()
+                env.scenario.server.createAuthenticationOptions(allowCredentials = allowCredentials)
+                    .clientPlatform.getAssertion()
+                    .server.verify()
             }
         }
     }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialIdSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialIdSpec.kt
@@ -16,7 +16,7 @@ import io.kotest.matchers.ints.shouldBeLessThanOrEqual
 class CredentialIdSpec : BehaviorSpec({
 
     Given("a registered credential") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         val reg = env.scenario.register()
 
         When("checking the credential ID length") {
@@ -27,7 +27,7 @@ class CredentialIdSpec : BehaviorSpec({
     }
 
     Given("a credential already registered on the server") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         val reg1 = env.scenario.register()
 
         When("attempting to authenticate with the registered credential") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialSelectorSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialSelectorSpec.kt
@@ -33,7 +33,7 @@ class CredentialSelectorSpec : BehaviorSpec({
 
             When("authenticating without allowCredentials (discoverable flow)") {
                 var candidateCount = 0
-                val options = env.scenario.createAuthenticationOptions(allowCredentials = null)
+                val options = env.scenario.server.createAuthenticationOptions(allowCredentials = null)
                 val context = PublicKeyCredentialRequestContext(
                     env.clientPlatform.origin,
                     publicKeyCredentialSelectionHandler = {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ExcludeCredentialsSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ExcludeCredentialsSpec.kt
@@ -14,7 +14,7 @@ import io.kotest.matchers.string.shouldContain
 class ExcludeCredentialsSpec : BehaviorSpec({
 
     Given("an existing registered credential") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         val firstRegistration = env.scenario.register()
         val existingCredentialId = firstRegistration.credential.rawId
 

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ExcludeCredentialsSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ExcludeCredentialsSpec.kt
@@ -25,9 +25,9 @@ class ExcludeCredentialsSpec : BehaviorSpec({
 
             Then("CTAP2_ERR_CREDENTIAL_EXCLUDED should be thrown") {
                 val ex = shouldThrow<CtapErrorException> {
-                    env.scenario.createRegistrationOptions(excludeCredentials = excludeList)
-                        .createCredential()
-                        .verifyOnServer()
+                    env.scenario.server.createRegistrationOptions(excludeCredentials = excludeList)
+                        .clientPlatform.createCredential()
+                        .server.verify()
                 }
                 ex.message.shouldContain("CTAP2_ERR_CREDENTIAL_EXCLUDED")
             }
@@ -40,9 +40,9 @@ class ExcludeCredentialsSpec : BehaviorSpec({
 
             Then("registration should succeed") {
                 shouldNotThrowAny {
-                    env.scenario.createRegistrationOptions(excludeCredentials = excludeList)
-                        .createCredential()
-                        .verifyOnServer()
+                    env.scenario.server.createRegistrationOptions(excludeCredentials = excludeList)
+                        .clientPlatform.createCredential()
+                        .server.verify()
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
@@ -10,10 +10,10 @@ import io.kotest.core.spec.style.BehaviorSpec
 @Tags("Parameter")
 class OriginSpec : BehaviorSpec({
 
-    Given("a registration from a malicious origin") {
+    Given("a default test environment") {
         val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
-        When("the credential is created from a different origin than the server expects") {
+        When("registering from a different origin than the server expects") {
             Then("BadOriginException should be thrown") {
                 shouldThrow<BadOriginException> {
                     env.scenario.server.createRegistrationOptions()
@@ -24,11 +24,11 @@ class OriginSpec : BehaviorSpec({
         }
     }
 
-    Given("an authentication from a malicious origin") {
+    Given("a registered credential") {
         val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         env.scenario.register()
 
-        When("the assertion is created from a different origin than the server expects") {
+        When("authenticating from a different origin than the server expects") {
             Then("BadOriginException should be thrown") {
                 shouldThrow<BadOriginException> {
                     env.scenario.server.createAuthenticationOptions()

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
@@ -11,7 +11,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 class OriginSpec : BehaviorSpec({
 
     Given("a registration from a malicious origin") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
         When("the credential is created from a different origin than the server expects") {
             Then("BadOriginException should be thrown") {
@@ -25,7 +25,7 @@ class OriginSpec : BehaviorSpec({
     }
 
     Given("an authentication from a malicious origin") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         env.scenario.register()
 
         When("the assertion is created from a different origin than the server expects") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
@@ -17,7 +17,7 @@ class OriginSpec : BehaviorSpec({
             Then("BadOriginException should be thrown") {
                 shouldThrow<BadOriginException> {
                     env.scenario.createRegistrationOptions()
-                        .createCredential(overrideOrigin = Origin("https://evil.example.com"))
+                        .createCredential(origin = Origin("https://evil.example.com"))
                         .verifyOnServer()
                 }
             }
@@ -32,7 +32,7 @@ class OriginSpec : BehaviorSpec({
             Then("BadOriginException should be thrown") {
                 shouldThrow<BadOriginException> {
                     env.scenario.createAuthenticationOptions()
-                        .getAssertion(overrideOrigin = Origin("https://evil.example.com"))
+                        .getAssertion(origin = Origin("https://evil.example.com"))
                         .verifyOnServer()
                 }
             }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
@@ -16,9 +16,9 @@ class OriginSpec : BehaviorSpec({
         When("the credential is created from a different origin than the server expects") {
             Then("BadOriginException should be thrown") {
                 shouldThrow<BadOriginException> {
-                    env.scenario.createRegistrationOptions()
-                        .createCredential(origin = Origin("https://evil.example.com"))
-                        .verifyOnServer()
+                    env.scenario.server.createRegistrationOptions()
+                        .clientPlatform.createCredential(origin = Origin("https://evil.example.com"))
+                        .server.verify()
                 }
             }
         }
@@ -31,9 +31,9 @@ class OriginSpec : BehaviorSpec({
         When("the assertion is created from a different origin than the server expects") {
             Then("BadOriginException should be thrown") {
                 shouldThrow<BadOriginException> {
-                    env.scenario.createAuthenticationOptions()
-                        .getAssertion(origin = Origin("https://evil.example.com"))
-                        .verifyOnServer()
+                    env.scenario.server.createAuthenticationOptions()
+                        .clientPlatform.getAssertion(origin = Origin("https://evil.example.com"))
+                        .server.verify()
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ResidentKeySpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ResidentKeySpec.kt
@@ -64,9 +64,9 @@ class ResidentKeySpec : BehaviorSpec({
                                 PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, reg.credential.rawId, null)
                             )
                             shouldNotThrowAny {
-                                env.scenario.createAuthenticationOptions(allowCredentials = allowCredentials)
-                                    .getAssertion()
-                                    .verifyOnServer()
+                                env.scenario.server.createAuthenticationOptions(allowCredentials = allowCredentials)
+                                    .clientPlatform.getAssertion()
+                                    .server.verify()
                             }
                         }
                     }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/RpIdSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/RpIdSpec.kt
@@ -15,9 +15,9 @@ class RpIdSpec : BehaviorSpec({
         When("the server verifies with a different rpId") {
             Then("BadRpIdException should be thrown") {
                 shouldThrow<BadRpIdException> {
-                    env.scenario.createRegistrationOptions()
-                        .createCredential()
-                        .verifyOnServer(rpId = "another.site.example.net")
+                    env.scenario.server.createRegistrationOptions()
+                        .clientPlatform.createCredential()
+                        .server.verify(rpId = "another.site.example.net")
                 }
             }
         }
@@ -30,9 +30,9 @@ class RpIdSpec : BehaviorSpec({
         When("the server verifies with a different rpId") {
             Then("BadRpIdException should be thrown") {
                 shouldThrow<BadRpIdException> {
-                    env.scenario.createAuthenticationOptions()
-                        .getAssertion()
-                        .verifyOnServer(rpId = "another.site.example.net")
+                    env.scenario.server.createAuthenticationOptions()
+                        .clientPlatform.getAssertion()
+                        .server.verify(rpId = "another.site.example.net")
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/RpIdSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/RpIdSpec.kt
@@ -10,7 +10,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 class RpIdSpec : BehaviorSpec({
 
     Given("a credential presented to a different RP during registration") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
         When("the server verifies with a different rpId") {
             Then("BadRpIdException should be thrown") {
@@ -24,7 +24,7 @@ class RpIdSpec : BehaviorSpec({
     }
 
     Given("a credential presented to a different RP during authentication") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         env.scenario.register()
 
         When("the server verifies with a different rpId") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/SignatureSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/SignatureSpec.kt
@@ -10,7 +10,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 class SignatureSpec : BehaviorSpec({
 
     Given("a registered credential") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         env.scenario.register()
 
         When("authenticating with a tampered signature (same length, incorrect value)") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/SignatureSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/SignatureSpec.kt
@@ -1,0 +1,42 @@
+package com.webauthn4j.test.integration.parameter
+
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.BadSignatureException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Parameter")
+class SignatureSpec : BehaviorSpec({
+
+    Given("a registered credential") {
+        val env = WebAuthnTestEnvironment.createDefault()
+        env.scenario.register()
+
+        When("authenticating with a tampered signature (same length, incorrect value)") {
+            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+                .clientPlatform.getAssertion()
+            val realSignature = assertionCreated.credential.response!!.signature
+            val tamperedSignature = ByteArray(realSignature.size) { i -> realSignature[i].toInt().inv().toByte() }
+
+            Then("BadSignatureException should be thrown") {
+                shouldThrow<BadSignatureException> {
+                    assertionCreated.server.verify(signature = tamperedSignature)
+                }
+            }
+        }
+
+        When("authenticating with a truncated signature (first half only)") {
+            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+                .clientPlatform.getAssertion()
+            val realSignature = assertionCreated.credential.response!!.signature
+            val truncatedSignature = realSignature.copyOfRange(0, realSignature.size / 2)
+
+            Then("BadSignatureException should be thrown") {
+                shouldThrow<BadSignatureException> {
+                    assertionCreated.server.verify(signature = truncatedSignature)
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/TransportSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/TransportSpec.kt
@@ -107,7 +107,7 @@ class TransportSpec : BehaviorSpec({
     }
 
     Given("an authenticator with default transports (USB)") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
         When("registering a credential") {
             Then("the registration response should contain USB transport") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserPresenceSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserPresenceSpec.kt
@@ -1,63 +1,154 @@
 package com.webauthn4j.test.integration.parameter
 
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
+import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting.*
 import com.webauthn4j.ctap.client.exception.UPNotSupportedException
+import com.webauthn4j.data.attestation.AttestationObject
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorOutput
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput
 import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.exception.UserNotPresentException
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
 @Tags("Parameter")
 class UserPresenceSpec : BehaviorSpec({
 
-    Given("an authenticator with userPresence=SUPPORTED") {
-        val env = WebAuthnTestEnvironment.create {
-            clientPlatform {
-                authenticator { userPresence = UserPresenceSetting.SUPPORTED }
-            }
-            relyingParty()
-        }
+    // --- Axis 1: RP configuration ---
 
-        When("registering a credential") {
-            Then("the UP flag should be set in authenticator data") {
-                val reg = env.scenario.register()
-                reg.registrationData.attestationObject!!.authenticatorData.isFlagUP shouldBe true
-            }
-
-            Then("authentication should succeed with UP flag set") {
-                val auth = env.scenario.authenticate()
-                auth.authenticationData.authenticatorData.shouldNotBeNull()
-                    .isFlagUP shouldBe true
-            }
-        }
+    data class RPConfig(
+        val conditionalMediation: Boolean,
+        val userPresenceRequired: Boolean,
+    ) {
+        override fun toString() = "conditionalMediation=$conditionalMediation, userPresenceRequired=$userPresenceRequired"
     }
 
-    Given("an authenticator with userPresence=NOT_SUPPORTED") {
-        val env = WebAuthnTestEnvironment.create {
-            clientPlatform {
-                authenticator { userPresence = UserPresenceSetting.NOT_SUPPORTED }
+    val REQUIRE_UP      = RPConfig(conditionalMediation = false, userPresenceRequired = true)
+    val DONT_REQUIRE_UP = RPConfig(conditionalMediation = false, userPresenceRequired = false)
+    val CONDITIONAL     = RPConfig(conditionalMediation = true,  userPresenceRequired = false)
+
+    // --- Axis 2: Authenticator UP capability ---
+
+    data class AuthenticatorState(
+        val setting: UserPresenceSetting,
+    ) {
+        override fun toString() = "$setting"
+    }
+
+    val UP_SUPPORTED     = AuthenticatorState(SUPPORTED)
+    val UP_NOT_SUPPORTED = AuthenticatorState(NOT_SUPPORTED)
+
+    // --- Matrix ---
+
+    data class MatrixEntry(
+        val rp: RPConfig,
+        val auth: AuthenticatorState,
+        val clientSuccess: Boolean,
+        val serverSuccess: Boolean = true,
+        val expectedUPFlag: Boolean? = null,
+    )
+
+    listOf(
+        //          RP                Authenticator        client  server  expected UP
+        MatrixEntry(REQUIRE_UP,       UP_SUPPORTED,       true,   true,   true),
+        MatrixEntry(REQUIRE_UP,       UP_NOT_SUPPORTED,   false),
+        MatrixEntry(DONT_REQUIRE_UP,  UP_SUPPORTED,       true,   true,   true),
+        MatrixEntry(DONT_REQUIRE_UP,  UP_NOT_SUPPORTED,   false),
+    ).forEach { (rp, auth, clientSuccess, serverSuccess, expectedUPFlag) ->
+
+        Given("registration: RP $rp × authenticator $auth") {
+            val env = WebAuthnTestEnvironment.create {
+                clientPlatform {
+                    authenticator { userPresence = auth.setting }
+                }
+                relyingParty { userPresenceRequired = rp.userPresenceRequired }
             }
-            relyingParty()
+
+            When("registering a credential") {
+                if (!clientSuccess) {
+                    Then("client-side error should be thrown") {
+                        shouldThrow<UPNotSupportedException> {
+                            env.scenario.server.createRegistrationOptions()
+                                .clientPlatform.createCredential()
+                        }
+                    }
+                } else if (!serverSuccess) {
+                    Then("UserNotPresentException should be thrown") {
+                        shouldThrow<UserNotPresentException> {
+                            env.scenario.server.createRegistrationOptions()
+                                .clientPlatform.createCredential()
+                                .server.verify()
+                        }
+                    }
+                } else {
+                    Then("registration should succeed with UP=$expectedUPFlag") {
+                        val reg = env.scenario.server.createRegistrationOptions()
+                            .clientPlatform.createCredential()
+                            .server.verify()
+                        if (expectedUPFlag != null) {
+                            reg.registrationData.attestationObject!!.authenticatorData.isFlagUP shouldBe expectedUPFlag
+                        }
+                    }
+                }
+            }
         }
 
-        When("attempting to register") {
-            Then("an exception should be thrown") {
-                shouldThrow<UPNotSupportedException> {
-                    env.scenario.register()
+        Given("authentication: RP $rp × authenticator $auth") {
+            val env = WebAuthnTestEnvironment.create {
+                clientPlatform {
+                    authenticator { userPresence = auth.setting }
+                }
+                relyingParty { userPresenceRequired = rp.userPresenceRequired }
+            }
+
+            When("authenticating") {
+                if (!clientSuccess) {
+                    Then("registration should fail before authentication") {
+                        shouldThrow<UPNotSupportedException> {
+                            env.scenario.register()
+                        }
+                    }
+                } else if (!serverSuccess) {
+                    Then("UserNotPresentException should be thrown") {
+                        env.scenario.register()
+                        shouldThrow<UserNotPresentException> {
+                            env.scenario.authenticate()
+                        }
+                    }
+                } else {
+                    Then("authentication should succeed with UP=$expectedUPFlag") {
+                        env.scenario.register()
+                        shouldNotThrowAny {
+                            env.scenario.authenticate()
+                        }
+                    }
                 }
             }
         }
     }
 
-    // TODO: Conditional mediation requires the client to skip UP and the authenticator to
-    //  return UP=false. The current webauthn4j-ctap client always requires UP support
-    //  (throws UPNotSupportedException otherwise), so a true conditional mediation flow
-    //  (authenticator UP=NOT_SUPPORTED + server userPresenceRequired=false) cannot be tested.
-    xGiven("conditional mediation: authenticator UP=false, server accepts without UP") {
-        When("registering and authenticating without user presence") {
-            Then("server should accept despite UP flag being false") {}
+    // --- Conditional mediation: client passes up=false to authenticator ---
+    // The current WebAuthnClient always requires UP support and does not support
+    // conditional mediation. These tests require bypassing the client or adding
+    // conditional mediation support to the test DSL.
+
+    listOf(
+        MatrixEntry(CONDITIONAL, UP_SUPPORTED, clientSuccess = true, serverSuccess = true, expectedUPFlag = false),
+    ).forEach { (rp, auth, _, _, _) ->
+        xGiven("registration: RP $rp × authenticator $auth") {
+            When("registering with conditional mediation") {
+                Then("registration should succeed with UP=false") {}
+            }
+        }
+
+        xGiven("authentication: RP $rp × authenticator $auth") {
+            When("authenticating with conditional mediation") {
+                Then("authentication should succeed with UP=false") {}
+            }
         }
     }
 })

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserVerificationSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserVerificationSpec.kt
@@ -120,9 +120,9 @@ class UserVerificationSpec : BehaviorSpec({
         When("authenticating without UV while server requires it") {
             Then("UserNotVerifiedException should be thrown") {
                 shouldThrow<UserNotVerifiedException> {
-                    env.scenario.createAuthenticationOptions(userVerificationRequirement = DISCOURAGED)
-                        .getAssertion()
-                        .verifyOnServer(userVerificationRequired = true)
+                    env.scenario.server.createAuthenticationOptions(userVerificationRequirement = DISCOURAGED)
+                        .clientPlatform.getAssertion()
+                        .server.verify(userVerificationRequired = true)
                 }
             }
         }
@@ -138,9 +138,9 @@ class UserVerificationSpec : BehaviorSpec({
         When("authenticating without UV") {
             Then("the server should accept the authentication") {
                 shouldNotThrowAny {
-                    env.scenario.createAuthenticationOptions(userVerificationRequirement = DISCOURAGED)
-                        .getAssertion()
-                        .verifyOnServer(userVerificationRequired = false)
+                    env.scenario.server.createAuthenticationOptions(userVerificationRequirement = DISCOURAGED)
+                        .clientPlatform.getAssertion()
+                        .server.verify(userVerificationRequired = false)
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserVerificationSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserVerificationSpec.kt
@@ -19,22 +19,19 @@ import io.kotest.matchers.shouldBe
 @Tags("Parameter")
 class UserVerificationSpec : BehaviorSpec({
 
-    // ============================================================
-    // Registration: RP requirement × Authenticator state matrix
-    // ============================================================
-
-    // --- Axis 1: RP requirement + server verification condition ---
+    // --- Axis 1: RP client-facing requirement + server-side verification ---
 
     data class RPConfig(
         val requirement: UserVerificationRequirement,
-        val uvRequired: Boolean,
+        val userVerificationRequired: Boolean,
     ) {
-        override fun toString() = requirement.toString()
+        override fun toString() = "$requirement, userVerificationRequired=$userVerificationRequired"
     }
 
-    val REQUIRE_UV    = RPConfig(REQUIRED,    uvRequired = true)
-    val PREFER_UV     = RPConfig(PREFERRED,   uvRequired = false)
-    val DISCOURAGE_UV = RPConfig(DISCOURAGED, uvRequired = false)
+    val REQUIRE_UV             = RPConfig(REQUIRED,    userVerificationRequired = true)
+    val PREFER_UV              = RPConfig(PREFERRED,   userVerificationRequired = false)
+    val DISCOURAGE_UV          = RPConfig(DISCOURAGED, userVerificationRequired = false)
+    val DISCOURAGE_BUT_REQUIRE = RPConfig(DISCOURAGED, userVerificationRequired = true)
 
     // --- Axis 2: Authenticator UV capability + ClientPIN state ---
 
@@ -52,95 +49,152 @@ class UserVerificationSpec : BehaviorSpec({
     val NOT_READY_NO_PIN  = AuthenticatorState(NOT_READY,     DISABLED)
     val NO_UV_NO_PIN      = AuthenticatorState(NOT_SUPPORTED, DISABLED)
 
-    // --- Matrix: RP × Authenticator → expected result ---
+    // ============================================================
+    // Registration
+    // ============================================================
 
-    data class MatrixEntry(
+    data class RegistrationEntry(
         val rp: RPConfig,
         val auth: AuthenticatorState,
-        val success: Boolean,
+        val clientSuccess: Boolean,
+        val serverSuccess: Boolean = true,
         val uvFlag: Boolean? = null,
     )
 
     listOf(
-        //          RP               Authenticator          success  UV flag
-        MatrixEntry(REQUIRE_UV,      READY_WITH_PIN,        true,    true),
-        MatrixEntry(REQUIRE_UV,      READY_NO_PIN,          true,    true),
-        MatrixEntry(REQUIRE_UV,      NOT_READY_SET_PIN,     true,    true),
-        MatrixEntry(REQUIRE_UV,      NOT_READY_NO_PIN,      false),
-        MatrixEntry(REQUIRE_UV,      NO_UV_NO_PIN,          false),
-        MatrixEntry(PREFER_UV,       READY_WITH_PIN,        true,    true),
-        MatrixEntry(PREFER_UV,       READY_NO_PIN,          true,    true),
-        MatrixEntry(PREFER_UV,       NOT_READY_SET_PIN,     true,    true),
-        MatrixEntry(PREFER_UV,       NOT_READY_NO_PIN,      true,    false),
-        MatrixEntry(PREFER_UV,       NO_UV_NO_PIN,          true,    false),
-        MatrixEntry(DISCOURAGE_UV,   READY_WITH_PIN,        true,    false),
-        MatrixEntry(DISCOURAGE_UV,   READY_NO_PIN,          true,    false),
-        MatrixEntry(DISCOURAGE_UV,   NOT_READY_SET_PIN,     true,    false),
-        MatrixEntry(DISCOURAGE_UV,   NOT_READY_NO_PIN,      true,    false),
-        MatrixEntry(DISCOURAGE_UV,   NO_UV_NO_PIN,          true,    false),
-    ).forEach { (rp, auth, success, uvFlag) ->
+        //                    RP                         Authenticator         client  server  UV flag
+        RegistrationEntry(REQUIRE_UV,                READY_WITH_PIN,       true,   true,   true),
+        RegistrationEntry(REQUIRE_UV,                READY_NO_PIN,         true,   true,   true),
+        RegistrationEntry(REQUIRE_UV,                NOT_READY_SET_PIN,    true,   true,   true),
+        RegistrationEntry(REQUIRE_UV,                NOT_READY_NO_PIN,     false),
+        RegistrationEntry(REQUIRE_UV,                NO_UV_NO_PIN,         false),
+        RegistrationEntry(PREFER_UV,                 READY_WITH_PIN,       true,   true,   true),
+        RegistrationEntry(PREFER_UV,                 READY_NO_PIN,         true,   true,   true),
+        RegistrationEntry(PREFER_UV,                 NOT_READY_SET_PIN,    true,   true,   true),
+        RegistrationEntry(PREFER_UV,                 NOT_READY_NO_PIN,     true,   true,   false),
+        RegistrationEntry(PREFER_UV,                 NO_UV_NO_PIN,         true,   true,   false),
+        RegistrationEntry(DISCOURAGE_UV,             READY_WITH_PIN,       true,   true,   false),
+        RegistrationEntry(DISCOURAGE_UV,             READY_NO_PIN,         true,   true,   false),
+        RegistrationEntry(DISCOURAGE_UV,             NOT_READY_SET_PIN,    true,   true,   false),
+        RegistrationEntry(DISCOURAGE_UV,             NOT_READY_NO_PIN,     true,   true,   false),
+        RegistrationEntry(DISCOURAGE_UV,             NO_UV_NO_PIN,         true,   true,   false),
+        RegistrationEntry(DISCOURAGE_BUT_REQUIRE,    READY_WITH_PIN,       true,   false,  false),
+        RegistrationEntry(DISCOURAGE_BUT_REQUIRE,    READY_NO_PIN,         true,   false,  false),
+        RegistrationEntry(DISCOURAGE_BUT_REQUIRE,    NOT_READY_SET_PIN,    true,   false,  false),
+        RegistrationEntry(DISCOURAGE_BUT_REQUIRE,    NOT_READY_NO_PIN,     true,   false,  false),
+        RegistrationEntry(DISCOURAGE_BUT_REQUIRE,    NO_UV_NO_PIN,         true,   false,  false),
+    ).forEach { (rp, auth, clientSuccess, serverSuccess, uvFlag) ->
 
-        Given("RP $rp × authenticator $auth") {
+        Given("registration: RP $rp × authenticator $auth") {
             val env = WebAuthnTestEnvironment.create {
                 clientPlatform {
                     authenticator { userVerification = auth.uv; clientPIN = auth.pin }
                 }
-                relyingParty { userVerificationRequirement = rp.requirement; userVerificationRequired = rp.uvRequired }
+                relyingParty { userVerificationRequirement = rp.requirement; userVerificationRequired = rp.userVerificationRequired }
             }
             if (auth.setPIN) env.clientPlatform.ctapService.setPIN("clientPIN")
 
             When("registering a credential") {
-                if (success) {
+                if (!clientSuccess) {
+                    Then("client-side error should be thrown") {
+                        shouldThrow<WebAuthnClientException> {
+                            env.scenario.server.createRegistrationOptions()
+                                .clientPlatform.createCredential()
+                        }
+                    }
+                } else if (!serverSuccess) {
+                    Then("UserNotVerifiedException should be thrown") {
+                        shouldThrow<UserNotVerifiedException> {
+                            env.scenario.server.createRegistrationOptions()
+                                .clientPlatform.createCredential()
+                                .server.verify()
+                        }
+                    }
+                } else {
                     Then("registration should succeed") {
-                        val reg = env.scenario.register()
+                        val reg = env.scenario.server.createRegistrationOptions()
+                            .clientPlatform.createCredential()
+                            .server.verify()
                         if (uvFlag != null) {
                             reg.registrationData.attestationObject!!.authenticatorData.isFlagUV shouldBe uvFlag
                         }
                     }
-                } else {
-                    Then("an error should be thrown") {
-                        shouldThrow<WebAuthnClientException> { env.scenario.register() }
+                }
+            }
+        }
+    }
+
+    // ============================================================
+    // Authentication
+    // ============================================================
+
+    data class AuthenticationEntry(
+        val rp: RPConfig,
+        val auth: AuthenticatorState,
+        val clientSuccess: Boolean,
+        val serverSuccess: Boolean = true,
+    )
+
+    listOf(
+        //                       RP                         Authenticator         client  server
+        AuthenticationEntry(REQUIRE_UV,                READY_WITH_PIN,       true,   true),
+        AuthenticationEntry(REQUIRE_UV,                READY_NO_PIN,         true,   true),
+        AuthenticationEntry(REQUIRE_UV,                NOT_READY_SET_PIN,    true,   true),
+        AuthenticationEntry(REQUIRE_UV,                NOT_READY_NO_PIN,     false),
+        AuthenticationEntry(REQUIRE_UV,                NO_UV_NO_PIN,         false),
+        AuthenticationEntry(PREFER_UV,                 READY_WITH_PIN,       true,   true),
+        AuthenticationEntry(PREFER_UV,                 READY_NO_PIN,         true,   true),
+        AuthenticationEntry(PREFER_UV,                 NOT_READY_SET_PIN,    true,   true),
+        AuthenticationEntry(PREFER_UV,                 NOT_READY_NO_PIN,     true,   true),
+        AuthenticationEntry(PREFER_UV,                 NO_UV_NO_PIN,         true,   true),
+        AuthenticationEntry(DISCOURAGE_UV,             READY_WITH_PIN,       true,   true),
+        AuthenticationEntry(DISCOURAGE_UV,             READY_NO_PIN,         true,   true),
+        AuthenticationEntry(DISCOURAGE_UV,             NOT_READY_SET_PIN,    true,   true),
+        AuthenticationEntry(DISCOURAGE_UV,             NOT_READY_NO_PIN,     true,   true),
+        AuthenticationEntry(DISCOURAGE_UV,             NO_UV_NO_PIN,         true,   true),
+        AuthenticationEntry(DISCOURAGE_BUT_REQUIRE,    READY_WITH_PIN,       true,   false),
+        AuthenticationEntry(DISCOURAGE_BUT_REQUIRE,    READY_NO_PIN,         true,   false),
+        AuthenticationEntry(DISCOURAGE_BUT_REQUIRE,    NOT_READY_SET_PIN,    true,   false),
+        AuthenticationEntry(DISCOURAGE_BUT_REQUIRE,    NOT_READY_NO_PIN,     true,   false),
+        AuthenticationEntry(DISCOURAGE_BUT_REQUIRE,    NO_UV_NO_PIN,         true,   false),
+    ).forEach { (rp, auth, clientSuccess, serverSuccess) ->
+
+        Given("authentication: RP $rp × authenticator $auth") {
+            val env = WebAuthnTestEnvironment.create {
+                clientPlatform {
+                    authenticator { userVerification = auth.uv; clientPIN = auth.pin }
+                }
+                relyingParty { userVerificationRequirement = rp.requirement; userVerificationRequired = false }
+            }
+            if (auth.setPIN) env.clientPlatform.ctapService.setPIN("clientPIN")
+
+            When("authenticating") {
+                if (!clientSuccess) {
+                    Then("registration should fail before authentication") {
+                        shouldThrow<WebAuthnClientException> {
+                            env.scenario.register()
+                        }
                     }
-                }
-            }
-        }
-    }
+                } else {
+                    env.scenario.register()
 
-    // ============================================================
-    // Authentication: server UV requirement vs client UV behavior
-    // ============================================================
-
-    Given("server requires UV but client authenticates with DISCOURAGED") {
-        val env = WebAuthnTestEnvironment.create {
-            clientPlatform { authenticator() }
-            relyingParty { userVerificationRequirement = REQUIRED; userVerificationRequired = true }
-        }
-        env.scenario.register()
-
-        When("authenticating without UV while server requires it") {
-            Then("UserNotVerifiedException should be thrown") {
-                shouldThrow<UserNotVerifiedException> {
-                    env.scenario.server.createAuthenticationOptions(userVerificationRequirement = DISCOURAGED)
-                        .clientPlatform.getAssertion()
-                        .server.verify(userVerificationRequired = true)
-                }
-            }
-        }
-    }
-
-    Given("server does not require UV and client authenticates with DISCOURAGED") {
-        val env = WebAuthnTestEnvironment.create {
-            clientPlatform { authenticator() }
-            relyingParty { userVerificationRequirement = DISCOURAGED; userVerificationRequired = false }
-        }
-        env.scenario.register()
-
-        When("authenticating without UV") {
-            Then("the server should accept the authentication") {
-                shouldNotThrowAny {
-                    env.scenario.server.createAuthenticationOptions(userVerificationRequirement = DISCOURAGED)
-                        .clientPlatform.getAssertion()
-                        .server.verify(userVerificationRequired = false)
+                    if (!serverSuccess) {
+                        Then("UserNotVerifiedException should be thrown") {
+                            shouldThrow<UserNotVerifiedException> {
+                                env.scenario.server.createAuthenticationOptions(userVerificationRequirement = rp.requirement)
+                                    .clientPlatform.getAssertion()
+                                    .server.verify(userVerificationRequired = rp.userVerificationRequired)
+                            }
+                        }
+                    } else {
+                        Then("authentication should succeed") {
+                            shouldNotThrowAny {
+                                env.scenario.server.createAuthenticationOptions(userVerificationRequirement = rp.requirement)
+                                    .clientPlatform.getAssertion()
+                                    .server.verify(userVerificationRequired = rp.userVerificationRequired)
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/ClientPINManagementSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/ClientPINManagementSpec.kt
@@ -13,7 +13,7 @@ import io.kotest.matchers.string.shouldContain
 class ClientPINManagementSpec : BehaviorSpec({
 
     Given("an authenticator with clientPIN already set") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         // Explicitly set the initial PIN
         env.clientPlatform.ctapService.setPIN("clientPIN")
 
@@ -28,7 +28,7 @@ class ClientPINManagementSpec : BehaviorSpec({
     }
 
     Given("an authenticator with clientPIN set for PIN change") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         // Explicitly set the initial PIN
         env.clientPlatform.ctapService.setPIN("clientPIN")
 
@@ -40,7 +40,7 @@ class ClientPINManagementSpec : BehaviorSpec({
     }
 
     Given("a registered credential and then PIN is changed") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         // Explicitly set the initial PIN before registration
         env.clientPlatform.ctapService.setPIN("clientPIN")
         env.scenario.register()
@@ -55,7 +55,7 @@ class ClientPINManagementSpec : BehaviorSpec({
     }
 
     Given("an authenticator for retry count verification") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
         When("checking the initial retry count") {
             val retries = env.clientPlatform.ctapService.getRetries()

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/CredentialDeletionSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/CredentialDeletionSpec.kt
@@ -9,7 +9,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 class CredentialDeletionSpec : BehaviorSpec({
 
     Given("a registered credential that is then deleted from the server") {
-        val env = WebAuthnTestEnvironment.createDefault()
+        val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
         val registration = env.scenario.register()
         env.relyingParty.deleteCredential(registration.credential.rawId)
 

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/SecondFactorFlowSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/SecondFactorFlowSpec.kt
@@ -33,12 +33,12 @@ class SecondFactorFlowSpec : BehaviorSpec({
             )
             Then("the authentication should succeed") {
                 shouldNotThrowAny {
-                    env.scenario.createAuthenticationOptions(
+                    env.scenario.server.createAuthenticationOptions(
                         allowCredentials = allowCredentials,
                         userVerificationRequirement = UserVerificationRequirement.DISCOURAGED
                     )
-                        .getAssertion()
-                        .verifyOnServer(userVerificationRequired = false)
+                        .clientPlatform.getAssertion()
+                        .server.verify(userVerificationRequired = false)
                 }
             }
         }


### PR DESCRIPTION
## DSL improvements

- Expose all optional parameters on StandardScenario step methods and remove the `override` prefix for naming consistency
- Introduce actor-scoped step chain (`.server` / `.clientPlatform`) to make it clear which entity performs each protocol step
- Replace raw byte array parameters with structured transformer lambdas for `clientData`, `authenticatorData`, and `attestationObject`
- Add `forTestsWithAttestationVerification()` factory with full attestation verification pipeline and rename `createDefault()` to `forTestsWithoutAttestationVerification()`

## Security verification tests

- Assertion signature tampering (tampered and truncated) → `BadSignatureException`
- Attestation signature tampering → `BadSignatureException`
- clientData type mismatch (webauthn.create ↔ webauthn.get) → `InconsistentClientDataTypeException`
- rpIdHash tampering in authenticatorData → `BadRpIdException`
- Server-side UP/UV verification matrix covering `userPresenceRequired` and `userVerificationRequired` parameters