### PR TITLE
Improve fido-integration-bdd naming and add test coverage

### DIFF
--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/environment/StandardScenario.kt
@@ -29,39 +29,39 @@ import com.webauthn4j.server.ServerProperty
  * protocol flow between a [RelyingParty] and a [ClientPlatform].
  *
  * Each flow is decomposed into step objects representing protocol states,
- * with actor-scoped accessors ([server] / [clientPlatform][RegistrationOptionsCreated.clientPlatform])
+ * with actor-scoped accessors ([relyingParty] / [clientPlatform][RegistrationOptionsCreated.clientPlatform])
  * that make it clear which entity performs each step:
  *
  * ```
- * scenario.server.createRegistrationOptions()
+ * scenario.relyingParty.createRegistrationOptions()
  *     .clientPlatform.createCredential()
- *     .server.verify()
+ *     .relyingParty.verify()
  * ```
  */
 class StandardScenario internal constructor(
-    val relyingParty: RelyingParty,
+    private val relyingPartyObject: RelyingParty,
     val defaultClientPlatform: ClientPlatform,
     private val objectConverter: ObjectConverter,
 ) {
-    val server = ServerActions()
+    val relyingParty = RelyingPartyActions()
 
     /** Convenience: full registration flow with all defaults. */
     suspend fun register(): RegistrationResult =
-        server.createRegistrationOptions()
+        relyingParty.createRegistrationOptions()
             .clientPlatform.createCredential()
-            .server.verify()
+            .relyingParty.verify()
 
     /** Convenience: full authentication flow with all defaults. */
     suspend fun authenticate(): AuthenticationResult =
-        server.createAuthenticationOptions()
+        relyingParty.createAuthenticationOptions()
             .clientPlatform.getAssertion()
-            .server.verify()
+            .relyingParty.verify()
 
     // ============================================================
-    // Server Actions (top-level)
+    // Relying Party Actions (top-level)
     // ============================================================
 
-    inner class ServerActions {
+    inner class RelyingPartyActions {
         fun createRegistrationOptions(
             pubKeyCredParams: List<PublicKeyCredentialParameters>? = null,
             excludeCredentials: List<PublicKeyCredentialDescriptor>? = null,
@@ -74,7 +74,7 @@ class StandardScenario internal constructor(
             hints: List<PublicKeyCredentialHints>? = null,
             attestationFormats: List<String>? = null,
         ): RegistrationOptionsCreated {
-            val rp = relyingParty
+            val rp = relyingPartyObject
             val challenge = DefaultChallenge()
             val effectiveResidentKeyRequirement = residentKeyRequirement ?: rp.residentKeyRequirement
             val options = PublicKeyCredentialCreationOptions(
@@ -107,7 +107,7 @@ class StandardScenario internal constructor(
             timeout: Long? = null,
             hints: List<PublicKeyCredentialHints>? = null,
         ): AuthenticationOptionsCreated {
-            val rp = relyingParty
+            val rp = relyingPartyObject
             val challenge = DefaultChallenge()
             val options = PublicKeyCredentialRequestOptions(
                 challenge, timeout, rp.rpId, allowCredentials,
@@ -173,9 +173,9 @@ class StandardScenario internal constructor(
         private val challenge: Challenge,
         private val scenario: StandardScenario,
     ) {
-        val server = ServerActions()
+        val relyingParty = RelyingPartyActions()
 
-        inner class ServerActions {
+        inner class RelyingPartyActions {
             /** Server verifies the registration response. */
             fun verify(
                 rpId: String? = null,
@@ -185,7 +185,7 @@ class StandardScenario internal constructor(
                 attestationObject: ((AttestationObject) -> AttestationObject)? = null,
                 clientData: ((CollectedClientData) -> CollectedClientData)? = null,
             ): RegistrationResult {
-                val rp = scenario.relyingParty
+                val rp = scenario.relyingPartyObject
                 val originalAttestationObject = credential.response!!.attestationObject
                 val effectiveAttestationObject = if (attestationObject != null) {
                     val converter = AttestationObjectConverter(scenario.objectConverter)
@@ -284,9 +284,9 @@ class StandardScenario internal constructor(
         private val challenge: Challenge,
         private val scenario: StandardScenario,
     ) {
-        val server = ServerActions()
+        val relyingParty = RelyingPartyActions()
 
-        inner class ServerActions {
+        inner class RelyingPartyActions {
             /** Server verifies the authentication response. */
             fun verify(
                 rpId: String? = null,
@@ -297,7 +297,7 @@ class StandardScenario internal constructor(
                 authenticatorData: ((AuthenticatorData<AuthenticationExtensionAuthenticatorOutput>) -> AuthenticatorData<AuthenticationExtensionAuthenticatorOutput>)? = null,
                 clientData: ((CollectedClientData) -> CollectedClientData)? = null,
             ): AuthenticationResult {
-                val rp = scenario.relyingParty
+                val rp = scenario.relyingPartyObject
                 val credentialRecord = rp.lookupCredential(credential.rawId)
                     ?: error("No credential found for ID. Did you register first?")
 

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AlgorithmSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AlgorithmSpec.kt
@@ -130,4 +130,32 @@ class AlgorithmSpec : BehaviorSpec({
             }
         }
     }
+
+    // --- EdDSA (Ed25519 / Ed448) ---
+    // Blocked on ctap-authenticator adding EdDSA key pair generation support
+    // (KeyPairUtil.createCredentialKeyPair does not handle EdDSA algorithms)
+
+    xGiven("RP requests [Ed25519] × authenticator supports [Ed25519]") {
+        When("registering a credential") {
+            Then("registration should succeed with EdDSACOSEKey") {}
+        }
+    }
+
+    xGiven("RP requests [Ed448] × authenticator supports [Ed448]") {
+        When("registering a credential") {
+            Then("registration should succeed with EdDSACOSEKey") {}
+        }
+    }
+
+    xGiven("server verification: authenticator=Ed25519, pubKeyCredParams=[Ed25519]") {
+        When("registering and verifying on server") {
+            Then("the server should accept the credential") {}
+        }
+    }
+
+    xGiven("server verification: authenticator=Ed448, pubKeyCredParams=[Ed448]") {
+        When("registering and verifying on server") {
+            Then("the server should accept the credential") {}
+        }
+    }
 })

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AlgorithmSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AlgorithmSpec.kt
@@ -54,9 +54,9 @@ class AlgorithmSpec : BehaviorSpec({
             When("registering a credential") {
                 if (case.success) {
                     Then("registration should succeed with ${case.expectedKeyType!!.simpleName}") {
-                        val reg = env.scenario.server.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
+                        val reg = env.scenario.relyingParty.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
                             .clientPlatform.createCredential()
-                            .server.verify()
+                            .relyingParty.verify()
                         val coseKey = reg.registrationData.attestationObject!!.authenticatorData
                             .attestedCredentialData.shouldNotBeNull().coseKey
                         coseKey!!::class shouldBe case.expectedKeyType
@@ -64,9 +64,9 @@ class AlgorithmSpec : BehaviorSpec({
                 } else {
                     Then("CTAP2_ERR_UNSUPPORTED_ALGORITHM should be thrown") {
                         val ex = shouldThrow<CtapErrorException> {
-                            env.scenario.server.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
+                            env.scenario.relyingParty.createRegistrationOptions(pubKeyCredParams = pubKeyCredParams)
                                 .clientPlatform.createCredential()
-                                .server.verify()
+                                .relyingParty.verify()
                         }
                         ex.message.shouldContain("CTAP2_ERR_UNSUPPORTED_ALGORITHM")
                     }
@@ -114,16 +114,16 @@ class AlgorithmSpec : BehaviorSpec({
             When("registering and verifying on server") {
                 if (case.success) {
                     Then("the server should accept the credential") {
-                        env.scenario.server.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
+                        env.scenario.relyingParty.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
                             .clientPlatform.createCredential()
-                            .server.verify(pubKeyCredParams = serverPubKeyCredParams)
+                            .relyingParty.verify(pubKeyCredParams = serverPubKeyCredParams)
                     }
                 } else {
                     Then("NotAllowedAlgorithmException should be thrown") {
                         shouldThrow<NotAllowedAlgorithmException> {
-                            env.scenario.server.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
+                            env.scenario.relyingParty.createRegistrationOptions(pubKeyCredParams = rpPubKeyCredParams)
                                 .clientPlatform.createCredential()
-                                .server.verify(pubKeyCredParams = serverPubKeyCredParams)
+                                .relyingParty.verify(pubKeyCredParams = serverPubKeyCredParams)
                         }
                     }
                 }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AllowCredentialsSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AllowCredentialsSpec.kt
@@ -17,9 +17,9 @@ class AllowCredentialsSpec : BehaviorSpec({
 
         When("authenticating") {
             Then("the server should accept any credential") {
-                env.scenario.server.createAuthenticationOptions()
+                env.scenario.relyingParty.createAuthenticationOptions()
                     .clientPlatform.getAssertion()
-                    .server.verify(allowCredentials = null)
+                    .relyingParty.verify(allowCredentials = null)
             }
         }
     }
@@ -33,9 +33,9 @@ class AllowCredentialsSpec : BehaviorSpec({
                 val clientAllow = listOf(
                     PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, reg1.credential.rawId, null)
                 )
-                env.scenario.server.createAuthenticationOptions(allowCredentials = clientAllow)
+                env.scenario.relyingParty.createAuthenticationOptions(allowCredentials = clientAllow)
                     .clientPlatform.getAssertion()
-                    .server.verify(
+                    .relyingParty.verify(
                         allowCredentials = listOf(reg1.credential.rawId, ByteArray(32))
                     )
             }
@@ -49,9 +49,9 @@ class AllowCredentialsSpec : BehaviorSpec({
         When("authenticating with empty list") {
             Then("NotAllowedCredentialIdException should be thrown") {
                 shouldThrow<NotAllowedCredentialIdException> {
-                    env.scenario.server.createAuthenticationOptions()
+                    env.scenario.relyingParty.createAuthenticationOptions()
                         .clientPlatform.getAssertion()
-                        .server.verify(allowCredentials = emptyList())
+                        .relyingParty.verify(allowCredentials = emptyList())
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttachmentSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttachmentSpec.kt
@@ -22,11 +22,11 @@ class AttachmentSpec : BehaviorSpec({
 
         When("registering a credential") {
             Then("registration should succeed") {
-                env.scenario.server.createRegistrationOptions(
+                env.scenario.relyingParty.createRegistrationOptions(
                     authenticatorAttachment = AuthenticatorAttachment.PLATFORM
                 )
                     .clientPlatform.createCredential()
-                    .server.verify()
+                    .relyingParty.verify()
             }
         }
     }
@@ -42,11 +42,11 @@ class AttachmentSpec : BehaviorSpec({
         When("attempting to register") {
             Then("WebAuthnClientException should be thrown") {
                 val ex = shouldThrow<WebAuthnClientException> {
-                    env.scenario.server.createRegistrationOptions(
+                    env.scenario.relyingParty.createRegistrationOptions(
                         authenticatorAttachment = AuthenticatorAttachment.PLATFORM
                     )
                         .clientPlatform.createCredential()
-                        .server.verify()
+                        .relyingParty.verify()
                 }
                 ex.message.shouldContain("Matching authenticator doesn't exist")
             }
@@ -64,11 +64,11 @@ class AttachmentSpec : BehaviorSpec({
         When("attempting to register") {
             Then("WebAuthnClientException should be thrown") {
                 val ex = shouldThrow<WebAuthnClientException> {
-                    env.scenario.server.createRegistrationOptions(
+                    env.scenario.relyingParty.createRegistrationOptions(
                         authenticatorAttachment = AuthenticatorAttachment.CROSS_PLATFORM
                     )
                         .clientPlatform.createCredential()
-                        .server.verify()
+                        .relyingParty.verify()
                 }
                 ex.message.shouldContain("Matching authenticator doesn't exist")
             }
@@ -85,11 +85,11 @@ class AttachmentSpec : BehaviorSpec({
 
         When("registering a credential") {
             Then("registration should succeed") {
-                env.scenario.server.createRegistrationOptions(
+                env.scenario.relyingParty.createRegistrationOptions(
                     authenticatorAttachment = AuthenticatorAttachment.CROSS_PLATFORM
                 )
                     .clientPlatform.createCredential()
-                    .server.verify()
+                    .relyingParty.verify()
             }
         }
     }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationSignatureSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationSignatureSpec.kt
@@ -1,8 +1,18 @@
 package com.webauthn4j.test.integration.parameter
 
+import com.webauthn4j.WebAuthnManager
+import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FBasicAttestationStatementProvider
+import com.webauthn4j.data.AttestationConveyancePreference
 import com.webauthn4j.data.attestation.AttestationObject
+import com.webauthn4j.data.attestation.authenticator.AAGUID
+import com.webauthn4j.data.attestation.statement.FIDOU2FAttestationStatement
 import com.webauthn4j.data.attestation.statement.PackedAttestationStatement
+import com.webauthn4j.test.TestAttestationUtil
 import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import com.webauthn4j.verifier.attestation.statement.packed.PackedAttestationStatementVerifier
+import com.webauthn4j.verifier.attestation.statement.u2f.FIDOU2FAttestationStatementVerifier
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.DefaultCertPathTrustworthinessVerifier
+import com.webauthn4j.verifier.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessVerifier
 import com.webauthn4j.verifier.exception.BadSignatureException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.Tags
@@ -11,7 +21,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 @Tags("Parameter")
 class AttestationSignatureSpec : BehaviorSpec({
 
-    Given("a test environment with attestation verification") {
+    Given("a Packed attestation environment with signature verification") {
         val env = WebAuthnTestEnvironment.forTestsWithAttestationVerification()
 
         When("registering with a tampered attestation signature") {
@@ -25,6 +35,46 @@ class AttestationSignatureSpec : BehaviorSpec({
                             val stmt = it.attestationStatement as PackedAttestationStatement
                             val tamperedSig = ByteArray(stmt.sig.size) { i -> stmt.sig[i].toInt().inv().toByte() }
                             AttestationObject(it.authenticatorData, PackedAttestationStatement(stmt.alg, tamperedSig, stmt.x5c))
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    Given("a FIDO U2F attestation environment with signature verification") {
+        val privateKey = TestAttestationUtil.load2tierTestAuthenticatorAttestationPrivateKey()
+        val certificate = TestAttestationUtil.load2tierTestAuthenticatorAttestationCertificate()
+        val trustAnchorRepository = TestAttestationUtil.createTrustAnchorRepositoryWith2tierTestRootCACertificate()
+
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform {
+                authenticator {
+                    attestationStatementProvider = FIDOU2FBasicAttestationStatementProvider(privateKey, certificate)
+                    aaguid = AAGUID.ZERO
+                }
+            }
+            relyingParty {
+                attestation = AttestationConveyancePreference.DIRECT
+                webAuthnManager = WebAuthnManager(
+                    listOf(FIDOU2FAttestationStatementVerifier()),
+                    DefaultCertPathTrustworthinessVerifier(trustAnchorRepository),
+                    DefaultSelfAttestationTrustworthinessVerifier()
+                )
+            }
+        }
+
+        When("registering with a tampered attestation signature") {
+            val credentialCreated = env.scenario.relyingParty.createRegistrationOptions()
+                .clientPlatform.createCredential()
+
+            Then("BadSignatureException should be thrown") {
+                shouldThrow<BadSignatureException> {
+                    credentialCreated.relyingParty.verify(
+                        attestationObject = {
+                            val stmt = it.attestationStatement as FIDOU2FAttestationStatement
+                            val tamperedSig = ByteArray(stmt.sig.size) { i -> stmt.sig[i].toInt().inv().toByte() }
+                            AttestationObject(it.authenticatorData, FIDOU2FAttestationStatement(stmt.x5c, tamperedSig))
                         }
                     )
                 }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationSignatureSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationSignatureSpec.kt
@@ -15,12 +15,12 @@ class AttestationSignatureSpec : BehaviorSpec({
         val env = WebAuthnTestEnvironment.forTestsWithAttestationVerification()
 
         When("registering with a tampered attestation signature") {
-            val credentialCreated = env.scenario.server.createRegistrationOptions()
+            val credentialCreated = env.scenario.relyingParty.createRegistrationOptions()
                 .clientPlatform.createCredential()
 
             Then("BadSignatureException should be thrown") {
                 shouldThrow<BadSignatureException> {
-                    credentialCreated.server.verify(
+                    credentialCreated.relyingParty.verify(
                         attestationObject = {
                             val stmt = it.attestationStatement as PackedAttestationStatement
                             val tamperedSig = ByteArray(stmt.sig.size) { i -> stmt.sig[i].toInt().inv().toByte() }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationTrustSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AttestationTrustSpec.kt
@@ -232,4 +232,21 @@ class AttestationTrustSpec : BehaviorSpec({
             }
         }
     }
+
+    // --- Self Attestation ---
+    // Requires PackedSelfAttestationStatementProvider to produce x5c=null (credential key signs).
+    // Blocked on webauthn4j-ctap fix: https://github.com/webauthn4j/webauthn4j-ctap/pull/XXX
+
+    xGiven("server configured to accept self attestation with Packed authenticator") {
+        When("registering a credential with self attestation") {
+            Then("the server should accept the attestation") {}
+            Then("authentication should succeed") {}
+        }
+    }
+
+    xGiven("server configured to prohibit self attestation with Packed authenticator") {
+        When("registering a credential with self attestation") {
+            Then("SelfAttestationProhibitedException should be thrown") {}
+        }
+    }
 })

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AuthenticatorDataSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/AuthenticatorDataSpec.kt
@@ -19,12 +19,12 @@ class AuthenticatorDataSpec : BehaviorSpec({
             val evilRpIdHash = MessageDigestUtil.createSHA256()
                 .digest("evil.example.com".toByteArray())
 
-            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+            val assertionCreated = env.scenario.relyingParty.createAuthenticationOptions()
                 .clientPlatform.getAssertion()
 
             Then("BadRpIdException should be thrown") {
                 shouldThrow<BadRpIdException> {
-                    assertionCreated.server.verify(
+                    assertionCreated.relyingParty.verify(
                         authenticatorData = {
                             AuthenticatorData(evilRpIdHash, it.flags, it.signCount)
                         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ChallengeSpec.kt
@@ -18,12 +18,12 @@ class ChallengeSpec : BehaviorSpec({
         val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
         When("the credential is created with an attacker's fixed challenge instead of the server's") {
-            val credentialCreated = env.scenario.server.createRegistrationOptions()
+            val credentialCreated = env.scenario.relyingParty.createRegistrationOptions()
                 .clientPlatform.createCredential(challenge = fixedChallenge)
 
             Then("BadChallengeException should be thrown") {
                 shouldThrow<BadChallengeException> {
-                    credentialCreated.server.verify()
+                    credentialCreated.relyingParty.verify()
                 }
             }
         }
@@ -34,12 +34,12 @@ class ChallengeSpec : BehaviorSpec({
         env.scenario.register()
 
         When("the assertion is created with an attacker's fixed challenge instead of the server's") {
-            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+            val assertionCreated = env.scenario.relyingParty.createAuthenticationOptions()
                 .clientPlatform.getAssertion(challenge = fixedChallenge)
 
             Then("BadChallengeException should be thrown") {
                 shouldThrow<BadChallengeException> {
-                    assertionCreated.server.verify()
+                    assertionCreated.relyingParty.verify()
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ClientDataTypeSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ClientDataTypeSpec.kt
@@ -16,12 +16,12 @@ class ClientDataTypeSpec : BehaviorSpec({
         env.scenario.register()
 
         When("authenticating with clientData type 'webauthn.create' instead of 'webauthn.get'") {
-            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+            val assertionCreated = env.scenario.relyingParty.createAuthenticationOptions()
                 .clientPlatform.getAssertion()
 
             Then("InconsistentClientDataTypeException should be thrown") {
                 shouldThrow<InconsistentClientDataTypeException> {
-                    assertionCreated.server.verify(
+                    assertionCreated.relyingParty.verify(
                         clientData = { it.withType(ClientDataType.WEBAUTHN_CREATE) }
                     )
                 }
@@ -33,12 +33,12 @@ class ClientDataTypeSpec : BehaviorSpec({
         val env = WebAuthnTestEnvironment.forTestsWithoutAttestationVerification()
 
         When("registering with clientData type 'webauthn.get' instead of 'webauthn.create'") {
-            val credentialCreated = env.scenario.server.createRegistrationOptions()
+            val credentialCreated = env.scenario.relyingParty.createRegistrationOptions()
                 .clientPlatform.createCredential()
 
             Then("InconsistentClientDataTypeException should be thrown") {
                 shouldThrow<InconsistentClientDataTypeException> {
-                    credentialCreated.server.verify(
+                    credentialCreated.relyingParty.verify(
                         clientData = { it.withType(ClientDataType.WEBAUTHN_GET) }
                     )
                 }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CounterSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CounterSpec.kt
@@ -22,14 +22,14 @@ class CounterSpec : BehaviorSpec({
             val allowCredentials = listOf(
                 PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, registration.credential.rawId, null)
             )
-            val auth1 = env.scenario.server.createAuthenticationOptions(allowCredentials = allowCredentials)
+            val auth1 = env.scenario.relyingParty.createAuthenticationOptions(allowCredentials = allowCredentials)
                 .clientPlatform.getAssertion()
-                .server.verify()
+                .relyingParty.verify()
             val counter1 = auth1.authenticationData.authenticatorData.shouldNotBeNull().signCount
 
-            val auth2 = env.scenario.server.createAuthenticationOptions(allowCredentials = allowCredentials)
+            val auth2 = env.scenario.relyingParty.createAuthenticationOptions(allowCredentials = allowCredentials)
                 .clientPlatform.getAssertion()
-                .server.verify()
+                .relyingParty.verify()
             val counter2 = auth2.authenticationData.authenticatorData.shouldNotBeNull().signCount
 
             Then("the counter should increment with each authentication") {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialIdSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialIdSpec.kt
@@ -36,9 +36,9 @@ class CredentialIdSpec : BehaviorSpec({
             )
 
             Then("the credential should be found in the server's store") {
-                env.scenario.server.createAuthenticationOptions(allowCredentials = allowCredentials)
+                env.scenario.relyingParty.createAuthenticationOptions(allowCredentials = allowCredentials)
                     .clientPlatform.getAssertion()
-                    .server.verify()
+                    .relyingParty.verify()
             }
         }
     }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialSelectorSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/CredentialSelectorSpec.kt
@@ -33,7 +33,7 @@ class CredentialSelectorSpec : BehaviorSpec({
 
             When("authenticating without allowCredentials (discoverable flow)") {
                 var candidateCount = 0
-                val options = env.scenario.server.createAuthenticationOptions(allowCredentials = null)
+                val options = env.scenario.relyingParty.createAuthenticationOptions(allowCredentials = null)
                 val context = PublicKeyCredentialRequestContext(
                     env.clientPlatform.origin,
                     publicKeyCredentialSelectionHandler = {

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ExcludeCredentialsSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ExcludeCredentialsSpec.kt
@@ -25,9 +25,9 @@ class ExcludeCredentialsSpec : BehaviorSpec({
 
             Then("CTAP2_ERR_CREDENTIAL_EXCLUDED should be thrown") {
                 val ex = shouldThrow<CtapErrorException> {
-                    env.scenario.server.createRegistrationOptions(excludeCredentials = excludeList)
+                    env.scenario.relyingParty.createRegistrationOptions(excludeCredentials = excludeList)
                         .clientPlatform.createCredential()
-                        .server.verify()
+                        .relyingParty.verify()
                 }
                 ex.message.shouldContain("CTAP2_ERR_CREDENTIAL_EXCLUDED")
             }
@@ -40,9 +40,9 @@ class ExcludeCredentialsSpec : BehaviorSpec({
 
             Then("registration should succeed") {
                 shouldNotThrowAny {
-                    env.scenario.server.createRegistrationOptions(excludeCredentials = excludeList)
+                    env.scenario.relyingParty.createRegistrationOptions(excludeCredentials = excludeList)
                         .clientPlatform.createCredential()
-                        .server.verify()
+                        .relyingParty.verify()
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/OriginSpec.kt
@@ -16,9 +16,9 @@ class OriginSpec : BehaviorSpec({
         When("registering from a different origin than the server expects") {
             Then("BadOriginException should be thrown") {
                 shouldThrow<BadOriginException> {
-                    env.scenario.server.createRegistrationOptions()
+                    env.scenario.relyingParty.createRegistrationOptions()
                         .clientPlatform.createCredential(origin = Origin("https://evil.example.com"))
-                        .server.verify()
+                        .relyingParty.verify()
                 }
             }
         }
@@ -31,9 +31,9 @@ class OriginSpec : BehaviorSpec({
         When("authenticating from a different origin than the server expects") {
             Then("BadOriginException should be thrown") {
                 shouldThrow<BadOriginException> {
-                    env.scenario.server.createAuthenticationOptions()
+                    env.scenario.relyingParty.createAuthenticationOptions()
                         .clientPlatform.getAssertion(origin = Origin("https://evil.example.com"))
-                        .server.verify()
+                        .relyingParty.verify()
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ResidentKeySpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/ResidentKeySpec.kt
@@ -64,9 +64,9 @@ class ResidentKeySpec : BehaviorSpec({
                                 PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, reg.credential.rawId, null)
                             )
                             shouldNotThrowAny {
-                                env.scenario.server.createAuthenticationOptions(allowCredentials = allowCredentials)
+                                env.scenario.relyingParty.createAuthenticationOptions(allowCredentials = allowCredentials)
                                     .clientPlatform.getAssertion()
-                                    .server.verify()
+                                    .relyingParty.verify()
                             }
                         }
                     }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/RpIdSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/RpIdSpec.kt
@@ -15,9 +15,9 @@ class RpIdSpec : BehaviorSpec({
         When("the server verifies with a different rpId") {
             Then("BadRpIdException should be thrown") {
                 shouldThrow<BadRpIdException> {
-                    env.scenario.server.createRegistrationOptions()
+                    env.scenario.relyingParty.createRegistrationOptions()
                         .clientPlatform.createCredential()
-                        .server.verify(rpId = "another.site.example.net")
+                        .relyingParty.verify(rpId = "another.site.example.net")
                 }
             }
         }
@@ -30,9 +30,9 @@ class RpIdSpec : BehaviorSpec({
         When("the server verifies with a different rpId") {
             Then("BadRpIdException should be thrown") {
                 shouldThrow<BadRpIdException> {
-                    env.scenario.server.createAuthenticationOptions()
+                    env.scenario.relyingParty.createAuthenticationOptions()
                         .clientPlatform.getAssertion()
-                        .server.verify(rpId = "another.site.example.net")
+                        .relyingParty.verify(rpId = "another.site.example.net")
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/SignatureSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/SignatureSpec.kt
@@ -14,27 +14,27 @@ class SignatureSpec : BehaviorSpec({
         env.scenario.register()
 
         When("authenticating with a tampered signature (same length, incorrect value)") {
-            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+            val assertionCreated = env.scenario.relyingParty.createAuthenticationOptions()
                 .clientPlatform.getAssertion()
             val realSignature = assertionCreated.credential.response!!.signature
             val tamperedSignature = ByteArray(realSignature.size) { i -> realSignature[i].toInt().inv().toByte() }
 
             Then("BadSignatureException should be thrown") {
                 shouldThrow<BadSignatureException> {
-                    assertionCreated.server.verify(signature = tamperedSignature)
+                    assertionCreated.relyingParty.verify(signature = tamperedSignature)
                 }
             }
         }
 
         When("authenticating with a truncated signature (first half only)") {
-            val assertionCreated = env.scenario.server.createAuthenticationOptions()
+            val assertionCreated = env.scenario.relyingParty.createAuthenticationOptions()
                 .clientPlatform.getAssertion()
             val realSignature = assertionCreated.credential.response!!.signature
             val truncatedSignature = realSignature.copyOfRange(0, realSignature.size / 2)
 
             Then("BadSignatureException should be thrown") {
                 shouldThrow<BadSignatureException> {
-                    assertionCreated.server.verify(signature = truncatedSignature)
+                    assertionCreated.relyingParty.verify(signature = truncatedSignature)
                 }
             }
         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserPresenceSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserPresenceSpec.kt
@@ -72,23 +72,23 @@ class UserPresenceSpec : BehaviorSpec({
                 if (!clientSuccess) {
                     Then("client-side error should be thrown") {
                         shouldThrow<UPNotSupportedException> {
-                            env.scenario.server.createRegistrationOptions()
+                            env.scenario.relyingParty.createRegistrationOptions()
                                 .clientPlatform.createCredential()
                         }
                     }
                 } else if (!serverSuccess) {
                     Then("UserNotPresentException should be thrown") {
                         shouldThrow<UserNotPresentException> {
-                            env.scenario.server.createRegistrationOptions()
+                            env.scenario.relyingParty.createRegistrationOptions()
                                 .clientPlatform.createCredential()
-                                .server.verify()
+                                .relyingParty.verify()
                         }
                     }
                 } else {
                     Then("registration should succeed with UP=$expectedUPFlag") {
-                        val reg = env.scenario.server.createRegistrationOptions()
+                        val reg = env.scenario.relyingParty.createRegistrationOptions()
                             .clientPlatform.createCredential()
-                            .server.verify()
+                            .relyingParty.verify()
                         if (expectedUPFlag != null) {
                             reg.registrationData.attestationObject!!.authenticatorData.isFlagUP shouldBe expectedUPFlag
                         }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserVerificationSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/parameter/UserVerificationSpec.kt
@@ -98,23 +98,23 @@ class UserVerificationSpec : BehaviorSpec({
                 if (!clientSuccess) {
                     Then("client-side error should be thrown") {
                         shouldThrow<WebAuthnClientException> {
-                            env.scenario.server.createRegistrationOptions()
+                            env.scenario.relyingParty.createRegistrationOptions()
                                 .clientPlatform.createCredential()
                         }
                     }
                 } else if (!serverSuccess) {
                     Then("UserNotVerifiedException should be thrown") {
                         shouldThrow<UserNotVerifiedException> {
-                            env.scenario.server.createRegistrationOptions()
+                            env.scenario.relyingParty.createRegistrationOptions()
                                 .clientPlatform.createCredential()
-                                .server.verify()
+                                .relyingParty.verify()
                         }
                     }
                 } else {
                     Then("registration should succeed") {
-                        val reg = env.scenario.server.createRegistrationOptions()
+                        val reg = env.scenario.relyingParty.createRegistrationOptions()
                             .clientPlatform.createCredential()
-                            .server.verify()
+                            .relyingParty.verify()
                         if (uvFlag != null) {
                             reg.registrationData.attestationObject!!.authenticatorData.isFlagUV shouldBe uvFlag
                         }
@@ -181,17 +181,17 @@ class UserVerificationSpec : BehaviorSpec({
                     if (!serverSuccess) {
                         Then("UserNotVerifiedException should be thrown") {
                             shouldThrow<UserNotVerifiedException> {
-                                env.scenario.server.createAuthenticationOptions(userVerificationRequirement = rp.requirement)
+                                env.scenario.relyingParty.createAuthenticationOptions(userVerificationRequirement = rp.requirement)
                                     .clientPlatform.getAssertion()
-                                    .server.verify(userVerificationRequired = rp.userVerificationRequired)
+                                    .relyingParty.verify(userVerificationRequired = rp.userVerificationRequired)
                             }
                         }
                     } else {
                         Then("authentication should succeed") {
                             shouldNotThrowAny {
-                                env.scenario.server.createAuthenticationOptions(userVerificationRequirement = rp.requirement)
+                                env.scenario.relyingParty.createAuthenticationOptions(userVerificationRequirement = rp.requirement)
                                     .clientPlatform.getAssertion()
-                                    .server.verify(userVerificationRequired = rp.userVerificationRequired)
+                                    .relyingParty.verify(userVerificationRequired = rp.userVerificationRequired)
                             }
                         }
                     }

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/CrossPlatformAuthenticationSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/CrossPlatformAuthenticationSpec.kt
@@ -1,0 +1,32 @@
+package com.webauthn4j.test.integration.scenario
+
+import com.webauthn4j.ctap.authenticator.store.InMemoryAuthenticatorPropertyStore
+import com.webauthn4j.test.integration.environment.WebAuthnTestEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.BehaviorSpec
+
+@Tags("Scenario")
+class CrossPlatformAuthenticationSpec : BehaviorSpec({
+
+    Given("two client platforms sharing the same authenticator") {
+        val sharedStore = InMemoryAuthenticatorPropertyStore()
+        val env = WebAuthnTestEnvironment.create {
+            clientPlatform { authenticator { propertyStore = sharedStore } }
+            clientPlatform { authenticator { propertyStore = sharedStore } }
+            relyingParty()
+        }
+
+        When("a credential is registered via the first client platform and authenticated via the second") {
+            env.scenario.register()
+
+            Then("the authentication should succeed") {
+                shouldNotThrowAny {
+                    env.scenario.relyingParty.createAuthenticationOptions()
+                        .clientPlatform.getAssertion(clientPlatform = env.clientPlatforms[1])
+                        .relyingParty.verify()
+                }
+            }
+        }
+    }
+})

--- a/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/SecondFactorFlowSpec.kt
+++ b/integration-tests/fido-integration-bdd/src/test/kotlin/com/webauthn4j/test/integration/scenario/SecondFactorFlowSpec.kt
@@ -33,12 +33,12 @@ class SecondFactorFlowSpec : BehaviorSpec({
             )
             Then("the authentication should succeed") {
                 shouldNotThrowAny {
-                    env.scenario.server.createAuthenticationOptions(
+                    env.scenario.relyingParty.createAuthenticationOptions(
                         allowCredentials = allowCredentials,
                         userVerificationRequirement = UserVerificationRequirement.DISCOURAGED
                     )
                         .clientPlatform.getAssertion()
-                        .server.verify(userVerificationRequired = false)
+                        .relyingParty.verify(userVerificationRequired = false)
                 }
             }
         }


### PR DESCRIPTION
- Rename `server` to `relyingParty` in StandardScenario DSL for consistency with WebAuthn terminology
- Add self attestation test placeholders in AttestationTrustSpec (blocked on webauthn4j-ctap#336)
- Add EdDSA (Ed25519/Ed448) test placeholders in AlgorithmSpec (blocked on ctap-authenticator EdDSA key generation support)
- Add FIDO U2F attestation signature tampering test alongside the existing Packed case in AttestationSignatureSpec
- Add CrossPlatformAuthenticationSpec verifying that a credential registered via one client platform can be authenticated via another sharing the same authenticator