### PR TITLE
Change Dependabot schedule to run on the 25th of each month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+      day: 25
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: monthly
+      day: 25
     labels:
       - "dev-dependencies"
     groups:


### PR DESCRIPTION
This change moves the Dependabot update schedule from the beginning of the month to the 25th to allow for better processing time, considering time zone differences and review availability.