### PR TITLE
Fix ECDSA JWS signature length to comply with RFC 7518

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSFactory.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSFactory.java
@@ -59,8 +59,14 @@ public class JWSFactory {
         try {
             signatureInstance.initSign(privateKey);
             signatureInstance.update(signedData.getBytes());
-            byte[] derSignature = signatureInstance.sign();
-            byte[] jwsSignature = JWSSignatureUtil.convertDerSignatureToJwsSignature(derSignature);
+            byte[] rawSignature = signatureInstance.sign();
+            byte[] jwsSignature;
+            if (header.getAlg() == JWAIdentifier.ES256 || header.getAlg() == JWAIdentifier.ES384 || header.getAlg() == JWAIdentifier.ES512) {
+                jwsSignature = JWSSignatureUtil.convertDerSignatureToJwsSignature(rawSignature, header.getAlg());
+            }
+            else {
+                jwsSignature = rawSignature;
+            }
             return new JWS<>(header, headerString, payload, payloadString, jwsSignature);
         } catch (InvalidKeyException | SignatureException e) {
             throw new IllegalArgumentException(e);

--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSSignatureUtil.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/jws/JWSSignatureUtil.java
@@ -87,7 +87,7 @@ class JWSSignatureUtil {
      * @param derSignature signature in DER format
      * @return signature in JWS format
      */
-    public static @NotNull byte[] convertDerSignatureToJwsSignature(@NotNull byte[] derSignature) {
+    public static @NotNull byte[] convertDerSignatureToJwsSignature(@NotNull byte[] derSignature, @NotNull JWAIdentifier alg) {
         ASN1Sequence seq;
         try {
             seq = ASN1Sequence.parse(derSignature);
@@ -103,17 +103,28 @@ class JWSSignatureUtil {
         BigInteger r = ((ASN1Integer) seq.get(0)).getContent();
         BigInteger s = ((ASN1Integer) seq.get(1)).getContent();
 
-        // Determine raw component length from the larger of the two
+        int componentLength = getComponentLength(alg);
         byte[] rUnsigned = toUnsignedByteArray(r);
         byte[] sUnsigned = toUnsignedByteArray(s);
-        int rawLen = Math.max(rUnsigned.length, sUnsigned.length);
 
-        // Pad to fixed-length and concatenate
-        byte[] concatSignature = new byte[2 * rawLen];
-        System.arraycopy(rUnsigned, 0, concatSignature, rawLen - rUnsigned.length, rUnsigned.length);
-        System.arraycopy(sUnsigned, 0, concatSignature, 2 * rawLen - sUnsigned.length, sUnsigned.length);
+        byte[] concatSignature = new byte[2 * componentLength];
+        System.arraycopy(rUnsigned, 0, concatSignature, componentLength - rUnsigned.length, rUnsigned.length);
+        System.arraycopy(sUnsigned, 0, concatSignature, 2 * componentLength - sUnsigned.length, sUnsigned.length);
 
         return concatSignature;
+    }
+
+    private static int getComponentLength(@NotNull JWAIdentifier alg) {
+        if (alg == JWAIdentifier.ES256) {
+            return 32;
+        }
+        else if (alg == JWAIdentifier.ES384) {
+            return 48;
+        }
+        else if (alg == JWAIdentifier.ES512) {
+            return 66;
+        }
+        throw new IllegalArgumentException("Unsupported algorithm for ECDSA signature conversion: " + alg);
     }
 
     private static byte[] toUnsignedByteArray(BigInteger value) {

--- a/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWSFactoryTest.java
+++ b/webauthn4j-core/src/test/java/com/webauthn4j/data/jws/JWSFactoryTest.java
@@ -57,6 +57,33 @@ class JWSFactoryTest {
         assertThatThrownBy(() -> target.create(header, payload, privateKey)).isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void signature_length_es256_test() {
+        JWSHeader header = new JWSHeader(JWAIdentifier.ES256, CertificateUtil.generateCertPath(Collections.emptyList()));
+        Payload payload = new Payload();
+        KeyPair keyPair = ECUtil.createKeyPair();
+        JWS<Payload> jws = target.create(header, payload, keyPair.getPrivate());
+        assertThat(jws.getSignature()).hasSize(64); // RFC 7518 Section 3.4: ES256 = 32+32 bytes
+    }
+
+    @Test
+    void signature_length_es384_test() {
+        JWSHeader header = new JWSHeader(JWAIdentifier.ES384, CertificateUtil.generateCertPath(Collections.emptyList()));
+        Payload payload = new Payload();
+        KeyPair keyPair = ECUtil.createKeyPair(ECUtil.P_384_SPEC);
+        JWS<Payload> jws = target.create(header, payload, keyPair.getPrivate());
+        assertThat(jws.getSignature()).hasSize(96); // RFC 7518 Section 3.4: ES384 = 48+48 bytes
+    }
+
+    @Test
+    void signature_length_es512_test() {
+        JWSHeader header = new JWSHeader(JWAIdentifier.ES512, CertificateUtil.generateCertPath(Collections.emptyList()));
+        Payload payload = new Payload();
+        KeyPair keyPair = ECUtil.createKeyPair(ECUtil.P_521_SPEC);
+        JWS<Payload> jws = target.create(header, payload, keyPair.getPrivate());
+        assertThat(jws.getSignature()).hasSize(132); // RFC 7518 Section 3.4: ES512 = 66+66 bytes
+    }
+
 
     private static class Payload {
         private String dummy;


### PR DESCRIPTION
The previous implementation used max(len(r), len(s)) to determine component length, producing variable-length signatures. RFC 7518 Section 3.4 requires fixed lengths: ES256=64, ES384=96, ES512=132 bytes.

Modified convertDerSignatureToJwsSignature() to accept algorithm parameter and use fixed component lengths. Added tests for all three algorithms.

Note: JWSFactory.create() is currently used only in test code. WebAuthn verification uses JWSFactory.parse(), which is unaffected.