### PR TITLE
Add CBOR canonical serializers for PublicKeyCredentialRpEntity and PublicKeyCredentialUserEntity

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/WebAuthnCBORModule.java
@@ -85,6 +85,8 @@ public class WebAuthnCBORModule extends SimpleModule {
         this.addSerializer(new PackedAttestationStatementSerializer());
         this.addSerializer(new PublicKeyCredentialDescriptorSerializer());
         this.addSerializer(new PublicKeyCredentialParametersSerializer());
+        this.addSerializer(new PublicKeyCredentialRpEntitySerializer());
+        this.addSerializer(new PublicKeyCredentialUserEntitySerializer());
         this.addSerializer(new RSACOSEKeySerializer());
         this.addSerializer(new TPMAttestationStatementSerializer());
         this.addSerializer(new TPMSAttestSerializer());

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialRpEntitySerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialRpEntitySerializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.serializer.cbor;
+
+import com.webauthn4j.data.PublicKeyCredentialRpEntity;
+
+import java.util.Arrays;
+
+public class PublicKeyCredentialRpEntitySerializer extends AbstractCtapCanonicalCborSerializer<PublicKeyCredentialRpEntity> {
+
+    public PublicKeyCredentialRpEntitySerializer() {
+        super(PublicKeyCredentialRpEntity.class, Arrays.asList(
+                new FieldSerializationRule<>("id", PublicKeyCredentialRpEntity::getId),
+                new FieldSerializationRule<>("name", PublicKeyCredentialRpEntity::getName)
+        ));
+    }
+}

--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialUserEntitySerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialUserEntitySerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.serializer.cbor;
+
+import com.webauthn4j.data.PublicKeyCredentialUserEntity;
+
+import java.util.Arrays;
+
+public class PublicKeyCredentialUserEntitySerializer extends AbstractCtapCanonicalCborSerializer<PublicKeyCredentialUserEntity> {
+
+    public PublicKeyCredentialUserEntitySerializer() {
+        super(PublicKeyCredentialUserEntity.class, Arrays.asList(
+                new FieldSerializationRule<>("id", PublicKeyCredentialUserEntity::getId),
+                new FieldSerializationRule<>("name", PublicKeyCredentialUserEntity::getName),
+                new FieldSerializationRule<>("displayName", PublicKeyCredentialUserEntity::getDisplayName)
+        ));
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialRpEntitySerializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialRpEntitySerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.serializer.cbor;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.PublicKeyCredentialRpEntity;
+import org.junit.jupiter.api.Test;
+import tools.jackson.dataformat.cbor.CBORMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PublicKeyCredentialRpEntitySerializerTest {
+
+    private final ObjectConverter objectConverter = new ObjectConverter();
+    private final CBORMapper cborMapper = objectConverter.getCborMapper();
+
+    @Test
+    void cbor_serialize_deserialize_test() {
+        PublicKeyCredentialRpEntity original = new PublicKeyCredentialRpEntity("example.com", "Example");
+        byte[] encoded = cborMapper.writeValueAsBytes(original);
+        PublicKeyCredentialRpEntity decoded = cborMapper.readValue(encoded, PublicKeyCredentialRpEntity.class);
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    @Test
+    void cbor_serialize_deserialize_with_null_name_test() {
+        PublicKeyCredentialRpEntity original = new PublicKeyCredentialRpEntity("example.com");
+        byte[] encoded = cborMapper.writeValueAsBytes(original);
+        PublicKeyCredentialRpEntity decoded = cborMapper.readValue(encoded, PublicKeyCredentialRpEntity.class);
+        assertThat(decoded.getId()).isEqualTo(original.getId());
+    }
+
+    @Test
+    void cbor_serialization_produces_definite_length_map() {
+        PublicKeyCredentialRpEntity entity = new PublicKeyCredentialRpEntity("example.com", "Example");
+        byte[] encoded = cborMapper.writeValueAsBytes(entity);
+        // First byte should be a definite-length CBOR map (0xA0-0xBE), not indefinite (0xBF)
+        int firstByte = encoded[0] & 0xFF;
+        assertThat(firstByte).isLessThan(0xBF);
+        assertThat(firstByte & 0xE0).isEqualTo(0xA0);
+    }
+}

--- a/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialUserEntitySerializerTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/converter/jackson/serializer/cbor/PublicKeyCredentialUserEntitySerializerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.converter.jackson.serializer.cbor;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.PublicKeyCredentialUserEntity;
+import org.junit.jupiter.api.Test;
+import tools.jackson.dataformat.cbor.CBORMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PublicKeyCredentialUserEntitySerializerTest {
+
+    private final ObjectConverter objectConverter = new ObjectConverter();
+    private final CBORMapper cborMapper = objectConverter.getCborMapper();
+
+    @Test
+    void cbor_serialize_deserialize_test() {
+        PublicKeyCredentialUserEntity original =
+                new PublicKeyCredentialUserEntity(new byte[]{1, 2, 3, 4}, "user@example.com", "Example User");
+        byte[] encoded = cborMapper.writeValueAsBytes(original);
+        PublicKeyCredentialUserEntity decoded = cborMapper.readValue(encoded, PublicKeyCredentialUserEntity.class);
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    @Test
+    void cbor_serialization_produces_definite_length_map() {
+        PublicKeyCredentialUserEntity entity =
+                new PublicKeyCredentialUserEntity(new byte[]{1, 2, 3, 4}, "user@example.com", "Example User");
+        byte[] encoded = cborMapper.writeValueAsBytes(entity);
+        // First byte should be a definite-length CBOR map (0xA0-0xBE), not indefinite (0xBF)
+        int firstByte = encoded[0] & 0xFF;
+        assertThat(firstByte).isLessThan(0xBF);
+        assertThat(firstByte & 0xE0).isEqualTo(0xA0);
+    }
+}


### PR DESCRIPTION
Register canonical CBOR serializers for `PublicKeyCredentialRpEntity` and `PublicKeyCredentialUserEntity` in `WebAuthnCBORModule`, following the same pattern as the existing `PublicKeyCredentialDescriptorSerializer` and `PublicKeyCredentialParametersSerializer`.

This enables CTAP authenticator implementations (e.g. webauthn4j-ctap) to use the webauthn4j-core entity types directly in CBOR responses without needing project-specific wrapper classes for canonical serialization.