### PR TITLE
Fix CachingMetadataBLOBAsyncProvider lock never being released

### DIFF
--- a/webauthn4j-metadata-async/src/main/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProvider.java
+++ b/webauthn4j-metadata-async/src/main/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProvider.java
@@ -18,65 +18,91 @@ package com.webauthn4j.async.metadata;
 
 import com.webauthn4j.metadata.data.MetadataBLOB;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class CachingMetadataBLOBAsyncProvider implements MetadataBLOBAsyncProvider {
 
-    private MetadataBLOB cachedMetadataBLOB = null;
-    private CompletableFuture<MetadataBLOB> metadataBLOBFuture = new CompletableFuture<>();
-    private LocalDate metadataBLOBLastUpdate = null;
-    private final Object metadataBLOBFutureLock = new Object();
-    private final Lock metadataBLOBRefreshingLock = new ReentrantLock();
+    private final Clock clock;
+    // CacheState is an immutable snapshot published by replacing the reference.
+    @SuppressWarnings("java:S3077")
+    private volatile CacheState cache = null;
+    private final AtomicReference<CompletableFuture<MetadataBLOB>> inFlight = new AtomicReference<>();
+
+    public CachingMetadataBLOBAsyncProvider() {
+        this(Clock.system(ZoneOffset.UTC));
+    }
+
+    CachingMetadataBLOBAsyncProvider(@NotNull Clock clock) {
+        this.clock = clock;
+    }
 
     @Override
     public @NotNull CompletionStage<MetadataBLOB> provide(){
 
-        if(!needsMetadataBLOBUpdate(cachedMetadataBLOB, metadataBLOBLastUpdate)){
-            return CompletableFuture.completedFuture(cachedMetadataBLOB);
+        CacheState current = cache;
+        if(!needsMetadataBLOBUpdate(current, clock)){
+            return CompletableFuture.completedFuture(current.blob);
         }
 
-        CompletableFuture<MetadataBLOB> response;
-        synchronized (metadataBLOBFutureLock){
-            response = metadataBLOBFuture;
-        }
+        while(true) {
+            CompletableFuture<MetadataBLOB> existing = inFlight.get();
+            if (existing != null) {
+                return existing;
+            }
 
-        if(metadataBLOBRefreshingLock.tryLock()){
-            doProvide()
-                    .thenAccept(metadataBLOB -> {
-                        cachedMetadataBLOB = metadataBLOB;
-                        metadataBLOBLastUpdate = LocalDate.now(ZoneOffset.UTC);
-                        synchronized (metadataBLOBFutureLock){
-                            metadataBLOBFuture.complete(metadataBLOB);
-                            metadataBLOBFuture = new CompletableFuture<>();
-                        }
-                    })
-                    .exceptionally(e ->{
-                        synchronized (metadataBLOBFutureLock){
-                            metadataBLOBFuture.completeExceptionally(e);
-                            metadataBLOBFuture = new CompletableFuture<>();
-                        }
-                        metadataBLOBRefreshingLock.unlock();
-                        return null;
-                    });
+            CompletableFuture<MetadataBLOB> future = new CompletableFuture<>();
+            if (inFlight.compareAndSet(null, future)) {
+                CompletionStage<MetadataBLOB> stage;
+                try {
+                    stage = doProvide();
+                }
+                catch (Throwable e) {
+                    inFlight.compareAndSet(future, null);
+                    future.completeExceptionally(e);
+                    return future;
+                }
+                stage.whenComplete((metadataBLOB, e) -> {
+                    if (e != null) {
+                        inFlight.compareAndSet(future, null);
+                        future.completeExceptionally(e);
+                    }
+                    else {
+                        cache = new CacheState(metadataBLOB, LocalDate.now(clock));
+                        inFlight.compareAndSet(future, null);
+                        future.complete(metadataBLOB);
+                    }
+                });
+                return future;
+            }
         }
-        return response;
     }
 
     protected abstract @NotNull CompletionStage<MetadataBLOB> doProvide();
 
-    static boolean needsMetadataBLOBUpdate(MetadataBLOB cachedMetadataBLOB, LocalDate metadataBLOBLastUpdate){
-        if(cachedMetadataBLOB == null){
+    static boolean needsMetadataBLOBUpdate(@Nullable CacheState cache, @NotNull Clock clock){
+        if(cache == null){
             return true;
         }
-        LocalDate today = LocalDate.now(ZoneOffset.UTC);
-        LocalDate nextUpdate = cachedMetadataBLOB.getPayload().getNextUpdate();
-        return (nextUpdate.isBefore(today) || nextUpdate.isEqual(today)) && metadataBLOBLastUpdate.isBefore(today);
+        LocalDate today = LocalDate.now(clock);
+        LocalDate nextUpdate = cache.blob.getPayload().getNextUpdate();
+        return (nextUpdate.isBefore(today) || nextUpdate.isEqual(today)) && cache.lastUpdate.isBefore(today);
+    }
+
+    static class CacheState {
+        final MetadataBLOB blob;
+        final LocalDate lastUpdate;
+
+        CacheState(@NotNull MetadataBLOB blob, @NotNull LocalDate lastUpdate) {
+            this.blob = blob;
+            this.lastUpdate = lastUpdate;
+        }
     }
 
 }

--- a/webauthn4j-metadata-async/src/test/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProviderTest.java
+++ b/webauthn4j-metadata-async/src/test/java/com/webauthn4j/async/metadata/CachingMetadataBLOBAsyncProviderTest.java
@@ -7,69 +7,205 @@ import com.webauthn4j.data.jws.JWSFactory;
 import com.webauthn4j.data.jws.JWSHeader;
 import com.webauthn4j.metadata.data.MetadataBLOB;
 import com.webauthn4j.metadata.data.MetadataBLOBPayload;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CachingMetadataBLOBAsyncProviderTest {
 
     @Test
     void nextUpdate_is_past_date_test() throws ExecutionException, InterruptedException {
         LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 2);
-        CachingMetadataBLOBAsyncProvider target = spy(CachingMetadataBLOBAsyncProvider.class);
-        when(target.doProvide()).thenReturn(CompletableFuture.completedFuture(createMetadataBLOB(nextUpdate)));
-        LocalDate firstTrialDay = LocalDate.of(2020, Month.JANUARY, 1);
-        LocalDate secondTrialDay = LocalDate.of(2020, Month.JANUARY, 3);
-        try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
-            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
-            target.provide().toCompletableFuture().get();
-            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(secondTrialDay);
-            target.provide().toCompletableFuture().get();
-            verify(target, times(2)).doProvide();
-        }
+        AtomicReference<Clock> clockRef = new AtomicReference<>();
+        AtomicInteger callCount = new AtomicInteger(0);
+        CachingMetadataBLOBAsyncProvider target = new CachingMetadataBLOBAsyncProvider(new DelegateClock(clockRef)) {
+            @Override
+            protected @NotNull CompletionStage<MetadataBLOB> doProvide() {
+                callCount.incrementAndGet();
+                return CompletableFuture.completedFuture(createMetadataBLOB(nextUpdate));
+            }
+        };
+
+        clockRef.set(fixedClock(2020, Month.JANUARY, 1));
+        target.provide().toCompletableFuture().get();
+
+        clockRef.set(fixedClock(2020, Month.JANUARY, 3));
+        target.provide().toCompletableFuture().get();
+
+        assertThat(callCount.get()).isEqualTo(2);
     }
 
     @Test
-    void nextUpdate_is_today_test(){
+    void nextUpdate_is_today_test() throws ExecutionException, InterruptedException {
         LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 2);
-        CachingMetadataBLOBAsyncProvider target = spy(CachingMetadataBLOBAsyncProvider.class);
-        when(target.doProvide()).thenReturn(CompletableFuture.completedFuture(createMetadataBLOB(nextUpdate)));
-        LocalDate firstTrialDay = LocalDate.of(2020, Month.JANUARY, 1);
-        LocalDate secondTrialDay = LocalDate.of(2020, Month.JANUARY, 2);
-        try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
-            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
-            target.provide();
-            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(secondTrialDay);
-            target.provide();
-            verify(target, times(2)).doProvide();
-        }
+        AtomicReference<Clock> clockRef = new AtomicReference<>();
+        AtomicInteger callCount = new AtomicInteger(0);
+        CachingMetadataBLOBAsyncProvider target = new CachingMetadataBLOBAsyncProvider(new DelegateClock(clockRef)) {
+            @Override
+            protected @NotNull CompletionStage<MetadataBLOB> doProvide() {
+                callCount.incrementAndGet();
+                return CompletableFuture.completedFuture(createMetadataBLOB(nextUpdate));
+            }
+        };
+
+        clockRef.set(fixedClock(2020, Month.JANUARY, 1));
+        target.provide().toCompletableFuture().get();
+
+        clockRef.set(fixedClock(2020, Month.JANUARY, 2));
+        target.provide().toCompletableFuture().get();
+
+        assertThat(callCount.get()).isEqualTo(2);
     }
 
     @Test
-    void nextUpdate_is_future_date_test(){
+    void nextUpdate_is_future_date_test() throws ExecutionException, InterruptedException {
         LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 3);
-        CachingMetadataBLOBAsyncProvider target = spy(CachingMetadataBLOBAsyncProvider.class);
-        when(target.doProvide()).thenReturn(CompletableFuture.completedFuture(createMetadataBLOB(nextUpdate)));
-        LocalDate firstTrialDay = LocalDate.of(2020, Month.JANUARY, 1);
-        LocalDate secondTrialDay = LocalDate.of(2020, Month.JANUARY, 2);
-        try(MockedStatic<LocalDate> mock = Mockito.mockStatic(LocalDate.class)){
-            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(firstTrialDay);
-            target.provide();
-            mock.when(() -> LocalDate.now(java.time.ZoneOffset.UTC)).thenReturn(secondTrialDay);
-            target.provide();
-            verify(target, times(1)).doProvide();
-        }
+        AtomicReference<Clock> clockRef = new AtomicReference<>();
+        AtomicInteger callCount = new AtomicInteger(0);
+        CachingMetadataBLOBAsyncProvider target = new CachingMetadataBLOBAsyncProvider(new DelegateClock(clockRef)) {
+            @Override
+            protected @NotNull CompletionStage<MetadataBLOB> doProvide() {
+                callCount.incrementAndGet();
+                return CompletableFuture.completedFuture(createMetadataBLOB(nextUpdate));
+            }
+        };
+
+        clockRef.set(fixedClock(2020, Month.JANUARY, 1));
+        target.provide().toCompletableFuture().get();
+
+        clockRef.set(fixedClock(2020, Month.JANUARY, 2));
+        target.provide().toCompletableFuture().get();
+
+        assertThat(callCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void concurrent_callers_share_same_result_test() throws Exception {
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 3);
+        MetadataBLOB blob = createMetadataBLOB(nextUpdate);
+        CompletableFuture<MetadataBLOB> pendingFuture = new CompletableFuture<>();
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        CachingMetadataBLOBAsyncProvider target = new CachingMetadataBLOBAsyncProvider(fixedClock(2020, Month.JANUARY, 1)) {
+            @Override
+            protected @NotNull CompletionStage<MetadataBLOB> doProvide() {
+                callCount.incrementAndGet();
+                return pendingFuture;
+            }
+        };
+
+        CompletionStage<MetadataBLOB> result1 = target.provide();
+        CompletionStage<MetadataBLOB> result2 = target.provide();
+        CompletionStage<MetadataBLOB> result3 = target.provide();
+
+        pendingFuture.complete(blob);
+
+        assertThat(result1.toCompletableFuture().get(1, TimeUnit.SECONDS)).isSameAs(blob);
+        assertThat(result2.toCompletableFuture().get(1, TimeUnit.SECONDS)).isSameAs(blob);
+        assertThat(result3.toCompletableFuture().get(1, TimeUnit.SECONDS)).isSameAs(blob);
+        assertThat(callCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void retry_after_async_failure_test() throws Exception {
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 3);
+        MetadataBLOB blob = createMetadataBLOB(nextUpdate);
+        CompletableFuture<MetadataBLOB> failingFuture = new CompletableFuture<>();
+        failingFuture.completeExceptionally(new RuntimeException("network error"));
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        CachingMetadataBLOBAsyncProvider target = new CachingMetadataBLOBAsyncProvider(fixedClock(2020, Month.JANUARY, 1)) {
+            @Override
+            protected @NotNull CompletionStage<MetadataBLOB> doProvide() {
+                if (callCount.incrementAndGet() == 1) {
+                    return failingFuture;
+                }
+                return CompletableFuture.completedFuture(blob);
+            }
+        };
+
+        CompletionStage<MetadataBLOB> firstResult = target.provide();
+        assertThatThrownBy(() -> firstResult.toCompletableFuture().get(1, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(RuntimeException.class);
+
+        CompletionStage<MetadataBLOB> secondResult = target.provide();
+        assertThat(secondResult.toCompletableFuture().get(1, TimeUnit.SECONDS)).isSameAs(blob);
+        assertThat(callCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    void retry_after_sync_exception_test() throws Exception {
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 3);
+        MetadataBLOB blob = createMetadataBLOB(nextUpdate);
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        CachingMetadataBLOBAsyncProvider target = new CachingMetadataBLOBAsyncProvider(fixedClock(2020, Month.JANUARY, 1)) {
+            @Override
+            protected @NotNull CompletionStage<MetadataBLOB> doProvide() {
+                if (callCount.incrementAndGet() == 1) {
+                    throw new RuntimeException("sync error");
+                }
+                return CompletableFuture.completedFuture(blob);
+            }
+        };
+
+        CompletionStage<MetadataBLOB> firstResult = target.provide();
+        assertThatThrownBy(() -> firstResult.toCompletableFuture().get(1, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(RuntimeException.class);
+
+        CompletionStage<MetadataBLOB> secondResult = target.provide();
+        assertThat(secondResult.toCompletableFuture().get(1, TimeUnit.SECONDS)).isSameAs(blob);
+        assertThat(callCount.get()).isEqualTo(2);
     }
 
 
+    @Test
+    void retry_from_failure_callback_test() throws Exception {
+        LocalDate nextUpdate = LocalDate.of(2020, Month.JANUARY, 3);
+        MetadataBLOB blob = createMetadataBLOB(nextUpdate);
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        CachingMetadataBLOBAsyncProvider target = new CachingMetadataBLOBAsyncProvider(fixedClock(2020, Month.JANUARY, 1)) {
+            @Override
+            protected @NotNull CompletionStage<MetadataBLOB> doProvide() {
+                if (callCount.incrementAndGet() == 1) {
+                    return CompletableFuture.failedFuture(new RuntimeException("first attempt"));
+                }
+                return CompletableFuture.completedFuture(blob);
+            }
+        };
+
+        MetadataBLOB result = target.provide()
+                .exceptionallyCompose(e -> target.provide())
+                .toCompletableFuture()
+                .get(1, TimeUnit.SECONDS);
+
+        assertThat(result).isSameAs(blob);
+        assertThat(callCount).hasValue(2);
+    }
+
+
+    private static Clock fixedClock(int year, Month month, int day) {
+        LocalDate date = LocalDate.of(year, month, day);
+        return Clock.fixed(date.atStartOfDay(ZoneOffset.UTC).toInstant(), ZoneOffset.UTC);
+    }
 
     private MetadataBLOB createMetadataBLOB(LocalDate nextUpdate){
         JWSFactory factory = new JWSFactory(new ObjectConverter());
@@ -77,6 +213,29 @@ class CachingMetadataBLOBAsyncProviderTest {
         MetadataBLOBPayload payload = new MetadataBLOBPayload("", 0, nextUpdate, Collections.emptyList());
         JWS<MetadataBLOBPayload> jws = factory.create(header, payload, new byte[32]);
         return new MetadataBLOB(jws);
+    }
+
+    private static class DelegateClock extends Clock {
+        private final AtomicReference<Clock> delegate;
+
+        DelegateClock(AtomicReference<Clock> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return delegate.get().instant();
+        }
     }
 
 }


### PR DESCRIPTION
Replace ReentrantLock with AtomicReference<CompletableFuture>-based CAS pattern. The original ReentrantLock was never released on success and threw IllegalMonitorStateException on failure.