### PR TITLE
Improve gh-pages deployment and add BDD test report

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,11 +32,12 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew javadoc generateReferenceJA generateReferenceEN
+          ./gradlew javadoc generateReferenceJA generateReferenceEN :integration-tests:fido-integration-bdd:check
       - name: Commit & Push pages
         run: |
           rm -rf docs
           mv build/docs/asciidoc/html5 docs
+          cp -r integration-tests/fido-integration-bdd/build/reports/bdd docs/bdd-report
           git checkout --orphan gh-pages
           git rm -rf --cached .
           git add docs

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           rm -rf docs
           mv build/docs/asciidoc/html5 docs
+          git checkout --orphan gh-pages
+          git rm -rf --cached .
           git add docs
           git commit -m "Update docs"
-          git checkout -b gh-pages
           git push origin gh-pages -f


### PR DESCRIPTION
Deploy gh-pages as an orphan branch containing only the `docs/` directory, instead of force-pushing the entire repository tree. This prevents push failures caused by workflow file changes requiring the `workflows` permission.

Also add the fido-integration-bdd HTML report to GitHub Pages at `docs/bdd-report/`.