### PR TITLE
Make DefaultCertPathAsyncChecker delegate to DefaultCertPathChecker

### DIFF
--- a/webauthn4j-metadata-async/src/main/java/com/webauthn4j/async/metadata/FidoMDS3MetadataBLOBAsyncProvider.java
+++ b/webauthn4j-metadata-async/src/main/java/com/webauthn4j/async/metadata/FidoMDS3MetadataBLOBAsyncProvider.java
@@ -22,25 +22,21 @@ import com.webauthn4j.metadata.data.MetadataBLOB;
 import com.webauthn4j.metadata.data.MetadataBLOBFactory;
 import com.webauthn4j.metadata.exception.CertPathCheckException;
 import com.webauthn4j.metadata.exception.MDSException;
-import com.webauthn4j.util.CertificateUtil;
-import com.webauthn4j.data.internal.asn1.der.ASN1;
-import com.webauthn4j.data.internal.asn1.der.ASN1OctetString;
-import com.webauthn4j.data.internal.asn1.der.ASN1Primitive;
-import com.webauthn4j.data.internal.asn1.der.ASN1Sequence;
-import com.webauthn4j.data.internal.asn1.der.ASN1Structure;
+import com.webauthn4j.metadata.util.internal.DefaultCertPathChecker;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.net.URL;
-import java.security.*;
-import java.security.cert.*;
-import java.util.*;
+import java.security.cert.CertPath;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 /**
  * Load MetadataBLOB from the FIDO Alliance Metadata Service. This provider validates MetadataBLOB signature.
@@ -49,6 +45,13 @@ public class FidoMDS3MetadataBLOBAsyncProvider extends CachingMetadataBLOBAsyncP
 
     public static final String DEFAULT_BLOB_ENDPOINT = "https://mds.fidoalliance.org/";
 
+    private static final Executor DEFAULT_CERT_PATH_VALIDATION_EXECUTOR =
+            Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "webauthn4j-mds-cert-path-validation");
+                thread.setDaemon(true);
+                return thread;
+            });
+
     private final MetadataBLOBFactory metadataBLOBFactory;
     private final String blobEndpoint;
     private final HttpAsyncClient httpClient;
@@ -56,12 +59,16 @@ public class FidoMDS3MetadataBLOBAsyncProvider extends CachingMetadataBLOBAsyncP
     private boolean revocationCheckEnabled = true;
     private CertPathAsyncChecker certPathAsyncChecker;
 
-    public FidoMDS3MetadataBLOBAsyncProvider(@NotNull ObjectConverter objectConverter, @NotNull String blobEndpoint, @NotNull HttpAsyncClient httpClient, @NotNull Set<TrustAnchor> trustAnchors) {
+    public FidoMDS3MetadataBLOBAsyncProvider(@NotNull ObjectConverter objectConverter, @NotNull String blobEndpoint, @NotNull HttpAsyncClient httpClient, @NotNull Set<TrustAnchor> trustAnchors, @NotNull Executor certPathValidationExecutor) {
         this.metadataBLOBFactory = new MetadataBLOBFactory(objectConverter);
         this.blobEndpoint = blobEndpoint;
         this.httpClient = httpClient;
         this.trustAnchors = trustAnchors;
-        this.certPathAsyncChecker = new DefaultCertPathAsyncChecker(httpClient);
+        this.certPathAsyncChecker = new DefaultCertPathAsyncChecker(certPathValidationExecutor);
+    }
+
+    public FidoMDS3MetadataBLOBAsyncProvider(@NotNull ObjectConverter objectConverter, @NotNull String blobEndpoint, @NotNull HttpAsyncClient httpClient, @NotNull Set<TrustAnchor> trustAnchors) {
+        this(objectConverter, blobEndpoint, httpClient, trustAnchors, DEFAULT_CERT_PATH_VALIDATION_EXECUTOR);
     }
 
     public FidoMDS3MetadataBLOBAsyncProvider(@NotNull ObjectConverter objectConverter, @NotNull String blobEndpoint, @NotNull Set<TrustAnchor> trustAnchors) {
@@ -129,114 +136,17 @@ public class FidoMDS3MetadataBLOBAsyncProvider extends CachingMetadataBLOBAsyncP
 
     private static class DefaultCertPathAsyncChecker implements CertPathAsyncChecker {
 
-        private final HttpAsyncClient httpClient;
+        private final Executor executor;
+        private final DefaultCertPathChecker delegate = new DefaultCertPathChecker();
 
-        public DefaultCertPathAsyncChecker(HttpAsyncClient httpClient){
-            this.httpClient = httpClient;
+        public DefaultCertPathAsyncChecker(Executor executor){
+            this.executor = executor;
         }
 
         @Override
         public CompletionStage<Void> check(CertPathCheckContext context) throws MDSException {
-            CertPathValidator certPathValidator = CertificateUtil.createCertPathValidator();
-            PKIXParameters certPathParameters = CertificateUtil.createPKIXParameters(context.getTrustAnchors());
-            certPathParameters.setRevocationEnabled(false); //This validator uses checkCRL, which is our own (async) revocation check.
-            try {
-                certPathValidator.validate(context.getCertPath(), certPathParameters);
-            } catch (InvalidAlgorithmParameterException e) {
-                throw new CertPathCheckException("invalid algorithm parameter", e);
-            } catch (CertPathValidatorException e) {
-                throw new CertPathCheckException("invalid cert path", e);
-            }
-
-            if(context.isRevocationCheckEnabled()){
-                return checkCRL(context);
-            }
-            else{
-                return CompletableFuture.completedFuture(null);
-            }
-        }
-
-        private CompletionStage<Void> checkCRL(CertPathCheckContext context) {
-            List<X509Certificate> certPathToTrustAnchor = new ArrayList<>();
-            context.getCertPath().getCertificates().forEach(cert -> certPathToTrustAnchor.add((X509Certificate) cert));
-            X509Certificate last = certPathToTrustAnchor.get(certPathToTrustAnchor.size()-1);
-            TrustAnchor trustAnchor = context.getTrustAnchors().stream().filter(item -> Objects.equals(item.getTrustedCert().getSubjectX500Principal(), last.getIssuerX500Principal())).findFirst().orElseThrow();
-            certPathToTrustAnchor.add(trustAnchor.getTrustedCert());
-
-
-            Stream<CompletionStage<Void>> completionStageStream = context.getCertPath().getCertificates().stream().map(certificate -> {
-                X509Certificate x509Certificate = (X509Certificate) certificate;
-                List<String> crlDistributionPoints = extractCRLDistributionPoints(x509Certificate);
-                Stream<CompletionStage<X509CRL>> crlCompletionStageStream = crlDistributionPoints.stream().map(this::fetchCRL);
-                return join(crlCompletionStageStream).thenApply(crlStream -> {
-                    crlStream.forEach(crl -> {
-                        try {
-                            X509Certificate crlIssuerCertificate = certPathToTrustAnchor.stream().filter(cert -> Objects.equals(cert.getSubjectX500Principal(), crl.getIssuerX500Principal())).findFirst().orElseThrow();
-                            crl.verify(crlIssuerCertificate.getPublicKey());
-                        } catch (CRLException | NoSuchAlgorithmException | InvalidKeyException | NoSuchProviderException | SignatureException e) {
-                            throw new CertPathCheckException("crl validation failed", e);
-                        }
-                        if(crl.isRevoked(certificate)){
-                            throw new CertPathCheckException("Certificate is revoked");
-                        }
-                    });
-                    return null;
-                });
-            });
-
-            return join(completionStageStream).thenApply(stream -> null);
-        }
-
-        private static <T> CompletionStage<Stream<T>> join(Stream<CompletionStage<T>> completionStages) {
-            List<CompletableFuture<T>> completableFutures = completionStages.map(CompletionStage::toCompletableFuture).collect(Collectors.toList());
-            CompletableFuture<?>[] array = completableFutures.toArray(CompletableFuture[]::new);
-            CompletableFuture<Void> joinedFuture = CompletableFuture.allOf(array);
-            return joinedFuture.thenApply(unused -> completableFutures.stream().map(CompletableFuture::join));
-        }
-
-        private CompletionStage<X509CRL> fetchCRL(String crlDistributionPoint){
-            try {
-                URL url = new URL(crlDistributionPoint);
-                if(url.getProtocol().equals("http") || url.getProtocol().equals("https")) {
-                    return httpClient.fetch(crlDistributionPoint).thenApply( response -> {
-                        if(response.getStatusCode() >= 400){
-                            throw new CertPathCheckException(String.format("Failed to fetch CRL. HTTP Status code: %d", response.getStatusCode()));
-                        }
-                        CertificateFactory certificateFactory = CertificateUtil.createCertificateFactory();
-                        try {
-                            return (X509CRL)certificateFactory.generateCRL(response.getBody());
-                        }
-                        catch (CRLException e) {
-                            throw new CertPathCheckException(e);
-                        }
-                    });
-                }
-                else {
-                    throw new CertPathCheckException("http or https is the only supported protocol to fetch CRL.");
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-
-        @SuppressWarnings("java:S1155")
-        private List<String> extractCRLDistributionPoints(X509Certificate x509Certificate){
-            byte[] extensionValue = x509Certificate.getExtensionValue("2.5.29.31");
-
-            ASN1OctetString encodedCrlExtension = ASN1OctetString.parse(extensionValue);
-            ASN1Sequence crlDistributionPoints = ASN1Sequence.parse(encodedCrlExtension.getValue());
-            ArrayList<String> urls = new ArrayList<>();
-            for (ASN1 item: crlDistributionPoints){
-                ASN1Structure distributionPointSequence = (ASN1Structure)item;
-                ASN1Structure distributionPoint = (ASN1Structure) distributionPointSequence.get(0);
-                ASN1Structure fullName = (ASN1Structure)distributionPoint.get(0);
-                for (ASN1 fullNameItem : fullName){
-                    String url = new String(((ASN1Primitive)fullNameItem).getValue(), java.nio.charset.StandardCharsets.UTF_8);
-                    urls.add(url);
-                }
-            }
-
-            return Collections.unmodifiableList(urls);
+            return CompletableFuture.completedStage(null)
+                    .thenCompose(unused -> CompletableFuture.runAsync(() -> delegate.check(context), executor));
         }
     }
 }

--- a/webauthn4j-metadata-async/src/test/java/com/webauthn4j/async/metadata/FidoMDS3MetadataBLOBAsyncProviderTest.java
+++ b/webauthn4j-metadata-async/src/test/java/com/webauthn4j/async/metadata/FidoMDS3MetadataBLOBAsyncProviderTest.java
@@ -1,0 +1,57 @@
+package com.webauthn4j.async.metadata;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.metadata.CertPathCheckContext;
+import com.webauthn4j.util.CertificateUtil;
+import org.junit.jupiter.api.Test;
+
+import java.security.cert.X509Certificate;
+import java.security.cert.TrustAnchor;
+import java.util.Collections;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FidoMDS3MetadataBLOBAsyncProviderTest {
+
+    @Test
+    void certPathValidation_is_executed_on_the_default_executor_test() {
+        FidoMDS3MetadataBLOBAsyncProvider target = new FidoMDS3MetadataBLOBAsyncProvider(
+                new ObjectConverter(),
+                FidoMDS3MetadataBLOBAsyncProvider.DEFAULT_BLOB_ENDPOINT,
+                mock(HttpAsyncClient.class),
+                Collections.emptySet());
+        CertPathCheckContext context = mock(CertPathCheckContext.class);
+        when(context.getCertPath()).thenReturn(CertificateUtil.generateCertPath(Collections.emptyList()));
+        when(context.getTrustAnchors()).thenReturn(Collections.singleton(new TrustAnchor(mock(X509Certificate.class), null)));
+        when(context.isRevocationCheckEnabled()).thenReturn(false);
+
+        CompletionStage<Void> result = target.getCertPathAsyncValidator().check(context);
+
+        assertThatThrownBy(() -> result.toCompletableFuture().join())
+                .isInstanceOf(CompletionException.class);
+    }
+
+    @Test
+    void certPathValidation_is_delegated_to_the_configured_executor_test() {
+        AtomicReference<Runnable> submittedTask = new AtomicReference<>();
+        Executor executor = submittedTask::set;
+        FidoMDS3MetadataBLOBAsyncProvider target = new FidoMDS3MetadataBLOBAsyncProvider(
+                new ObjectConverter(),
+                FidoMDS3MetadataBLOBAsyncProvider.DEFAULT_BLOB_ENDPOINT,
+                mock(HttpAsyncClient.class),
+                Collections.<TrustAnchor>emptySet(),
+                executor);
+
+        CompletionStage<Void> result = target.getCertPathAsyncValidator().check(mock(CertPathCheckContext.class));
+
+        assertThat(submittedTask.get()).isNotNull();
+        assertThat(result.toCompletableFuture()).isNotDone();
+    }
+}

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/FidoMDS3MetadataBLOBProvider.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/FidoMDS3MetadataBLOBProvider.java
@@ -21,16 +21,14 @@ import com.webauthn4j.metadata.data.MetadataBLOB;
 import com.webauthn4j.metadata.data.MetadataBLOBFactory;
 import com.webauthn4j.metadata.exception.CertPathCheckException;
 import com.webauthn4j.metadata.exception.MDSException;
-import com.webauthn4j.util.CertificateUtil;
+import com.webauthn4j.metadata.util.internal.DefaultCertPathChecker;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.security.InvalidAlgorithmParameterException;
 import java.security.cert.*;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Set;
 
 /**
@@ -115,27 +113,5 @@ public class FidoMDS3MetadataBLOBProvider extends CachingMetadataBLOBProvider{
 
     public void setCertPathChecker(@NotNull CertPathChecker certPathChecker) {
         this.certPathChecker = certPathChecker;
-    }
-
-    private class DefaultCertPathChecker implements CertPathChecker {
-
-        @Override
-        public void check(CertPathCheckContext context) throws MDSException {
-            CertPathValidator certPathValidator = CertificateUtil.createCertPathValidator();
-            PKIXParameters certPathParameters = CertificateUtil.createPKIXParameters(trustAnchors);
-            certPathParameters.setRevocationEnabled(revocationCheckEnabled);
-            if(revocationCheckEnabled){
-                PKIXRevocationChecker pkixRevocationChecker = (PKIXRevocationChecker) certPathValidator.getRevocationChecker();
-                pkixRevocationChecker.setOptions(EnumSet.of(PKIXRevocationChecker.Option.PREFER_CRLS));
-                certPathParameters.addCertPathChecker(pkixRevocationChecker);
-            }
-            try {
-                certPathValidator.validate(context.getCertPath(), certPathParameters);
-            } catch (InvalidAlgorithmParameterException e) {
-                throw new CertPathCheckException("invalid algorithm parameter", e);
-            } catch (CertPathValidatorException e) {
-                throw new CertPathCheckException("invalid cert path", e);
-            }
-        }
     }
 }

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/util/internal/DefaultCertPathChecker.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/util/internal/DefaultCertPathChecker.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webauthn4j.metadata.util.internal;
+
+import com.webauthn4j.metadata.CertPathCheckContext;
+import com.webauthn4j.metadata.CertPathChecker;
+import com.webauthn4j.metadata.exception.CertPathCheckException;
+import com.webauthn4j.metadata.exception.MDSException;
+import com.webauthn4j.util.CertificateUtil;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.cert.CertPathValidator;
+import java.security.cert.CertPathValidatorException;
+import java.security.cert.PKIXParameters;
+import java.security.cert.PKIXRevocationChecker;
+import java.util.EnumSet;
+
+public class DefaultCertPathChecker implements CertPathChecker {
+
+    @Override
+    public void check(CertPathCheckContext context) throws MDSException {
+        CertPathValidator certPathValidator = CertificateUtil.createCertPathValidator();
+        PKIXParameters certPathParameters = CertificateUtil.createPKIXParameters(context.getTrustAnchors());
+        certPathParameters.setRevocationEnabled(context.isRevocationCheckEnabled());
+        if(context.isRevocationCheckEnabled()){
+            PKIXRevocationChecker pkixRevocationChecker = (PKIXRevocationChecker) certPathValidator.getRevocationChecker();
+            pkixRevocationChecker.setOptions(EnumSet.of(PKIXRevocationChecker.Option.PREFER_CRLS));
+            certPathParameters.addCertPathChecker(pkixRevocationChecker);
+        }
+        try {
+            certPathValidator.validate(context.getCertPath(), certPathParameters);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new CertPathCheckException("invalid algorithm parameter", e);
+        } catch (CertPathValidatorException e) {
+            throw new CertPathCheckException("invalid cert path", e);
+        }
+    }
+}

--- a/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/util/internal/DefaultCertPathCheckerTest.java
+++ b/webauthn4j-metadata/src/test/java/com/webauthn4j/metadata/util/internal/DefaultCertPathCheckerTest.java
@@ -1,0 +1,36 @@
+package com.webauthn4j.metadata.util.internal;
+
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.metadata.CertPathCheckContext;
+import com.webauthn4j.metadata.data.MetadataBLOB;
+import com.webauthn4j.metadata.data.MetadataBLOBFactory;
+import com.webauthn4j.metadata.exception.CertPathCheckException;
+import com.webauthn4j.util.CertificateUtil;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.cert.Certificate;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+class DefaultCertPathCheckerTest {
+
+    @Test
+    void invalid_cert_path_throws_CertPathCheckException_when_revocation_check_is_disabled_test() throws Exception {
+        String blobJwt = Files.readString(Paths.get(ClassLoader.getSystemResource("integration/component/blob.jwt").toURI()));
+        MetadataBLOB metadataBLOB = new MetadataBLOBFactory(new ObjectConverter()).parse(blobJwt);
+        List<? extends Certificate> certificates = metadataBLOB.getHeader().getX5c().getCertificates();
+        X509Certificate trustAnchorCertificate = (X509Certificate) certificates.get(certificates.size() - 1);
+        CertPathCheckContext context = new CertPathCheckContext(
+                CertificateUtil.generateCertPath(certificates.subList(0, certificates.size() - 1)),
+                Collections.singleton(new TrustAnchor(trustAnchorCertificate, null)),
+                false);
+
+        assertThatThrownBy(() -> new DefaultCertPathChecker().check(context))
+                .isInstanceOf(CertPathCheckException.class);
+    }
+}


### PR DESCRIPTION
Run certificate path validation on an injectable Executor to keep the blocking operation off the caller thread.