### PR TITLE
Change Dependabot check interval from daily to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,13 @@ updates:
   - package-ecosystem: gradle
     directory: "/"
     schedule:
-      interval: daily
+      interval: monthly
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: monthly
     labels:
       - "dev-dependencies"
     groups:


### PR DESCRIPTION
Reduce Dependabot version update checks from daily to monthly for both Gradle and GitHub Actions ecosystems. Security updates are triggered independently of this schedule, so only non-security version bumps are affected.