### PR TITLE
Emit RSA COSE key fields in CTAP2 canonical CBOR order

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/RSACOSEKeySerializer.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/converter/jackson/serializer/cbor/RSACOSEKeySerializer.java
@@ -28,19 +28,23 @@ public class RSACOSEKeySerializer extends AbstractCtapCanonicalCborSerializer<RS
 
     public RSACOSEKeySerializer() {
         super(RSACOSEKey.class, Arrays.asList(
-                new FieldSerializationRule<>(-8, RSACOSEKey::getQInv),
-                new FieldSerializationRule<>(-7, RSACOSEKey::getDQ),
-                new FieldSerializationRule<>(-6, RSACOSEKey::getDP),
-                new FieldSerializationRule<>(-5, RSACOSEKey::getQ),
-                new FieldSerializationRule<>(-4, RSACOSEKey::getP),
-                new FieldSerializationRule<>(-3, RSACOSEKey::getD),
-                new FieldSerializationRule<>(-2, RSACOSEKey::getE),
-                new FieldSerializationRule<>(-1, RSACOSEKey::getN),
+                // CTAP2 canonical CBOR order: positive labels (major type 0)
+                // before negative labels (major type 1), each ascending by the
+                // encoded key bytes. Matches EC2COSEKeySerializer /
+                // EdDSACOSEKeySerializer.
                 new FieldSerializationRule<>(1, RSACOSEKey::getKeyType),
                 new FieldSerializationRule<>(2, RSACOSEKey::getKeyId),
                 new FieldSerializationRule<>(3, RSACOSEKey::getAlgorithm),
                 new FieldSerializationRule<>(4, RSACOSEKey::getKeyOps),
-                new FieldSerializationRule<>(5, RSACOSEKey::getBaseIV)
+                new FieldSerializationRule<>(5, RSACOSEKey::getBaseIV),
+                new FieldSerializationRule<>(-1, RSACOSEKey::getN),
+                new FieldSerializationRule<>(-2, RSACOSEKey::getE),
+                new FieldSerializationRule<>(-3, RSACOSEKey::getD),
+                new FieldSerializationRule<>(-4, RSACOSEKey::getP),
+                new FieldSerializationRule<>(-5, RSACOSEKey::getQ),
+                new FieldSerializationRule<>(-6, RSACOSEKey::getDP),
+                new FieldSerializationRule<>(-7, RSACOSEKey::getDQ),
+                new FieldSerializationRule<>(-8, RSACOSEKey::getQInv)
         ));
     }
 

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/RSACOSEKeyTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/attestation/authenticator/RSACOSEKeyTest.java
@@ -108,6 +108,20 @@ class RSACOSEKeyTest {
     }
 
     @Test
+    void cbor_serialize_uses_ctap2_canonical_key_order_test() {
+        // CTAP2 canonical CBOR orders map keys by their encoded bytes: positive
+        // COSE labels (major type 0: 1=kty -> 0x01, 3=alg -> 0x03) sort before
+        // negative labels (major type 1: -1=n -> 0x20, -2=e -> 0x21). The map
+        // must therefore begin with kty (0x01), not with a negative label.
+        RSACOSEKey original = TestDataUtil.createRSACOSEPublicKey();
+
+        byte[] serialized = cborMapper.writeValueAsBytes(original);
+
+        assertThat(serialized[0] & 0xE0).isEqualTo(0xA0); // CBOR map header
+        assertThat(serialized[1]).isEqualTo((byte) 0x01); // first key is kty (label 1)
+    }
+
+    @Test
     void json_serialize_deserialize_test() {
         // Given
         RSACOSEKey original = TestDataUtil.createRSACOSEPublicKey();


### PR DESCRIPTION
## The bug

`AbstractCtapCanonicalCborSerializer#serialize` writes fields **in the order of the `FieldSerializationRule` list** it is constructed with — it does not sort them. So each subclass's list must already be in CTAP2 canonical order.

CTAP2 canonical CBOR sorts map keys by their encoded bytes: positive COSE labels (major type 0, e.g. `1`→`0x01`, `3`→`0x03`) come before negative labels (major type 1, e.g. `-1`→`0x20`, `-2`→`0x21`), each ascending.

`EC2COSEKeySerializer` and `EdDSACOSEKeySerializer` list their fields correctly (`1,2,3,4,5,-1,-2,…`). But `RSACOSEKeySerializer` lists the negatives **first and descending**:

```java
-8, -7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5
```

For a typical RSA public key `{1:kty, 3:alg, -1:n, -2:e}` this emits the keys as `-2, -1, 1, 3`:

```
… 21 …  20 …  01 …  03 …      # -2, -1, 1, 3  — wrong
```

instead of the canonical `1, 3, -1, -2`:

```
… 01 …  03 …  20 …  21 …      # 1, 3, -1, -2  — correct
```

### Impact
The serialized RSA COSE key is not in CTAP2 canonical form. Anything that depends on deterministic/canonical encoding of the key is affected — re-encoding for storage or comparison, hashing, and COSE Key Thumbprints (RFC 9679). EC2 and EdDSA keys are unaffected, which is why this only surfaces for RSA (`RS256`/`PS256`) credentials.

## The fix

Reorder the RSA field list to positive-labels-then-negatives-ascending, matching `EC2COSEKeySerializer` / `EdDSACOSEKeySerializer`:

```java
1, 2, 3, 4, 5, -1, -2, -3, -4, -5, -6, -7, -8
```

## Verification

- Added `RSACOSEKeyTest#cbor_serialize_uses_ctap2_canonical_key_order_test`, which asserts the serialized map begins with `kty` (label `1`, `0x01`). It **fails on the current code** (the map starts with a negative label) and passes with the fix.
- `:webauthn4j-core:test --tests "*RSACOSEKeyTest"` is green with the fix; the existing round-trip tests are unaffected.
